### PR TITLE
fix: safely handle non-Error thrown values in StoreBackend

### DIFF
--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -358,8 +358,8 @@ export class StoreBackend implements BackendProtocolV2 {
       const lines = fileDataV2.content.split("\n");
       const selected = lines.slice(offset, offset + limit);
       return { content: selected.join("\n"), mimeType: fileDataV2.mimeType };
-    } catch (e: any) {
-      return { error: e.message };
+    } catch (e: unknown) {
+      return { error: e instanceof Error ? e.message : String(e) };
     }
   }
 
@@ -449,8 +449,9 @@ export class StoreBackend implements BackendProtocolV2 {
       const storeValue = this.convertFileDataToStoreValue(newFileData);
       await store.put(namespace, filePath, storeValue);
       return { path: filePath, filesUpdate: null, occurrences: occurrences };
-    } catch (e: any) {
-      return { error: `Error: ${e.message}` };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { error: `Error: ${msg}` };
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace `catch (e: any)` with `catch (e: unknown)` in two `StoreBackend` methods (`readFileContent`, `editFileContent`)
- Guard `.message` access with `e instanceof Error` check, falling back to `String(e)` for non-Error thrown values
- Prevents error responses containing `undefined` when a non-Error value (string, number, object) is thrown

## Test plan
- [ ] Verify existing unit tests for `StoreBackend.readFileContent` and `editFileContent` still pass
- [ ] Confirm error message is correctly captured when a non-Error value is thrown