### PR TITLE
fix(tools): enforce returning Command object in writeTodos for graph state updates

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -23,7 +23,7 @@ import { DeepAgentStateType } from "./types.js";
  */
 export const writeTodos = tool(
   (input, config: ToolRunnableConfig) => {
-    return {
+    return new Command({
       update: {
         todos: input.todos,
         messages: [
@@ -33,7 +33,7 @@ export const writeTodos = tool(
           }),
         ],
       },
-    };
+    });
   },
   {
     name: "write_todos",


### PR DESCRIPTION
This PR addresses the inconsistency in the writeTodos tool implementation, which currently returns a plain object rather than the documented Command object. 

Please refer #14 for more information.

