### PR TITLE
fix(deepagent): properly derrive types from createDeepAgent input

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.52.0"
   },
-  "packageManager": "pnpm@10.27.0"
+  "packageManager": "pnpm@10.28.0"
 }


### PR DESCRIPTION
If a developer passes in custom middleware or response format into `createDeepAgent` the types should properly propagate to the `createAgent` instance so that the return values from `invoke` are the same as `createAgent`. For example:

```ts
const agent = createDeepAgent({
  tools: [sampleTool],
  subagents,
  middleware: [ResearchMiddleware],
});
assertAllDeepAgentQualities(agent);
expect(agent.graph.streamChannels).toContain("research");

const result = await agent.invoke(
  {
    messages: [
      new HumanMessage("Get surface level info on lebron james"),
    ],
  },
  { recursionLimit: 100 },
);

result.research // <-- should have proper types
```