### PR TITLE
fix: Comparison between inconvertible types

### DIFF
--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -1040,12 +1040,15 @@ ${summary}
    */
   function isContextOverflow(err: unknown): boolean {
     let cause: unknown = err;
-    while (cause != null) {
+    for (;;) {
+      if (!cause) {
+        break;
+      }
       if (ContextOverflowError.isInstance(cause)) {
         return true;
       }
       cause =
-        typeof cause === "object" && cause !== null && "cause" in cause
+        typeof cause === "object" && "cause" in cause
           ? (cause as { cause?: unknown }).cause
           : undefined;
     }


### PR DESCRIPTION
General fix approach: Avoid comparing `cause` directly to `null` in a way that confuses static analysis when its type is a wide union. Instead, structure the loop so that `cause` is checked for truthiness (or explicitly for `undefined`/`null`) in a way that the analyzer understands, while keeping the same runtime behavior of walking the `.cause` chain until it ends.

Best concrete fix here: Change the `while (cause != null)` loop into an infinite `for (;;)` or `while (true)` loop that breaks when `cause` is `null`/`undefined`. Inside the loop, first check if `cause` is falsy (`if (!cause) break;`). Then run the existing logic: if `ContextOverflowError.isInstance(cause)` return `true`; otherwise compute the next `cause` from `cause.cause` when available, otherwise set it to `undefined`. This preserves exactly the same semantics (termination when `cause` becomes `undefined` or `null`) but removes the flagged direct comparison in the loop header.

Concretely, in `libs/deepagents/src/middleware/summarization.ts`, in the `isContextOverflow` function, replace:

```ts
let cause: unknown = err;
while (cause != null) {
  if (ContextOverflowError.isInstance(cause)) {
    return true;
  }
  cause =
    typeof cause === "object" && cause !== null && "cause" in cause
      ? (cause as { cause?: unknown }).cause
      : undefined;
}
return false;
```

with:

```ts
let cause: unknown = err;
for (;;) {
  if (!cause) {
    break;
  }
  if (ContextOverflowError.isInstance(cause)) {
    return true;
  }
  cause =
    typeof cause === "object" && "cause" in cause
      ? (cause as { cause?: unknown }).cause
      : undefined;
}
return false;
```

This removes the problematic comparison and slightly simplifies the `typeof`/null check (we can drop `cause !== null` because `if (!cause) break;` already handles `null` and `undefined`).

No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._