### PR TITLE
fix: handle multi-type content blocks in tool result size checking

### DIFF
--- a/libs/deepagents/src/middleware/fs.eviction.test.ts
+++ b/libs/deepagents/src/middleware/fs.eviction.test.ts
@@ -5,6 +5,7 @@ import type { StructuredTool } from "langchain";
 import {
   createContentPreview,
   createFilesystemMiddleware,
+  extractTextContent,
   TOOLS_EXCLUDED_FROM_EVICTION,
   NUM_CHARS_PER_TOKEN,
 } from "./fs.js";
@@ -291,5 +292,43 @@ describe("read_file character-based truncation", () => {
     expect(result).not.toContain("Output was truncated");
     // Should contain the full content (formatted with line numbers)
     expect(result.length).toBeGreaterThan(100000);
+  });
+});
+
+describe("extractTextContent", () => {
+  it("should return the string directly for string content", () => {
+    expect(extractTextContent("hello world")).toBe("hello world");
+  });
+
+  it("should join text blocks from array content", () => {
+    const content = [
+      { type: "text", text: "hello " },
+      { type: "text", text: "world" },
+    ];
+    expect(extractTextContent(content)).toBe("hello world");
+  });
+
+  it("should ignore non-text blocks", () => {
+    const content = [
+      { type: "text", text: "hello" },
+      { type: "image_url", image_url: { url: "http://example.com/img.png" } },
+      { type: "text", text: " world" },
+    ];
+    expect(extractTextContent(content)).toBe("hello world");
+  });
+
+  it("should return null for array with no text blocks", () => {
+    const content = [
+      { type: "image_url", image_url: { url: "http://example.com/img.png" } },
+    ];
+    expect(extractTextContent(content)).toBeNull();
+  });
+
+  it("should return null for empty array", () => {
+    expect(extractTextContent([])).toBeNull();
+  });
+
+  it("should return empty string for string content that is empty", () => {
+    expect(extractTextContent("")).toBe("");
   });
 });

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -136,6 +136,34 @@ export function createContentPreview(
 }
 
 /**
+ * Extract joined text from message content (string or array of content blocks).
+ */
+export function extractTextContent(
+  content: string | Array<Record<string, unknown>>,
+): string | null {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    const textParts: string[] = [];
+    for (const block of content) {
+      if (
+        typeof block === "object" &&
+        block !== null &&
+        block.type === "text" &&
+        typeof block.text === "string"
+      ) {
+        textParts.push(block.text);
+      }
+    }
+    if (textParts.length > 0) {
+      return textParts.join("");
+    }
+  }
+  return null;
+}
+
+/**
  * required for type inference
  */
 import type * as _zodTypes from "@langchain/core/utils/types";
@@ -853,9 +881,10 @@ export function createFilesystemMiddleware(
         msg: ToolMessage,
         toolTokenLimitBeforeEvict: number,
       ) {
+        const textContent = extractTextContent(msg.content);
         if (
-          typeof msg.content === "string" &&
-          msg.content.length > toolTokenLimitBeforeEvict * NUM_CHARS_PER_TOKEN
+          textContent !== null &&
+          textContent.length > toolTokenLimitBeforeEvict * NUM_CHARS_PER_TOKEN
         ) {
           // Build StateAndStore from request
           const stateAndStore: StateAndStore = {
@@ -871,7 +900,7 @@ export function createFilesystemMiddleware(
 
           const writeResult = await resolvedBackend.write(
             evictPath,
-            msg.content,
+            textContent,
           );
 
           if (writeResult.error) {
@@ -879,7 +908,7 @@ export function createFilesystemMiddleware(
           }
 
           // Create preview showing head and tail of the result
-          const contentSample = createContentPreview(msg.content);
+          const contentSample = createContentPreview(textContent);
           const replacementText = TOO_LARGE_TOOL_MSG.replace(
             "{tool_call_id}",
             msg.tool_call_id,

--- a/libs/deepagents/src/middleware/index.ts
+++ b/libs/deepagents/src/middleware/index.ts
@@ -5,6 +5,7 @@ export {
   TOOLS_EXCLUDED_FROM_EVICTION,
   NUM_CHARS_PER_TOKEN,
   createContentPreview,
+  extractTextContent,
 } from "./fs.js";
 export {
   createSubAgentMiddleware,


### PR DESCRIPTION
## Description
Fixes a bug where the tool result eviction logic only checked `content` when it was a plain string, ignoring array-based content blocks (e.g., `[{ type: "text", text: "..." }]`). This meant that a tool result with complex content blocks containing arbitrarily large `text` fields would bypass the size limit and be sent directly back to the agent.

The fix introduces an `extractTextContent` helper that handles both content formats:
- **String content**: returned as-is (existing behavior)
- **Array content blocks**: joins all blocks with `type === "text"` and checks the combined length

Changes:
- Added `extractTextContent()` utility function in `fs.ts`
- Updated `processToolMessage()` to use `extractTextContent()` instead of only checking string content
- Added 6 unit tests for `extractTextContent`
- Exported `extractTextContent` from the middleware index

Resolves https://github.com/langchain-ai/deepagentsjs/issues/277

## Test Plan
- [x] All 499 existing + new tests pass (`pnpm test`)
- [x] TypeScript compilation passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm lint`)
- [x] Format passes (`pnpm format`)
- [ ] Verify that tool results with array content blocks containing large text are properly evicted
- [ ] Verify that tool results with string content still work as before