### PR TITLE
fix(deepagents, quickjs): read store from runtime/config.store instead of config.configurable

### DIFF
--- a/.changeset/store-propagation-fix.md
+++ b/.changeset/store-propagation-fix.md
@@ -1,0 +1,8 @@
+---
+"deepagents": patch
+"@langchain/quickjs": patch
+---
+
+fix(deepagents, quickjs): read store from runtime/config.store instead of config.configurable
+
+The filesystem middleware was reading the store from `request.config.store` (with a `@ts-expect-error`) and the QuickJS middleware from `config.configurable.__pregel_store`. Both now use the properly typed paths: `request.runtime.store` and `config.store` respectively.

--- a/libs/deepagents/src/backends/composite.test.ts
+++ b/libs/deepagents/src/backends/composite.test.ts
@@ -365,7 +365,7 @@ describe("CompositeBackend", () => {
     const result = await (middleware as any).wrapToolCall(
       {
         toolCall: mockToolCall,
-        config: config,
+        config,
         state: { files: {}, messages: [] },
         runtime: {},
       },
@@ -386,7 +386,7 @@ describe("CompositeBackend", () => {
   });
 
   it("should handle large tool result interception routed to store", async () => {
-    const { config } = makeConfig();
+    const { store } = makeConfig();
     const { createFilesystemMiddleware } = await import("../middleware/fs.js");
     const { ToolMessage } = await import("@langchain/core/messages");
 
@@ -411,9 +411,8 @@ describe("CompositeBackend", () => {
     const result = await (middleware as any).wrapToolCall(
       {
         toolCall: mockToolCall,
-        config: config,
         state: { files: {}, messages: [] },
-        runtime: {},
+        runtime: { store },
       },
       mockToolFn,
     );
@@ -422,10 +421,7 @@ describe("CompositeBackend", () => {
     expect(result.content).toContain("Tool result too large");
     expect(result.content).toContain("/large_tool_results/test_routed_123");
 
-    const storedContent = await config.store.get(
-      ["filesystem"],
-      "/test_routed_123",
-    );
+    const storedContent = await store.get(["filesystem"], "/test_routed_123");
     expect(storedContent).toBeDefined();
     expect((storedContent!.value as any).content).toEqual([largeContent]);
   });

--- a/libs/deepagents/src/backends/state.test.ts
+++ b/libs/deepagents/src/backends/state.test.ts
@@ -339,7 +339,7 @@ describe("StateBackend", () => {
     const result = await (middleware as any).wrapToolCall(
       {
         toolCall: mockToolCall,
-        config: config,
+        config,
         state: { files: {}, messages: [] },
         runtime: {},
       },

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -413,7 +413,7 @@ describe("StoreBackend", () => {
   });
 
   it("should handle large tool result interception via middleware", async () => {
-    const { store, config } = makeConfig();
+    const { store } = makeConfig();
     const { createFilesystemMiddleware } = await import("../middleware/fs.js");
     const { ToolMessage } = await import("@langchain/core/messages");
 
@@ -435,9 +435,8 @@ describe("StoreBackend", () => {
     const result = await (middleware as any).wrapToolCall(
       {
         toolCall: mockToolCall,
-        config: config,
         state: { files: {}, messages: [] },
-        runtime: {},
+        runtime: { store },
       },
       mockToolFn,
     );

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -825,8 +825,7 @@ export function createFilesystemMiddleware(
       // Check if backend supports execution
       const stateAndStore: StateAndStore = {
         state: request.state || {},
-        // @ts-expect-error - request.config is incorrect typed
-        store: request.config?.store,
+        store: request.runtime?.store,
       };
       const resolvedBackend = getBackend(backend, stateAndStore);
       const supportsExecution = isSandboxBackend(resolvedBackend);
@@ -878,8 +877,7 @@ export function createFilesystemMiddleware(
           // Build StateAndStore from request
           const stateAndStore: StateAndStore = {
             state: request.state || {},
-            // @ts-expect-error - request.config is incorrect typed
-            store: request.config?.store,
+            store: request.runtime?.store,
           };
           const resolvedBackend = getBackend(backend, stateAndStore);
           const sanitizedId = sanitizeToolCallId(

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -47,7 +47,10 @@ import {
 import type * as _zodTypes from "@langchain/core/utils/types";
 import type * as _zodMeta from "@langchain/langgraph/zod";
 import type * as _messages from "@langchain/core/messages";
-import { getCurrentTaskInput } from "@langchain/langgraph";
+import {
+  getCurrentTaskInput,
+  LangGraphRunnableConfig,
+} from "@langchain/langgraph";
 
 /**
  * Backend-provided tools excluded from PTC by default.
@@ -224,12 +227,12 @@ export function createQuickJSMiddleware(
   }
 
   const jsEvalTool = tool(
-    async (input, config) => {
+    async (input, config: LangGraphRunnableConfig) => {
       const threadId = config.configurable?.thread_id || DEFAULT_SESSION_ID;
 
       const stateAndStore: StateAndStore = {
         state: getCurrentTaskInput(config) || {},
-        store: config.configurable?.__pregel_store,
+        store: config.store,
       };
       const resolvedBackend = getBackend(backend, stateAndStore);
 


### PR DESCRIPTION
## Summary

Fix store propagation in filesystem and QuickJS middleware to use properly typed access paths instead of reaching into internal configurable fields.

## Changes

### `deepagents` — `libs/deepagents/src/middleware/fs.ts`

The filesystem middleware was accessing the store via `request.config.store` with `@ts-expect-error` suppressions. This worked by accident because LangGraph happened to attach the store there, but it wasn't part of the typed contract. Updated both call sites in `createFilesystemMiddleware` to read from `request.runtime.store` instead, which is the intended propagation path. This removes two `@ts-expect-error` comments.

### `@langchain/quickjs` — `libs/providers/quickjs/src/middleware.ts`

The QuickJS middleware was reading the store from `config.configurable.__pregel_store`, an internal/private LangGraph field. Updated to use `config.store`, which is the public API exposed by `LangGraphRunnableConfig`. Added the `LangGraphRunnableConfig` type import and annotated the tool callback parameter for proper typing.

### Test updates

Updated tests in `composite.test.ts`, `state.test.ts`, and `store.test.ts` to pass the store via `runtime: { store }` instead of `config: { store }`, matching the new propagation path.
