### PR TITLE
revert: "revert: "chore(sdk): unify sync subagents and async subagents into a single property (#326)" (#348)"

### DIFF
--- a/.changeset/curvy-donkeys-walk.md
+++ b/.changeset/curvy-donkeys-walk.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+chore(sdk): unify sync subagents and async subagents into a single property

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -23,11 +23,14 @@ import {
   createSkillsMiddleware,
   type SubAgent,
   createAsyncSubAgentMiddleware,
+  isAsyncSubAgent,
 } from "./middleware/index.js";
 import { StateBackend } from "./backends/index.js";
 import { InteropZodObject } from "@langchain/core/utils/types";
 import { CompiledSubAgent } from "./middleware/subagents.js";
+import type { AsyncSubAgent } from "./middleware/async_subagents.js";
 import type {
+  AnySubAgent,
   CreateDeepAgentParams,
   DeepAgent,
   DeepAgentTypeConfig,
@@ -96,8 +99,7 @@ export function createDeepAgent<
   TResponse extends SupportedResponseFormat = SupportedResponseFormat,
   ContextSchema extends InteropZodObject = InteropZodObject,
   const TMiddleware extends readonly AgentMiddleware[] = readonly [],
-  const TSubagents extends readonly (SubAgent | CompiledSubAgent)[] =
-    readonly [],
+  const TSubagents extends readonly AnySubAgent[] = readonly [],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly [],
 >(
   params: CreateDeepAgentParams<
@@ -129,7 +131,6 @@ export function createDeepAgent<
     name,
     memory,
     skills,
-    asyncSubAgents,
   } = params;
 
   const anthropicModel = isAnthropicModel(model);
@@ -187,13 +188,24 @@ export function createDeepAgent<
       : [];
 
   /**
+   * Split the unified subagents array into sync and async subagents.
+   * AsyncSubAgents are identified by the presence of a `graphId` field.
+   */
+  const syncSubAgents = (subagents as readonly AnySubAgent[]).filter(
+    (a): a is SubAgent | CompiledSubAgent => !isAsyncSubAgent(a),
+  );
+  const asyncSubAgents = (subagents as readonly AnySubAgent[]).filter(
+    (a): a is AsyncSubAgent => isAsyncSubAgent(a),
+  );
+
+  /**
    * Process subagents to add SkillsMiddleware for those with their own skills.
    *
    * Custom subagents do NOT inherit skills from the main agent by default.
    * Only the general-purpose subagent inherits the main agent's skills (via defaultMiddleware).
    * If a custom subagent needs skills, it must specify its own `skills` array.
    */
-  const processedSubagents = subagents.map((subagent) => {
+  const processedSubagents = syncSubAgents.map((subagent) => {
     /**
      * CompiledSubAgent - use as-is (already has its own middleware baked in)
      */

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -7,6 +7,7 @@
 
 export { createDeepAgent } from "./agent.js";
 export type {
+  AnySubAgent,
   CreateDeepAgentParams,
   MergedDeepAgentState,
   // DeepAgent type bag and helper types
@@ -44,6 +45,7 @@ export {
   computeSummarizationDefaults,
   createMemoryMiddleware,
   createAsyncSubAgentMiddleware,
+  isAsyncSubAgent,
   // Skills middleware - matches Python's SkillsMiddleware interface
   createSkillsMiddleware,
   type SkillsMiddlewareOptions,

--- a/libs/deepagents/src/middleware/async_subagents.ts
+++ b/libs/deepagents/src/middleware/async_subagents.ts
@@ -8,6 +8,7 @@ import {
   type ToolRuntime,
 } from "langchain";
 import { z } from "zod/v4";
+import type { AnySubAgent } from "../types.js";
 
 /**
  * Specification for an async subagent running on a remote LangGraph server.
@@ -805,6 +806,19 @@ export interface AsyncSubAgentMiddlewareOptions {
  * });
  * ```
  */
+
+/**
+ * Type guard to distinguish async SubAgents from sync SubAgents/CompiledSubAgents.
+ *
+ * Uses the presence of the `graphId` field as the runtime discriminant —
+ * `AsyncSubAgent` requires it, while `SubAgent` and `CompiledSubAgent` do not have it.
+ */
+export function isAsyncSubAgent(
+  subAgent: AnySubAgent,
+): subAgent is AsyncSubAgent {
+  return "graphId" in subAgent;
+}
+
 export function createAsyncSubAgentMiddleware(
   options: AsyncSubAgentMiddlewareOptions,
 ) {

--- a/libs/deepagents/src/middleware/index.ts
+++ b/libs/deepagents/src/middleware/index.ts
@@ -56,6 +56,7 @@ export {
 // Async SubAgent middleware
 export {
   createAsyncSubAgentMiddleware,
+  isAsyncSubAgent,
   type AsyncSubAgentMiddlewareOptions,
   type AsyncSubAgent,
   type AsyncTask,

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -32,6 +32,9 @@ import type { CompiledSubAgent } from "./middleware/subagents.js";
 // We use AnnotationRoot<any> as a compatible equivalent
 type AnyAnnotationRoot = AnnotationRoot<any>;
 
+/** Any subagent specification — sync, compiled, or async. */
+export type AnySubAgent = SubAgent | CompiledSubAgent | AsyncSubAgent;
+
 // TODO: import TypedToolStrategy from "langchain" once exported from the top-level entry point
 // (currently only available via "langchain/dist/agents/responses.js")
 interface TypedToolStrategy<T = unknown> extends Array<ToolStrategy<any>> {
@@ -53,32 +56,30 @@ export type ExtractSubAgentMiddleware<T> = T extends { middleware?: infer M }
 /**
  * Helper type to flatten and merge middleware from all subagents
  */
-export type FlattenSubAgentMiddleware<
-  T extends readonly (SubAgent | CompiledSubAgent)[],
-> = T extends readonly []
-  ? readonly []
-  : T extends readonly [infer First, ...infer Rest]
-    ? Rest extends readonly (SubAgent | CompiledSubAgent)[]
-      ? readonly [
-          ...ExtractSubAgentMiddleware<First>,
-          ...FlattenSubAgentMiddleware<Rest>,
-        ]
-      : ExtractSubAgentMiddleware<First>
-    : readonly [];
+export type FlattenSubAgentMiddleware<T extends readonly AnySubAgent[]> =
+  T extends readonly []
+    ? readonly []
+    : T extends readonly [infer First, ...infer Rest]
+      ? Rest extends readonly AnySubAgent[]
+        ? readonly [
+            ...ExtractSubAgentMiddleware<First>,
+            ...FlattenSubAgentMiddleware<Rest>,
+          ]
+        : ExtractSubAgentMiddleware<First>
+      : readonly [];
 
 /**
  * Helper type to merge states from subagent middleware
  */
-export type InferSubAgentMiddlewareStates<
-  T extends readonly (SubAgent | CompiledSubAgent)[],
-> = InferMiddlewareStates<FlattenSubAgentMiddleware<T>>;
+export type InferSubAgentMiddlewareStates<T extends readonly AnySubAgent[]> =
+  InferMiddlewareStates<FlattenSubAgentMiddleware<T>>;
 
 /**
  * Combined state type including custom middleware and subagent middleware states
  */
 export type MergedDeepAgentState<
   TMiddleware extends readonly AgentMiddleware[],
-  TSubagents extends readonly (SubAgent | CompiledSubAgent)[],
+  TSubagents extends readonly AnySubAgent[],
 > = InferMiddlewareStates<TMiddleware> &
   InferSubAgentMiddlewareStates<TSubagents>;
 
@@ -165,10 +166,7 @@ export interface DeepAgentTypeConfig<
     | ClientTool
     | ServerTool
   )[],
-  TSubagents extends readonly (SubAgent | CompiledSubAgent)[] = readonly (
-    | SubAgent
-    | CompiledSubAgent
-  )[],
+  TSubagents extends readonly AnySubAgent[] = readonly AnySubAgent[],
 > extends AgentTypeConfig<TResponse, TState, TContext, TMiddleware, TTools> {
   /** The subagents array type for type-safe streaming */
   Subagents: TSubagents;
@@ -184,7 +182,7 @@ export interface DefaultDeepAgentTypeConfig extends DeepAgentTypeConfig {
   Context: AnyAnnotationRoot;
   Middleware: readonly AgentMiddleware[];
   Tools: readonly (ClientTool | ServerTool)[];
-  Subagents: readonly (SubAgent | CompiledSubAgent)[];
+  Subagents: readonly AnySubAgent[];
 }
 
 /**
@@ -358,10 +356,7 @@ export interface CreateDeepAgentParams<
   ContextSchema extends AnnotationRoot<any> | InteropZodObject =
     AnnotationRoot<any>,
   TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[],
-  TSubagents extends readonly (SubAgent | CompiledSubAgent)[] = readonly (
-    | SubAgent
-    | CompiledSubAgent
-  )[],
+  TSubagents extends readonly AnySubAgent[] = readonly AnySubAgent[],
   TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -375,7 +370,13 @@ export interface CreateDeepAgentParams<
   systemPrompt?: string | SystemMessage;
   /** Custom middleware to apply after standard middleware */
   middleware?: TMiddleware;
-  /** List of subagent specifications for task delegation */
+  /**
+   * List of subagent specifications for task delegation.
+   *
+   * Supports sync SubAgents, CompiledSubAgents, and AsyncSubAgents in the same array.
+   * AsyncSubAgents (identified by their `graphId` field) are automatically separated
+   * at runtime and wired to the async SubAgent middleware.
+   */
   subagents?: TSubagents;
   /** Structured output response format for the agent (Zod schema or other format) */
   responseFormat?: TResponse;
@@ -435,25 +436,4 @@ export interface CreateDeepAgentParams<
    * ```
    */
   skills?: string[];
-
-  /**
-   * Optional list of async subagent specifications for background jobs on
-   * remote LangGraph servers.
-   *
-   * Async subagents connect to LangGraph deployments via the LangGraph SDK.
-   * They run as background jobs that the main agent can monitor and update.
-   *
-   * @example
-   * ```ts
-   * const agent = createDeepAgent({
-   *   asyncSubAgents: [{
-   *     name: "researcher",
-   *     description: "Research agent for deep analysis",
-   *     url: "https://my-deployment.langsmith.dev",
-   *     graphId: "research_agent",
-   *   }],
-   * });
-   * ```
-   */
-  asyncSubAgents?: AsyncSubAgent[];
 }


### PR DESCRIPTION
This reverts commit 96dc34ccb63d1a096889954b8cb9e226cb4bf6ed.

This adds unified subagents API back into our dev branch.