### PR TITLE
chore: update dependabot schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-      day: "monday"
-      time: "11:00"
+      interval: monthly
     open-pull-requests-limit: 10
     versioning-strategy: increase-if-necessary
     groups:
@@ -27,9 +25,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-      day: "monday"
-      time: "11:00"
+      interval: monthly
     open-pull-requests-limit: 10
     groups:
       patch-deps-updates:


### PR DESCRIPTION
Fixes dependabot configuration to use monthly update schedules instead of weekly, per organization posture standards.

Changes:
- Updated npm updates schedule from weekly to monthly
- Updated github-actions updates schedule from weekly to monthly

This reduces update noise while maintaining reasonable dependency currency.