### PR TITLE
feat: Add a name property value to ToolMessage

### DIFF
--- a/src/middleware/fs.ts
+++ b/src/middleware/fs.ts
@@ -135,6 +135,7 @@ const writeFile = tool(
           new ToolMessage({
             content: `Updated file ${input.file_path}`,
             tool_call_id: config.toolCall?.id as string,
+            name: "write_file",
           }),
         ],
       },
@@ -223,6 +224,7 @@ const editFile = tool(
           new ToolMessage({
             content: `Updated file ${file_path}`,
             tool_call_id: config.toolCall?.id as string,
+            name: "edit_file",
           }),
         ],
       },

--- a/src/middleware/todo.ts
+++ b/src/middleware/todo.ts
@@ -47,6 +47,7 @@ const writeTodos = tool(
           new ToolMessage({
             content: `Updated todo list to ${JSON.stringify(todos)}`,
             tool_call_id: config.toolCall?.id as string,
+            name: "write_todos",
           }),
         ],
       },

--- a/src/subAgent.ts
+++ b/src/subAgent.ts
@@ -99,6 +99,7 @@ export function createTaskTool(inputs: {
                 content:
                   result.messages?.slice(-1)[0]?.content || "Task completed",
                 tool_call_id: config.toolCall?.id as string,
+                name: subagent_type,
               }),
             ],
           },
@@ -113,6 +114,7 @@ export function createTaskTool(inputs: {
               new ToolMessage({
                 content: `Error executing task '${description}' with agent '${subagent_type}': ${errorMessage}`,
                 tool_call_id: config.toolCall?.id as string,
+                name: subagent_type,
               }),
             ],
           },

--- a/src/subAgent.ts
+++ b/src/subAgent.ts
@@ -103,7 +103,7 @@ export function createTaskTool(inputs: {
                 content:
                   result.messages?.slice(-1)[0]?.content || "Task completed",
                 tool_call_id: config.toolCall?.id as string,
-                name: subagent_type,
+                name: "task",
               }),
             ],
           },
@@ -118,7 +118,7 @@ export function createTaskTool(inputs: {
               new ToolMessage({
                 content: `Error executing task '${description}' with agent '${subagent_type}': ${errorMessage}`,
                 tool_call_id: config.toolCall?.id as string,
-                name: subagent_type,
+                name: "task",
               }),
             ],
           },


### PR DESCRIPTION
Add an explicit name attribute to tools and guarantee a non-undefined fallback when absent; this is fully backward-compatible.
