### PR TITLE
feat: add CJS/ESM dual module support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "deepagents",
   "version": "1.3.1",
   "description": "Deep Agents - a library for building controllable AI agents with LangGraph",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsdown",
+    "clean": "rm -rf dist/ .tsdown/",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/**/*.ts examples/**/*.ts",
@@ -74,6 +75,19 @@
     "typescript-eslint": "^8.22.0",
     "uuid": "^11.0.5",
     "vitest": "^2.1.8"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist/**/*"

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,5 +1,19 @@
 import { defineConfig } from "tsdown";
 
-export default defineConfig({
+export default defineConfig([{
   entry: ["./src/index.ts"],
-});
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  outDir: "dist",
+  outExtensions: () => ({ js: '.js' }),
+}, {
+  entry: ["./src/index.ts"],
+  format: ["cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  outDir: "dist",
+  outExtensions: () => ({ js: '.cjs' }),
+}]);


### PR DESCRIPTION
- Add exports field in package.json for dual module support
- Configure tsdown to build both CJS and ESM formats
- Add post-build script to rename files to correct extensions
- Keep original tsconfig.json configuration
- Generate single-file outputs: index.cjs and index.mjs

Refs:
- https://github.com/langchain-ai/deepagentsjs/issues/75
- https://github.com/langchain-ai/deepagents/issues/557