### PR TITLE
fix: File state loss during multiple file operations

### DIFF
--- a/src/backends/state.ts
+++ b/src/backends/state.ts
@@ -154,7 +154,7 @@ export class StateBackend implements BackendProtocol {
     const newFileData = createFileData(content);
     return {
       path: filePath,
-      filesUpdate: { [filePath]: newFileData },
+      filesUpdate: { ...files, ...{ [filePath]: newFileData } },
     };
   }
 
@@ -191,7 +191,7 @@ export class StateBackend implements BackendProtocol {
     const newFileData = updateFileData(fileData, newContent);
     return {
       path: filePath,
-      filesUpdate: { [filePath]: newFileData },
+      filesUpdate: { ...files, ...{ [filePath]: newFileData } },
       occurrences: occurrences,
     };
   }


### PR DESCRIPTION
Fixes #60 

When tools that update files (like `write_file` or `edit_file`) were called, the new state in "files" only contained the most recently edited file. All other previously existing files disappeared from the state.