### PR TITLE
feat: support SystemMessage for systemPrompt parameter

### DIFF
--- a/tests/integration/deepagents.test.ts
+++ b/tests/integration/deepagents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { AIMessage, HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { createDeepAgent } from "../../src/index.js";
 import {
   SAMPLE_MODEL,
@@ -311,6 +311,23 @@ describe("DeepAgents Integration Tests", () => {
       ).toBe(true);
     }
   );
+
+  it.concurrent("should create deep agent with string system prompt", () => {
+    const agent = createDeepAgent({
+      systemPrompt: "You are a helpful assistant specializing in math.",
+    });
+    assertAllDeepAgentQualities(agent);
+  });
+
+  it.concurrent("should create deep agent with SystemMessage system prompt", () => {
+    const systemMessage = new SystemMessage(
+      "You are a helpful assistant specializing in science."
+    );
+    const agent = createDeepAgent({
+      systemPrompt: systemMessage,
+    });
+    assertAllDeepAgentQualities(agent);
+  });
 
   // Note: response_format with ToolStrategy is not yet available in LangChain TS v1
   // Skipping test_response_format_tool_strategy for now


### PR DESCRIPTION
## Summary

- Allow `createDeepAgent()` to accept `SystemMessage` objects in addition to strings for the `systemPrompt` parameter
- Aligns with the capability already available in langchain's `createAgent()`
- Enables cleaner integration for projects that model system prompts as structured `SystemMessage` objects

Closes #83

## Changes

1. Import `SystemMessage` from `@langchain/core/messages`
2. Update `systemPrompt` type in `CreateDeepAgentParams` interface to `string | SystemMessage`
3. Add logic to extract content from `SystemMessage` if provided
4. Add tests for both string and `SystemMessage` system prompts

## Test plan

- [x] Added unit tests for string systemPrompt
- [x] Added unit tests for SystemMessage systemPrompt
- [ ] Note: Existing test failures are due to a known upstream bug (Issue #75) unrelated to this PR