### PR TITLE
fix: updates zod import

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -7,7 +7,7 @@
  * with proper configuration. Ensures exact parameter matching and behavior with Python version.
  */
 
-import "@langchain/anthropic/zod";
+// import "@langchain/anthropic/zod";
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { createTaskTool } from "./subAgent.js";
 import { getDefaultModel } from "./model.js";


### PR DESCRIPTION
fixes this issue 

```

⏺ Bash(node dist-examples/examples/test-example.js)
  ⎿  Error: node:internal/modules/esm/resolve:313
       return new ERR_PACKAGE_PATH_NOT_EXPORTED(
              ^

     Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './zod' is not defined by "exports" in /Users/palash/Desktop/test/deepagentsjs/node_modules/@langchain/anthropic/package.json imported from 
     /Users/palash/Desktop/test/deepagentsjs/dist-examples/src/graph.js
         at exportsNotFound (node:internal/modules/esm/resolve:313:10)
         at packageExportsResolve (node:internal/modules/esm/resolve:660:9)
         at packageResolve (node:internal/modules/esm/resolve:773:12)
         at moduleResolve (node:internal/modules/esm/resolve:853:18)
         at defaultResolve (node:internal/modules/esm/resolve:983:11)
     … +9 lines (ctrl+r to see all)
```