### PR TITLE
feat: allow filesystemOptions to be passed to built-in middleware

### DIFF
--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -242,7 +242,10 @@ export function createDeepAgent<
     /**
      * Enables filesystem operations and optional long-term memory storage
      */
-    createFilesystemMiddleware({ backend: filesystemBackend, ...filesystemOptions }),
+    createFilesystemMiddleware({
+      backend: filesystemBackend,
+      ...filesystemOptions,
+    }),
     /**
      * Enables delegation to specialized subagents for complex tasks
      */

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -20,7 +20,10 @@ import type {
   BaseStore,
 } from "@langchain/langgraph-checkpoint";
 
-import type { SubAgent, FilesystemMiddlewareOptions } from "./middleware/index.js";
+import type {
+  SubAgent,
+  FilesystemMiddlewareOptions,
+} from "./middleware/index.js";
 import type { BackendProtocol } from "./backends/index.js";
 import type { InteropZodObject } from "@langchain/core/utils/types";
 import type { AnnotationRoot } from "@langchain/langgraph";
@@ -370,7 +373,7 @@ export interface CreateDeepAgentParams<
    * });
    * ```
    */
-  filesystemOptions?: Omit<FilesystemMiddlewareOptions, 'backend'>;
+  filesystemOptions?: Omit<FilesystemMiddlewareOptions, "backend">;
   /**
    * Optional list of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).
    *


### PR DESCRIPTION
Allow fileSystemOption to be passed into built-in file system middleware. Helps for those trying to model things other than files into a filesystem structure where the LLM might need additional guidance