### PR TITLE
fix(skills): isolate skillsMetadata between parent agent and subagents

### DIFF
--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -166,6 +166,14 @@ export function createDeepAgent<
       : [];
 
   /**
+   * Build middleware stack ONLY for the general-purpose subagent (custom subagents do NOT inherit these)
+   * skills middleware is only added to the general-purpose agent.
+   */
+  const generalPurposeSubagentMiddleware: AgentMiddleware[] = [
+    ...skillsMiddlewareArray,
+  ];
+
+  /**
    * Built-in middleware array - core middleware with known types
    * This tuple is typed without conditional spreads to preserve TypeScript's tuple inference.
    * Optional middleware (skills, memory, HITL) are handled at runtime but typed explicitly.
@@ -191,10 +199,6 @@ export function createDeepAgent<
          */
         todoListMiddleware(),
         /**
-         * Subagent middleware: Skills (if provided) - added at runtime
-         */
-        ...skillsMiddlewareArray,
-        /**
          * Subagent middleware: Filesystem operations
          */
         createFilesystemMiddleware({
@@ -219,6 +223,10 @@ export function createDeepAgent<
          */
         createPatchToolCallsMiddleware(),
       ],
+      /**
+       * Skills middleware is ONLY added to the general-purpose subagent, not custom subagents
+       */
+      generalPurposeMiddleware: generalPurposeSubagentMiddleware,
       defaultInterruptOn: interruptOn,
       subagents: subagents as unknown as (SubAgent | CompiledSubAgent)[],
       generalPurposeAgent: true,


### PR DESCRIPTION
This PR exclude skillsMetadata from subagent state updates to prevent concurrent update errors

**1. Added `skillsMetadata` to `EXCLUDED_STATE_KEYS`**

Skills are loaded per-agent by the skills middleware, so there's no need to propagate `skillsMetadata` between parent and child agents:
- Subagents don't receive parent's `skillsMetadata` 
- Subagents don't return their `skillsMetadata` to parent

This prevents concurrent update conflicts when parallel subagents complete simultaneously.

**2. Fixed skills middleware to only apply to general-purpose subagent**

Skills middleware is now added via the `generalPurposeMiddleware` parameter instead of `defaultMiddleware`:
- General-purpose subagent: Gets skills middleware (inherits from parent config)
- Custom subagents: Do NOT get skills middleware (define their own middleware explicitly)

Added unit tests that verify:
- Custom subagents do NOT inherit skills middleware
- `skillsMetadata` does NOT bubble up from subagent to parent  
- General-purpose subagent DOES inherit skills middleware