### PR TITLE
fix: resolve instanceof AIMessageChunk failing for Ollama provider

### DIFF
--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@langchain/langgraph-checkpoint": "^1.0.0",
+    "@langchain/ollama": "^1.1.0",
     "@langchain/openai": "^1.2.1",
     "@langchain/tavily": "^1.2.0",
     "@tsconfig/recommended": "^1.0.13",

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -633,7 +633,7 @@ export function createFilesystemMiddleware(
             return { message: msg, filesUpdate: null };
           }
 
-          if (result instanceof ToolMessage) {
+          if (ToolMessage.isInstance(result)) {
             const processed = await processToolMessage(result);
 
             if (processed.filesUpdate) {
@@ -661,7 +661,7 @@ export function createFilesystemMiddleware(
             const processedMessages: ToolMessage[] = [];
 
             for (const msg of update.messages) {
-              if (msg instanceof ToolMessage) {
+              if (ToolMessage.isInstance(msg)) {
                 const processed = await processToolMessage(msg);
                 processedMessages.push(processed.message);
 

--- a/libs/deepagents/src/ollama-instanceof.int.test.ts
+++ b/libs/deepagents/src/ollama-instanceof.int.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Integration test for instanceof AIMessageChunk with Ollama provider.
+ *
+ * This test verifies that the fix for issue #64 works correctly:
+ * - AIMessageChunk instances from Ollama streaming should pass `instanceof AIMessageChunk`
+ * - This was previously failing because of duplicate @langchain/core module instances
+ *
+ * Prerequisites:
+ * - Ollama must be running locally (`ollama serve`)
+ * - A model must be available (e.g., `ollama pull tinyllama`)
+ */
+
+import { describe, it, expect } from "vitest";
+import { ChatOllama } from "@langchain/ollama";
+import { AIMessageChunk } from "@langchain/core/messages";
+
+describe("Ollama instanceof AIMessageChunk", () => {
+  it.concurrent(
+    "should return true for instanceof AIMessageChunk when streaming",
+    { timeout: 60_000 },
+    async () => {
+      const model = new ChatOllama({
+        model: "tinyllama",
+        baseUrl: "http://localhost:11434",
+      });
+
+      const chunks: AIMessageChunk[] = [];
+      let instanceofPassCount = 0;
+      let isInstancePassCount = 0;
+
+      // Stream a simple response
+      const stream = await model.stream("Say 'hello' in one word.");
+
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+
+        // Test both methods
+        if (chunk instanceof AIMessageChunk) {
+          instanceofPassCount++;
+        }
+        if (AIMessageChunk.isInstance(chunk)) {
+          isInstancePassCount++;
+        }
+
+        // Debug info available in verbose mode:
+        // content, instanceofPass, isInstancePass, constructorName
+      }
+
+      // We should have received at least one chunk
+      expect(chunks.length).toBeGreaterThan(0);
+
+      // All chunks should pass AIMessageChunk.isInstance() - this always works
+      expect(isInstancePassCount).toBe(chunks.length);
+
+      // After the fix: All chunks should ALSO pass instanceof AIMessageChunk
+      // Before the fix, this would fail because of duplicate module instances
+      expect(instanceofPassCount).toBe(chunks.length);
+
+      // Success: all chunks passed both instanceof and isInstance checks
+    }
+  );
+
+  it.concurrent(
+    "should work with the recommended isInstance pattern",
+    { timeout: 60_000 },
+    async () => {
+      const model = new ChatOllama({
+        model: "tinyllama",
+        baseUrl: "http://localhost:11434",
+      });
+
+      const stream = await model.stream("Say 'test'");
+
+      for await (const chunk of stream) {
+        // This is the recommended pattern from LangChain maintainers
+        // It should always work regardless of module instance issues
+        expect(AIMessageChunk.isInstance(chunk)).toBe(true);
+        expect(chunk.content).toBeDefined();
+      }
+    }
+  );
+});

--- a/libs/deepagents/tsdown.config.ts
+++ b/libs/deepagents/tsdown.config.ts
@@ -9,6 +9,10 @@ export default defineConfig([
     sourcemap: true,
     outDir: "dist",
     outExtensions: () => ({ js: ".js" }),
+    // Externalize @langchain/core to prevent bundling duplicate copies.
+    // This fixes instanceof checks (e.g. AIMessageChunk) failing when
+    // providers like Ollama construct chunks from a different module instance.
+    external: [/^@langchain\/core/],
   },
   {
     entry: ["./src/index.ts"],
@@ -18,5 +22,7 @@ export default defineConfig([
     sourcemap: true,
     outDir: "dist",
     outExtensions: () => ({ js: ".cjs" }),
+    // Externalize @langchain/core to prevent bundling duplicate copies.
+    external: [/^@langchain\/core/],
   },
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@langchain/langgraph-checkpoint':
         specifier: ^1.0.0
         version: 1.0.0(@langchain/core@1.1.12(openai@6.16.0(zod@4.3.5)))
+      '@langchain/ollama':
+        specifier: ^1.1.0
+        version: 1.1.0(@langchain/core@1.1.12(openai@6.16.0(zod@4.3.5)))
       '@langchain/openai':
         specifier: ^1.2.1
         version: 1.2.1(@langchain/core@1.1.12(openai@6.16.0(zod@4.3.5)))
@@ -589,6 +592,12 @@ packages:
     peerDependenciesMeta:
       zod-to-json-schema:
         optional: true
+
+  '@langchain/ollama@1.1.0':
+    resolution: {integrity: sha512-kEP0zvj+xtJ84QcK1ALKkz71ynpWMgzXbASzabMhkRAMSN/wTVm28HUNPRDHxbS9+BZnq1zcZeuzOf29XCal5g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
 
   '@langchain/openai@1.2.1':
     resolution: {integrity: sha512-eZYPhvXIwz0/8iCjj2LWqeaznQ7DZ6tBdvF+Ebv4sQW2UqJWZqRC8QIdKZgTbs8ffMWPHkSSOidYqu4XfWCNYg==}
@@ -2115,6 +2124,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
+
   openai@6.16.0:
     resolution: {integrity: sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==}
     hasBin: true
@@ -2758,6 +2770,9 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -3219,6 +3234,12 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
+
+  '@langchain/ollama@1.1.0(@langchain/core@1.1.12(openai@6.16.0(zod@4.3.5)))':
+    dependencies:
+      '@langchain/core': 1.1.12(openai@6.16.0(zod@4.3.5))
+      ollama: 0.6.3
+      uuid: 10.0.0
 
   '@langchain/openai@1.2.1(@langchain/core@1.1.12(openai@6.16.0(zod@4.3.5)))':
     dependencies:
@@ -3704,7 +3725,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@22.19.3)(@vitest/ui@4.0.16)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.16(@types/node@25.0.3)(@vitest/ui@4.0.16)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@4.0.16':
     dependencies:
@@ -4750,6 +4771,10 @@ snapshots:
 
   obug@2.1.1: {}
 
+  ollama@0.6.3:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   openai@6.16.0(zod@4.3.5):
     optionalDependencies:
       zod: 4.3.5
@@ -5490,6 +5515,8 @@ snapshots:
       - yaml
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-fetch@3.6.20: {}
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION
Closes #64

## Problem
When streaming responses using the Ollama provider, chunks look like AIMessageChunk objects but instanceof AIMessageChunk returns false. This happens because @langchain/core was being bundled, creating a duplicate module instance with a different prototype chain.

## Solution
1. Externalize @langchain/core in tsdown bundler config to prevent duplicate module instances
2. Replace internal instanceof ToolMessage checks with the more robust ToolMessage.isInstance() pattern

## Testing
- Added integration test that verifies Ollama-streamed chunks pass both instanceof AIMessageChunk and AIMessageChunk.isInstance()
- All 178 existing unit tests pass