### PR TITLE
fix(store): make sure `getNamespace` can be overriden

### DIFF
--- a/.changeset/tough-shoes-give.md
+++ b/.changeset/tough-shoes-give.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(store): make sure `getNamespace` can be overriden

--- a/src/backends/store.ts
+++ b/src/backends/store.ts
@@ -58,7 +58,7 @@ export class StoreBackend implements BackendProtocol {
    * [assistant_id, "filesystem"] to provide per-assistant isolation.
    * Otherwise return ["filesystem"].
    */
-  private getNamespace(): string[] {
+  protected getNamespace(): string[] {
     const namespace = "filesystem";
     const assistantId = this.stateAndStore.assistantId;
 


### PR DESCRIPTION
Allow customising the namespace used by `StoreBackend`