### PR TITLE
fix(deepagents): exclude skillsMetadata from subagent state updates

### DIFF
--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -30,11 +30,15 @@ const DEFAULT_SUBAGENT_PROMPT =
 //    and no clear meaning for returning them from a subagent to the main agent.
 // 3. The files key is excluded to prevent concurrent subagents from writing to the files
 //    channel simultaneously (which causes LastValue errors in LangGraph).
+// 4. The skillsMetadata key is excluded for the same reason as files - it uses implicit
+//    LastValue (no custom reducer) and parallel subagents returning it simultaneously
+//    causes "LastValue can only receive one value per step" errors.
 const EXCLUDED_STATE_KEYS = [
   "messages",
   "todos",
   "structuredResponse",
   "files",
+  "skillsMetadata",
 ] as const;
 
 const DEFAULT_GENERAL_PURPOSE_DESCRIPTION =


### PR DESCRIPTION
## Summary

Adds `skillsMetadata` to `EXCLUDED_STATE_KEYS` to prevent concurrent update errors when multiple subagents complete in parallel with skills middleware enabled.

## Problem

When skills middleware is enabled and multiple subagents run in parallel, each subagent returns `skillsMetadata` in their state update. Since `skillsMetadata` uses implicit `LastValue` (no custom reducer), LangGraph fails with:

```
Invalid update for channel "skillsMetadata" with values [[...],[...],[...]]:
LastValue can only receive one value per step.
```

## Solution

Add `"skillsMetadata"` to `EXCLUDED_STATE_KEYS` (matching the existing handling for `files`):

```typescript
const EXCLUDED_STATE_KEYS = [
  "messages",
  "todos",
  "structuredResponse",
  "files",
  "skillsMetadata",  // Added
] as const;
```

## Changes

- `libs/deepagents/src/middleware/subagents.ts`: Add `skillsMetadata` to excluded keys with explanatory comment

## Test Plan

- [x] All existing unit tests pass (277 tests)
- [x] Manually verified fix resolves the concurrent update error