### PR TITLE
chore: Minor version bump to 1.1.0

### DIFF
--- a/.changeset/four-breads-battle.md
+++ b/.changeset/four-breads-battle.md
@@ -1,0 +1,5 @@
+---
+"deepagents": minor
+---
+
+Bumping to 1.1.0 because there was an old published version of 1.0.0 which was deprecated


### PR DESCRIPTION
There is an old version of 1.0.0 released in August 2025 which was deprecated