### PR TITLE
fix(deepagents): shell commands for ls and glob tools output a string that cannot be parsed

### DIFF
--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -142,7 +142,7 @@ function parseStatLine(
  */
 function buildLsCommand(dirPath: string): string {
   const quotedPath = shellQuote(dirPath);
-  return `find ${quotedPath} -maxdepth 1 -not -path ${quotedPath} -exec stat -c '%s\\t%Y\\t%F\\t%n' {} + 2>/dev/null || true`;
+  return `find ${quotedPath} -maxdepth 1 -not -path ${quotedPath} -exec stat -c "%s\t%Y\t%F\t%n" {} + 2>/dev/null || true`;
 }
 
 /**
@@ -153,7 +153,7 @@ function buildLsCommand(dirPath: string): string {
  */
 function buildFindCommand(searchPath: string): string {
   const quotedPath = shellQuote(searchPath);
-  return `find ${quotedPath} -not -path ${quotedPath} -exec stat -c '%s\\t%Y\\t%F\\t%n' {} + 2>/dev/null || true`;
+  return `find ${quotedPath} -not -path ${quotedPath} -exec stat -c "%s\t%Y\t%F\t%n" {} + 2>/dev/null || true`;
 }
 
 /**


### PR DESCRIPTION
## Problem description

The new POSIX shell commands for `ls` and `glob` introduced in https://github.com/langchain-ai/deepagentsjs/pull/88 have `\\t` in their patterns.
This produces commands like that:
```bash
find '/workspace' -not -path '/workspace' -exec stat -c '%s\\t%Y\\t%F\\t%n' {} + 2>/dev/null || true
```
and they in turn produce output like this:
```
632\\t1770575029\\tregular file\\t/workspace/dragon_ascii_art.txt\n25\\t1770330477\\tregular file\\t/workspace/ascii_art_cat.txt\n
```
then this output is split into lines and passed to [`parseStatLine`](https://github.com/langchain-ai/deepagentsjs/blob/main/libs/deepagents/src/backends/sandbox.ts#L110-L135) and at [line 113](https://github.com/langchain-ai/deepagentsjs/blob/main/libs/deepagents/src/backends/sandbox.ts#L113) it essentially always returns `-1`:

```js
"632\\t1770575029\\tregular file\\t/workspace/dragon_ascii_art.txt".indexOf("\t") // returns -1
```
Because `\\t` is interpreted as `\ + t`, not `\ + \t`:
```js
'\\' + 't' === '\\t' // returns true
```

## Fix

Drop extra `\` in the patterns