### PR TITLE
docs: document GraphInterrupt limitation from tools and provide solution (#131)

### DIFF
--- a/.changeset/graph-interrupt-tools-documentation.md
+++ b/.changeset/graph-interrupt-tools-documentation.md
@@ -1,0 +1,36 @@
+---
+"deepagents": patch
+---
+
+Document GraphInterrupt limitation when thrown from tools and provide recommended solution
+
+## Issue
+
+When a tool throws a `GraphInterrupt`, the error loses its `interrupts` property during error propagation through LangGraph's tool execution chain. This is due to LangGraph's error serialization code (pregel/runner.js:171-173) only preserving `{message, name}` properties, causing a TypeError when `_commit()` tries to access `error.interrupts.length`.
+
+Root cause: `interrupt()` and `GraphInterrupt` are designed to be called from graph **nodes**, not from within **tools**.
+
+## Solution
+
+Use the existing HITL (Human-in-the-Loop) middleware with `interruptOn` configuration:
+
+```typescript
+const agent = createDeepAgent({
+  tools: [myTool],
+  interruptOn: {
+    my_tool: true,  // Interrupt before executing this tool
+  },
+  checkpointer: new MemorySaver(),
+});
+```
+
+## Changes
+
+- Added integration test demonstrating the issue and recommended solution
+- Created GRAPH_INTERRUPT_TOOLS.md documentation explaining the limitation and workarounds
+- Test includes both a skipped test showing the issue and a working test showing the HITL middleware solution
+
+## Related
+
+- GitHub Issue #131: https://github.com/langchain-ai/deepagentsjs/issues/131
+- Upstream LangGraph issues: #6624, #6626

--- a/libs/deepagents/GRAPH_INTERRUPT_TOOLS.md
+++ b/libs/deepagents/GRAPH_INTERRUPT_TOOLS.md
@@ -1,0 +1,146 @@
+# GraphInterrupt from Tools - Issue Analysis and Workaround
+
+## Issue Description
+
+When a tool throws a `GraphInterrupt` in DeepAgents, the error loses its `interrupts` property during propagation through the tool execution chain, causing a TypeError in LangGraph's internal `_commit()` function.
+
+**GitHub Issue:** [#131](https://github.com/langchain-ai/deepagentsjs/issues/131)
+
+## Root Cause
+
+The problem occurs in LangGraph's error serialization code (`pregel/runner.js:171-173`):
+
+```javascript
+else this.loop.putWrites(task.id, [[ERROR, {
+    message: error.message,
+    name: error.name
+}]]);
+```
+
+When an error that's not caught by earlier checks occurs, LangGraph only preserves the `message` and `name` properties. When the error is later reconstructed, it becomes a plain Error object that passes the `isGraphInterrupt(error)` check (which only examines the `name` property), but lacks the critical `interrupts` array.
+
+## Why This Happens
+
+`interrupt()` and `GraphInterrupt` are designed to be called from graph **nodes**, not from within **tools**. When called from a tool:
+
+1. ✅ Tool constructs `GraphInterrupt` with proper `interrupts` array
+2. ✅ Error is thrown from tool
+3. ❌ Error is serialized by LangGraph's tool execution layer, losing custom properties
+4. ❌ By the time it reaches `_commit()`, the `interrupts` property is undefined
+5. ❌ TypeError: `undefined is not an object (evaluating 'error.interrupts.length')`
+
+## Recommended Solution: Use HITL Middleware
+
+DeepAgents already provides a proper solution for tool-level approval workflows through the **Human-in-the-Loop (HITL) middleware**:
+
+```typescript
+import { createDeepAgent } from "deepagents";
+import { MemorySaver } from "@langchain/langgraph";
+
+const checkpointer = new MemorySaver();
+
+const agent = createDeepAgent({
+  tools: [myTool, otherTool],
+  interruptOn: {
+    my_tool: true,  // Interrupt before executing this tool
+    other_tool: { allowedDecisions: ["approve", "reject"] },
+  },
+  checkpointer,
+});
+
+// First invocation - will interrupt before executing my_tool
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Use my_tool" }],
+}, { configurable: { thread_id: "thread-1" } });
+
+// Check for interrupts
+if (result.__interrupt__) {
+  const interrupts = result.__interrupt__[0].value;
+  // Review interrupts and approve/reject
+}
+
+// Resume with approval
+const result2 = await agent.invoke(
+  new Command({
+    resume: {
+      decisions: [{ type: "approve" }],
+    },
+  }),
+  { configurable: { thread_id: "thread-1" } }
+);
+```
+
+## Why HITL Middleware is Better
+
+1. **Designed for Tools**: The HITL middleware is specifically designed to handle interrupts at the tool level
+2. **Proper State Management**: Uses LangGraph's checkpointing system correctly
+3. **Type-Safe**: Fully typed with proper interrupt handling
+4. **Flexible**: Supports approve/reject/edit decisions
+5. **Works with Subagents**: Properly propagates interrupt configuration to subagents
+
+## Alternative: Use Command API
+
+If you need custom interrupt data from within a tool, use the Command API:
+
+```typescript
+import { tool } from "langchain";
+import { Command } from "@langchain/langgraph";
+import { ToolMessage } from "@langchain/core/messages";
+import { z } from "zod";
+
+const approvalTool = tool(
+  async (input, config) => {
+    // Instead of throwing GraphInterrupt, return a Command
+    return new Command({
+      update: {
+        messages: [
+          new ToolMessage({
+            content: `Requesting approval for: ${input.action}`,
+            tool_call_id: config.toolCall?.id as string,
+          }),
+        ],
+      },
+      // You can add custom interrupt data here if needed
+      // Note: This requires setting up proper interrupt handling
+    });
+  },
+  {
+    name: "request_approval",
+    description: "Request approval for an action",
+    schema: z.object({
+      action: z.string(),
+    }),
+  }
+);
+```
+
+## Upstream Fix Required
+
+The ultimate fix requires changes to LangGraph's error serialization to preserve the `interrupts` property:
+
+**Current code (pregel/runner.js:171-173):**
+```javascript
+else this.loop.putWrites(task.id, [[ERROR, {
+    message: error.message,
+    name: error.name
+}]]);
+```
+
+**Should be:**
+```javascript
+else if (isGraphInterrupt(error)) this.loop.putWrites(task.id, [[ERROR, {
+    message: error.message,
+    name: error.name,
+    interrupts: error.interrupts  // Preserve interrupts property
+}]]);
+else this.loop.putWrites(task.id, [[ERROR, {
+    message: error.message,
+    name: error.name
+}]]);
+```
+
+## References
+
+- [LangGraph Interrupt Documentation](https://langchain-ai.github.io/langgraphjs/how-tos/human_in_the_loop/)
+- [ToolNode doesn't collect all interrupts from parallel tool execution #6624](https://github.com/langchain-ai/langgraph/issues/6624)
+- [Interrupt calls in parallel tools generate identical IDs #6626](https://github.com/langchain-ai/langgraph/issues/6626)

--- a/libs/deepagents/src/middleware/graph-interrupt-tool.int.test.ts
+++ b/libs/deepagents/src/middleware/graph-interrupt-tool.int.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { GraphInterrupt } from "@langchain/langgraph";
+import { MemorySaver, Command } from "@langchain/langgraph";
+import { createDeepAgent } from "../index.js";
+import { SAMPLE_MODEL } from "../testing/utils.js";
+import { v4 as uuidv4 } from "uuid";
+
+describe("GraphInterrupt from Tool Tests", () => {
+  it.skip(
+    "demonstrates that throwing GraphInterrupt from tools loses interrupts property",
+    { timeout: 30000 },
+    async () => {
+      // This test demonstrates the issue described in GitHub issue #131
+      // Throwing GraphInterrupt from a tool results in a TypeError because
+      // LangGraph's error serialization only preserves {message, name} properties
+
+      const interruptingTool = new DynamicStructuredTool({
+        name: "pause_tool",
+        description: "A tool that pauses execution",
+        schema: z.object({
+          reason: z.string(),
+        }),
+        func: async (input) => {
+          const graphInterrupt = new GraphInterrupt([
+            {
+              id: "test-interrupt",
+              value: { reason: input.reason },
+            },
+          ]);
+
+          // Verify it's properly constructed before throwing
+          expect(graphInterrupt.interrupts).toBeDefined();
+          expect(graphInterrupt.interrupts).toHaveLength(1);
+
+          throw graphInterrupt;
+        },
+      });
+
+      const agent = createDeepAgent({
+        systemPrompt: "Use pause_tool when user asks to pause",
+        tools: [interruptingTool],
+        model: SAMPLE_MODEL,
+      });
+
+      // This will throw a TypeError: undefined is not an object (evaluating 'error.interrupts.length')
+      // because the interrupts property is lost during error serialization
+      await expect(
+        agent.invoke({
+          messages: [{ role: "user", content: "Pause execution" }],
+        })
+      ).rejects.toThrow();
+    }
+  );
+
+  it.concurrent(
+    "demonstrates the recommended solution: use HITL middleware with interruptOn",
+    { timeout: 90000 },
+    async () => {
+      // This test shows the PROPER way to implement tool-level approval workflows
+      // Using the HITL middleware with interruptOn configuration
+
+      const actionTool = new DynamicStructuredTool({
+        name: "perform_action",
+        description: "Perform a potentially dangerous action",
+        schema: z.object({
+          action: z.string().describe("The action to perform"),
+        }),
+        func: async (input) => {
+          return `Performed action: ${input.action}`;
+        },
+      });
+
+      const checkpointer = new MemorySaver();
+      const agent = createDeepAgent({
+        tools: [actionTool],
+        interruptOn: {
+          perform_action: true, // Interrupt before executing this tool
+        },
+        checkpointer,
+        model: SAMPLE_MODEL,
+      });
+
+      const config = { configurable: { thread_id: uuidv4() } };
+
+      // First invocation - should interrupt before executing the tool
+      const result = await agent.invoke(
+        {
+          messages: [
+            {
+              role: "user",
+              content: "Perform a dangerous action",
+            },
+          ],
+        },
+        config
+      );
+
+      // Verify that execution was interrupted
+      expect(result.__interrupt__).toBeDefined();
+      expect(result.__interrupt__).toHaveLength(1);
+
+      // The interrupt contains the tool call information
+      const interrupt = result.__interrupt__[0].value;
+      expect(interrupt.actionRequests).toBeDefined();
+      expect(interrupt.actionRequests.length).toBeGreaterThan(0);
+
+      // Resume with approval
+      const result2 = await agent.invoke(
+        new Command({
+          resume: {
+            decisions: [{ type: "approve" }],
+          },
+        }),
+        config
+      );
+
+      // Verify the tool was executed after approval
+      const toolMessages = result2.messages.filter(
+        (msg: any) => msg._getType() === "tool"
+      );
+      expect(toolMessages.some((msg: any) => msg.name === "perform_action")).toBe(
+        true
+      );
+
+      // No more interrupts
+      expect(result2.__interrupt__).toBeUndefined();
+    }
+  );
+});


### PR DESCRIPTION
## Summary
Addresses #131 by documenting the GraphInterrupt limitation when thrown from tools and providing the recommended solution using HITL middleware.

## Problem
When a tool throws a `GraphInterrupt`, the error loses its `interrupts` property during error propagation, causing:
```
TypeError: undefined is not an object (evaluating 'error.interrupts.length')
```

### Root Cause
- LangGraph's error serialization (pregel/runner.js:171-173) only preserves `{message, name}` properties
- `interrupt()` and `GraphInterrupt` are designed for graph **nodes**, not **tools**
- When errors cross async boundaries in tool execution, custom properties are lost

## Solution
Use the existing **HITL middleware** with `interruptOn` configuration:

```typescript
const agent = createDeepAgent({
  tools: [myTool],
  interruptOn: {
    my_tool: true,  // Interrupt before executing tool
  },
  checkpointer: new MemorySaver(),
});

const result = await agent.invoke(input, config);

// Check for interrupts
if (result.__interrupt__) {
  // Review and approve/reject
}

// Resume with decision
await agent.invoke(
  new Command({ resume: { decisions: [{ type: "approve" }] } }),
  config
);
```

## Changes

### Added
- `libs/deepagents/GRAPH_INTERRUPT_TOOLS.md` - Comprehensive documentation of the issue, root cause analysis, and recommended solutions
- `libs/deepagents/src/middleware/graph-interrupt-tool.int.test.ts` - Integration test demonstrating both the issue and the proper solution
- `.changeset/graph-interrupt-tools-documentation.md` - Changeset for release notes

### Test Coverage
1. **Skipped test**: Demonstrates the GraphInterrupt issue when thrown from tools
2. **Working test**: Shows proper HITL middleware usage for tool-level approval workflows

## Why This Approach

1. **No breaking changes**: Uses existing HITL middleware already in deepagents
2. **Type-safe**: Fully typed interrupt handling
3. **Production-ready**: HITL middleware is tested and documented
4. **Flexible**: Supports approve/reject/edit decisions
5. **Works with subagents**: Properly propagates interrupt configuration

## Upstream Issue
This is a limitation in LangGraph's error serialization. The ultimate fix requires changes upstream in LangGraph to preserve the `interrupts` property during error serialization.

## Related
- Issue #131
- LangGraph issues: #6624 (parallel tool interrupts), #6626 (interrupt ID collision)

## Test Plan
- [x] Created integration test demonstrating the recommended solution
- [x] Test shows proper use of HITL middleware with interruptOn
- [x] Test verifies interrupt handling and resume workflow
- [x] Documentation provides clear examples and explanations

🤖 Generated with [Claude Code](https://claude.com/claude-code)