### PR TITLE
fix: exclude files from subagent state updates

### DIFF
--- a/src/middleware/subagents.ts
+++ b/src/middleware/subagents.ts
@@ -22,7 +22,7 @@ const DEFAULT_SUBAGENT_PROMPT =
   "In order to complete the objective that the user asks of you, you have access to a number of standard tools.";
 
 // State keys that should be excluded when passing state to subagents
-const EXCLUDED_STATE_KEYS = ["messages", "todos", "jumpTo"] as const;
+const EXCLUDED_STATE_KEYS = ["messages", "todos", "jumpTo", "files"] as const;
 
 const DEFAULT_GENERAL_PURPOSE_DESCRIPTION =
   "General-purpose agent for researching complex questions, searching for files and content, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you. This agent has access to all tools as the main agent.";


### PR DESCRIPTION
  ## Problem

  When multiple subagents run in parallel and complete in the same LangGraph step,
  both try to update the parent's `files` channel simultaneously, causing:

  InvalidUpdateError: Invalid update for channel "files" with values [{},{}]:
  LastValue can only receive one value per step.

  ## Root Cause

  `EXCLUDED_STATE_KEYS` filters state when subagents return results to the parent
  via `returnCommandWithStateUpdate()`. Currently it excludes `messages`, `todos`,
  and `jumpTo`, but NOT `files`.

  When using external backends (like Azure Blob, NFS, or even StoreBackend), files
  are already persisted externally. Passing the `files` state back to the parent
  is unnecessary and causes concurrent update errors when subagents run in parallel.

  ## Solution

  Add `"files"` to `EXCLUDED_STATE_KEYS`. This is consistent with how `messages`
  and `todos` are handled - they have their own reducers and don't need to be
  passed through subagent state updates.