### PR TITLE
fix(modal): prevent sandbox timeout in integration tests

### DIFF
--- a/libs/providers/modal/src/sandbox.int.test.ts
+++ b/libs/providers/modal/src/sandbox.int.test.ts
@@ -34,9 +34,11 @@ sandboxStandardTests({
   name: "ModalSandbox",
   skip: !hasCredentials,
   timeout: TEST_TIMEOUT,
+  sequential: true,
   createSandbox: async (options) =>
     ModalSandbox.create({
       imageName: "alpine:3.21",
+      timeoutMs: 900_000,
       ...options,
     }),
   createUninitializedSandbox: () =>
@@ -55,6 +57,7 @@ describe.skipIf(!hasCredentials)("ModalSandbox Provider-Specific Tests", () => {
         sandbox = await withRetry(() =>
           ModalSandbox.create({
             imageName: "alpine:3.21",
+            timeoutMs: 300_000,
             initialFiles: {
               "/tmp/binary-init.txt": encoder.encode("Binary content test"),
             },
@@ -88,6 +91,7 @@ describe.skipIf(!hasCredentials)("ModalSandbox Provider-Specific Tests", () => {
         sandbox = await withRetry(() =>
           ModalSandbox.create({
             imageName: "alpine:3.21",
+            timeoutMs: 300_000,
             initialFiles: {
               "/tmp/download-init.txt": "Content to download",
             },
@@ -133,6 +137,7 @@ describe.skipIf(!hasCredentials)("ModalSandbox Provider-Specific Tests", () => {
         sandbox = await withRetry(() =>
           ModalSandbox.create({
             imageName: "alpine:3.21",
+            timeoutMs: 300_000,
             initialFiles: {
               "/app/config.json": configContent,
             },


### PR DESCRIPTION
## Summary

Fixes flaky Modal provider integration tests that were failing due to sandbox instances being garbage-collected mid-test.

## Changes

### `@langchain/modal`

The Modal standard integration tests were failing because:

1. **No `timeoutMs` on the shared sandbox** — The shared sandbox created by the standard test harness used Modal's SDK default TTL (~5 min), but the full test suite takes ~13 minutes for Modal. The sandbox was terminated mid-run, causing `NOT_FOUND` errors in `globInfo` and `integration` tests.

2. **Concurrent test execution hitting Modal concurrency limits** — Parallel sandbox creation caused `beforeAll` hooks to time out (180s) waiting for capacity.

Fixes:
- Added `timeoutMs: 900_000` (15 min) to the shared sandbox so it survives the full test suite
- Added `sequential: true` to avoid hitting Modal's sandbox concurrency limits (matching the Deno provider pattern)
- Added `timeoutMs: 300_000` (5 min) to the three provider-specific sandbox creations that were missing it
