### PR TITLE
feat(providers): add @langchain/wasmsh — in-process shell + Python sandbox

### DIFF
--- a/.changeset/add-wasmsh-sandbox.md
+++ b/.changeset/add-wasmsh-sandbox.md
@@ -1,0 +1,17 @@
+---
+"deepagents": minor
+"@langchain/wasmsh": minor
+---
+
+feat: add @langchain/wasmsh sandbox provider
+
+Adds a new sandbox provider backed by wasmsh, a Bash-compatible shell
+runtime compiled to WebAssembly. Runs entirely in-process with no
+containers or remote services — works in both Node.js and browser
+Web Workers.
+
+- New package `@langchain/wasmsh` with `WasmshSandbox.createNode()` and
+  `WasmshSandbox.createBrowserWorker()` factory methods
+- Browser build entry for deepagents core (`index.browser.js`)
+- `filesystemOptions` parameter on `createDeepAgent` for middleware tuning
+- Browser-compatible subagent state handling

--- a/examples/sandbox/wasmsh-browser-sandbox.ts
+++ b/examples/sandbox/wasmsh-browser-sandbox.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-console */
+import { WasmshSandbox } from "@langchain/wasmsh";
+
+async function main() {
+  const sandbox = await WasmshSandbox.createBrowserWorker({
+    assetBaseUrl: "/node_modules/wasmsh-pyodide/assets",
+  });
+
+  try {
+    const result = await sandbox.execute(
+      "python3 -c \"print('hello from browser worker')\"",
+    );
+    console.log(result.output.trim());
+  } finally {
+    await sandbox.stop();
+  }
+}
+
+void main();

--- a/examples/sandbox/wasmsh-node-sandbox.ts
+++ b/examples/sandbox/wasmsh-node-sandbox.ts
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+import "dotenv/config";
+
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+
+import { createDeepAgent } from "deepagents";
+import { WasmshSandbox } from "@langchain/wasmsh";
+
+const systemPrompt = `You are a coding assistant with access to a wasmsh sandbox.
+
+The sandbox is rooted at /workspace and supports bash-compatible shell commands
+plus python3. It is not a general Linux container.
+`;
+
+async function main() {
+  const sandbox = await WasmshSandbox.createNode({
+    initialFiles: {
+      "/workspace/data.txt": "hello from wasmsh",
+    },
+  });
+
+  try {
+    const agent = createDeepAgent({
+      model: "claude-haiku-4-5",
+      systemPrompt,
+      backend: sandbox,
+    });
+
+    const result = await agent.invoke({
+      messages: [
+        new HumanMessage(
+          "Read data.txt with bash, then confirm its contents from python3 and summarize what you found.",
+        ),
+      ],
+    });
+
+    const reply = result.messages.findLast(AIMessage.isInstance);
+    if (reply) {
+      console.log(reply.content);
+    }
+  } finally {
+    await sandbox.stop();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -602,6 +602,25 @@ When using a sandbox backend, the agent gains access to an `execute` tool that c
 
 See [examples/sandbox/local-sandbox.ts](examples/sandbox/local-sandbox.ts) for a complete implementation.
 
+#### Pre-built Sandbox Providers
+
+| Package | Environment | Description |
+|---------|------------|-------------|
+| `@langchain/wasmsh` | Node / Browser Worker | In-process Pyodide/WASM sandbox with bash + Python — no container required |
+| `@langchain/deno` | Deno Deploy | Remote Deno sandbox |
+| `@langchain/modal` | Modal | Remote Modal sandbox |
+| `@langchain/daytona` | Daytona | Remote Daytona devbox |
+
+```typescript
+import { WasmshSandbox } from "@langchain/wasmsh";
+
+const sandbox = await WasmshSandbox.createNode();
+const agent = createDeepAgent({ backend: sandbox, systemPrompt: "..." });
+// sandbox supports both bash and python3 in /workspace
+```
+
+See [examples/sandbox/](examples/sandbox/) for provider-specific examples.
+
 ## Deep Agents Middleware
 
 Deep Agents are built with a modular middleware architecture. As a reminder, Deep Agents have access to:

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -64,8 +64,13 @@
     "typescript": "^6.0.2",
     "vitest": "^4.0.18"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/index.browser.js"
+      },
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -173,6 +173,7 @@ export function createDeepAgent<
     checkpointer,
     store,
     backend = (config) => new StateBackend(config),
+    filesystemOptions,
     interruptOn,
     name,
     memory,
@@ -217,7 +218,7 @@ export function createDeepAgent<
       // Provides todo list management capabilities for tracking tasks.
       todoListMiddleware(),
       // Enables filesystem operations and optional long-term memory storage.
-      createFilesystemMiddleware({ backend }),
+      createFilesystemMiddleware({ backend, ...filesystemOptions }),
       // Automatically summarizes conversation history when token limits are approached.
       // Uses createSummarizationMiddleware (deepagents version) with backend support
       // and auto-computed defaults from model profile.
@@ -283,7 +284,7 @@ export function createDeepAgent<
     // Provides todo list management capabilities for tracking tasks.
     todoListMiddleware(),
     // Enables filesystem operations and optional long-term memory storage.
-    createFilesystemMiddleware({ backend }),
+    createFilesystemMiddleware({ backend, ...filesystemOptions }),
     // Enables delegation to specialized subagents for complex tasks.
     createSubAgentMiddleware({
       defaultModel: model,

--- a/libs/deepagents/src/backends/index.browser.ts
+++ b/libs/deepagents/src/backends/index.browser.ts
@@ -1,0 +1,42 @@
+/**
+ * Browser-safe backend exports.
+ *
+ * Excludes FilesystemBackend, LocalShellBackend, and LangSmithSandbox
+ * which require Node.js APIs (node:fs, node:child_process).
+ *
+ * In browser, use a SandboxBackendProtocol implementation (e.g. wasmsh
+ * BrowserSandbox) that provides filesystem, shell, and Python via Web Worker.
+ */
+
+export type {
+  BackendProtocol,
+  BackendFactory,
+  BackendRuntime,
+  FileData,
+  FileInfo,
+  GrepMatch,
+  WriteResult,
+  EditResult,
+  StateAndStore,
+  ExecuteResponse,
+  FileOperationError,
+  FileDownloadResponse,
+  FileUploadResponse,
+  SandboxBackendProtocol,
+  MaybePromise,
+  SandboxInfo,
+  SandboxListResponse,
+  SandboxListOptions,
+  SandboxGetOrCreateOptions,
+  SandboxDeleteOptions,
+  SandboxErrorCode,
+} from "./protocol.js";
+
+export { isSandboxBackend, SandboxError, resolveBackend } from "./protocol.js";
+
+export { StateBackend } from "./state.js";
+export { StoreBackend, type StoreBackendOptions } from "./store.js";
+export { CompositeBackend } from "./composite.js";
+export { BaseSandbox } from "./sandbox.js";
+
+export * from "./utils.js";

--- a/libs/deepagents/src/index.browser.ts
+++ b/libs/deepagents/src/index.browser.ts
@@ -1,0 +1,98 @@
+/**
+ * Browser entry point for Deep Agents.
+ *
+ * Exports everything needed to run createDeepAgent() in the browser with a
+ * SandboxBackendProtocol implementation (e.g. wasmsh BrowserSandbox).
+ *
+ * All middleware (filesystem tools, skills, memory, subagents, summarization)
+ * works through the BackendProtocol — the sandbox provides execute(), read(),
+ * write(), edit(), lsInfo(), grepRaw(), globInfo() in the browser.
+ *
+ * Excludes only modules that use Node.js APIs directly (not through protocol):
+ * - config.ts (scans local .git dirs with fs/path/os)
+ * - middleware/agent-memory.ts (reads agent.md from disk with node:fs)
+ * - skills/loader.ts (scans local dirs for SKILL.md with node:fs)
+ * - backends/filesystem.ts (Node.js filesystem backend)
+ * - backends/local-shell.ts (Node.js shell backend)
+ * - backends/langsmith.ts (LangSmith sandbox)
+ */
+
+export { createDeepAgent } from "./agent.js";
+export { ConfigurationError, type ConfigurationErrorCode } from "./errors.js";
+export type {
+  CreateDeepAgentParams,
+  MergedDeepAgentState,
+  DeepAgent,
+  DeepAgentTypeConfig,
+  DefaultDeepAgentTypeConfig,
+  ResolveDeepAgentTypeConfig,
+  InferDeepAgentType,
+  InferDeepAgentSubagents,
+  InferSubagentByName,
+  InferSubagentReactAgentType,
+  ExtractSubAgentMiddleware,
+  FlattenSubAgentMiddleware,
+  InferSubAgentMiddlewareStates,
+  SupportedResponseFormat,
+  InferStructuredResponse,
+} from "./types.js";
+
+// Middleware — all work through BackendProtocol, browser-safe
+export {
+  createFilesystemMiddleware,
+  createSubAgentMiddleware,
+  createPatchToolCallsMiddleware,
+  createSummarizationMiddleware,
+  computeSummarizationDefaults,
+  createMemoryMiddleware,
+  createSkillsMiddleware,
+  type SkillsMiddlewareOptions,
+  type SkillMetadata,
+  MAX_SKILL_FILE_SIZE,
+  MAX_SKILL_NAME_LENGTH,
+  MAX_SKILL_DESCRIPTION_LENGTH,
+  GENERAL_PURPOSE_SUBAGENT,
+  DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
+  DEFAULT_SUBAGENT_PROMPT,
+  TASK_SYSTEM_PROMPT,
+  type FilesystemMiddlewareOptions,
+  type SubAgentMiddlewareOptions,
+  type MemoryMiddlewareOptions,
+  type SubAgent,
+  type CompiledSubAgent,
+} from "./middleware/index.js";
+
+export { filesValue } from "./values.js";
+
+// Browser-safe backends (no FilesystemBackend, LocalShellBackend, LangSmithSandbox)
+export {
+  StateBackend,
+  StoreBackend,
+  type StoreBackendOptions,
+  CompositeBackend,
+  BaseSandbox,
+  isSandboxBackend,
+  SandboxError,
+  type BackendProtocol,
+  type BackendFactory,
+  type BackendRuntime,
+  resolveBackend,
+  type FileInfo,
+  type GrepMatch,
+  type WriteResult,
+  type EditResult,
+  type ExecuteResponse,
+  type FileData,
+  type FileOperationError,
+  type FileDownloadResponse,
+  type FileUploadResponse,
+  type SandboxBackendProtocol,
+  type StateAndStore,
+  type MaybePromise,
+  type SandboxInfo,
+  type SandboxListResponse,
+  type SandboxListOptions,
+  type SandboxGetOrCreateOptions,
+  type SandboxDeleteOptions,
+  type SandboxErrorCode,
+} from "./backends/index.browser.js";

--- a/libs/deepagents/src/middleware/subagents.browser.test.ts
+++ b/libs/deepagents/src/middleware/subagents.browser.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@langchain/langgraph", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@langchain/langgraph")>();
+  return {
+    ...actual,
+    getCurrentTaskInput: vi.fn(() => {
+      throw new Error(
+        "browser task tool should use runtime.state instead of getCurrentTaskInput",
+      );
+    }),
+  };
+});
+
+import { createAgent, type ToolRuntime } from "langchain";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+import { Command, getCurrentTaskInput } from "@langchain/langgraph";
+import { createSubAgentMiddleware } from "../index.js";
+import { extractToolsFromAgent, SAMPLE_MODEL } from "../testing/utils.js";
+
+type BrowserToolState = {
+  messages?: unknown[];
+  todos?: string[];
+  files?: Record<string, unknown>;
+  custom?: string;
+};
+
+describe("browser subagent task tool", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses runtime.state when invoking a subagent", async () => {
+    const invoke = vi.fn(async () => ({
+      messages: [new AIMessage("Subagent finished")],
+    }));
+
+    const agent = createAgent({
+      model: SAMPLE_MODEL,
+      middleware: [
+        createSubAgentMiddleware({
+          defaultModel: SAMPLE_MODEL,
+          subagents: [
+            {
+              name: "worker",
+              description: "Browser-safe worker",
+              runnable: { invoke } as any,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const tools = extractToolsFromAgent(agent);
+    const runtime = {
+      toolCall: { id: "call-task-1" },
+      toolCallId: "call-task-1",
+      config: {
+        configurable: {
+          thread_id: "parent-thread-1",
+        },
+      },
+      context: undefined,
+      store: null,
+      writer: null,
+      state: {
+        messages: [new HumanMessage("Parent message")],
+        todos: ["keep out of subagent state"],
+        files: {
+          "/workspace/input.txt": {
+            content: ["seed"],
+            created_at: "2024-01-01",
+            modified_at: "2024-01-01",
+          },
+        },
+        custom: "keep me",
+      },
+    } as unknown as ToolRuntime<BrowserToolState>;
+
+    const result = await tools.task.invoke(
+      {
+        description: "Inspect /workspace/input.txt",
+        subagent_type: "worker",
+      },
+      runtime,
+    );
+
+    expect(vi.mocked(getCurrentTaskInput)).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledTimes(1);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [subagentState, subagentConfig] = invoke.mock.calls[0] as any[];
+    expect(subagentConfig).toEqual(runtime.config);
+    expect(subagentState).toMatchObject({
+      files: runtime.state.files,
+      custom: "keep me",
+    });
+    expect(subagentState.messages).toEqual([
+      new HumanMessage({ content: "Inspect /workspace/input.txt" }),
+    ]);
+    expect(subagentState.todos).toBeUndefined();
+    expect(result).toBeInstanceOf(Command);
+  });
+});

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -13,6 +13,7 @@ import {
   type InterruptOnConfig,
   type ReactAgent,
   type CreateAgentParams,
+  type ToolRuntime,
   StructuredTool,
   context,
 } from "langchain";
@@ -56,6 +57,18 @@ const EXCLUDED_STATE_KEYS = [
  */
 export const DEFAULT_GENERAL_PURPOSE_DESCRIPTION =
   "General-purpose agent for researching complex questions, searching for files and content, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you. This agent has access to all tools as the main agent.";
+
+type SubAgentToolState = Record<string, unknown>;
+
+function getSubagentParentState(
+  runtime: ToolRuntime<SubAgentToolState>,
+): SubAgentToolState {
+  if (runtime.state && typeof runtime.state === "object") {
+    return runtime.state;
+  }
+
+  return getCurrentTaskInput<SubAgentToolState>();
+}
 
 // Comprehensive task tool description from Python
 function getTaskToolDescription(subagentDescriptions: string[]): string {
@@ -580,7 +593,7 @@ function createTaskTool(options: {
   return tool(
     async (
       input: { description: string; subagent_type: string },
-      config,
+      runtime: ToolRuntime<SubAgentToolState>,
     ): Promise<Command | string> => {
       const { description, subagent_type } = input;
 
@@ -597,17 +610,17 @@ function createTaskTool(options: {
       const subagent = subagentGraphs[subagent_type];
 
       // Get current state and filter it for subagent
-      const currentState = getCurrentTaskInput<Record<string, unknown>>();
+      const currentState = getSubagentParentState(runtime);
       const subagentState = filterStateForSubagent(currentState);
       subagentState.messages = [new HumanMessage({ content: description })];
 
       // Invoke the subagent
-      const result = (await subagent.invoke(subagentState, config)) as Record<
-        string,
-        unknown
-      >;
+      const result = (await subagent.invoke(
+        subagentState,
+        runtime.config,
+      )) as Record<string, unknown>;
 
-      if (!config.toolCall?.id) {
+      if (!runtime.toolCall?.id) {
         if (result.structuredResponse != null) {
           return JSON.stringify(result.structuredResponse);
         }
@@ -631,7 +644,7 @@ function createTaskTool(options: {
         return content;
       }
 
-      return returnCommandWithStateUpdate(result, config.toolCall.id);
+      return returnCommandWithStateUpdate(result, runtime.toolCall.id);
     },
     {
       name: "task",

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -24,6 +24,7 @@ import type {
 
 import type { AnyBackendProtocol } from "./backends/index.js";
 import type { AsyncSubAgent, SubAgent } from "./middleware/index.js";
+import type { FilesystemMiddlewareOptions } from "./middleware/index.js";
 import type { InteropZodObject } from "@langchain/core/utils/types";
 import type { AnnotationRoot } from "@langchain/langgraph";
 import type { CompiledSubAgent } from "./middleware/subagents.js";
@@ -394,6 +395,11 @@ export interface CreateDeepAgentParams<
   backend?:
     | AnyBackendProtocol
     | ((config: { state: unknown; store?: BaseStore }) => AnyBackendProtocol);
+  /** Optional overrides for the built-in filesystem middleware */
+  filesystemOptions?: Pick<
+    FilesystemMiddlewareOptions,
+    "toolTokenLimitBeforeEvict" | "humanMessageTokenLimitBeforeEvict"
+  >;
   /** Optional interrupt configuration mapping tool names to interrupt configs */
   interruptOn?: Record<string, boolean | InterruptOnConfig>;
   /** The name of the agent */

--- a/libs/deepagents/tsdown.config.ts
+++ b/libs/deepagents/tsdown.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "tsdown";
 // Mark all node_modules as external since this is a library
 const external = [/^[^./]/];
 
+// Browser build: inline `langchain` (its browser entry omits agent middleware)
+// but keep @langchain/* external (they have proper browser support)
+const browserExternal = [/^(?!langchain(\/|$))[^./]/];
+
 export default defineConfig([
   {
     entry: ["./src/index.ts"],
@@ -18,10 +22,20 @@ export default defineConfig([
     entry: ["./src/index.ts"],
     format: ["cjs"],
     dts: true,
-    clean: true,
+    clean: false,
     sourcemap: true,
     outDir: "dist",
     outExtensions: () => ({ js: ".cjs" }),
     external,
+  },
+  {
+    entry: { "index.browser": "./src/index.browser.ts" },
+    format: ["esm"],
+    dts: true,
+    clean: false,
+    sourcemap: true,
+    outDir: "dist",
+    outExtensions: () => ({ js: ".js" }),
+    external: browserExternal,
   },
 ]);

--- a/libs/providers/wasmsh/README.md
+++ b/libs/providers/wasmsh/README.md
@@ -1,0 +1,207 @@
+# @langchain/wasmsh
+
+Wasmsh sandbox provider for [Deep Agents](https://github.com/langchain-ai/deepagentsjs).
+Runs bash and Python 3 inside an in-process Pyodide/WASM sandbox — no container
+or cloud service required.
+
+## Getting started
+
+### Install
+
+```bash
+pnpm add @langchain/wasmsh deepagents
+```
+
+Requires Node.js 20+.
+
+### Create an agent with a wasmsh sandbox
+
+```typescript
+import { createDeepAgent } from "deepagents";
+import { WasmshSandbox } from "@langchain/wasmsh";
+
+const sandbox = await WasmshSandbox.createNode();
+
+try {
+  const agent = createDeepAgent({
+    model: "claude-sonnet-4-5-20250929",
+    systemPrompt: "You are a coding assistant with bash and Python access.",
+    backend: sandbox,
+  });
+
+  const result = await agent.invoke({
+    messages: [{ role: "user", content: "Write a Python script that computes fibonacci(10) and save it to fib.py, then run it." }],
+  });
+
+  console.log(result.messages.at(-1)?.content);
+} finally {
+  await sandbox.stop();
+}
+```
+
+The agent automatically gets `execute`, `read_file`, `write_file`, `edit_file`,
+`ls`, `glob`, and `grep` tools — all routed through the sandbox.
+
+## How-to guides
+
+### Seed files before the agent runs
+
+Pass `initialFiles` to pre-populate `/workspace`:
+
+```typescript
+const sandbox = await WasmshSandbox.createNode({
+  initialFiles: {
+    "/workspace/data.csv": "name,score\nalice,95\nbob,87\n",
+    "/workspace/config.json": JSON.stringify({ threshold: 90 }),
+  },
+});
+```
+
+Both string and `Uint8Array` values are accepted.
+
+### Retrieve files after execution
+
+Use `downloadFiles` to pull artifacts out of the sandbox:
+
+```typescript
+const results = await sandbox.downloadFiles(["/workspace/report.txt"]);
+if (results[0].error === null) {
+  const text = new TextDecoder().decode(results[0].content!);
+  console.log(text);
+}
+```
+
+### Upload files at runtime
+
+```typescript
+const encoder = new TextEncoder();
+await sandbox.uploadFiles([
+  ["/workspace/input.txt", encoder.encode("new data")],
+]);
+```
+
+### Use a custom working directory
+
+By default, all commands run relative to `/workspace`. Override this:
+
+```typescript
+const sandbox = await WasmshSandbox.createNode({
+  workingDirectory: "/home/user",
+});
+```
+
+### Run in a browser Web Worker
+
+Browser support uses a Web Worker to isolate the WASM runtime from the main
+thread:
+
+```typescript
+const sandbox = await WasmshSandbox.createBrowserWorker({
+  assetBaseUrl: "/node_modules/wasmsh-pyodide/assets",
+});
+
+try {
+  const result = await sandbox.execute("python3 -c \"print('hello')\"");
+  console.log(result.output);
+} finally {
+  await sandbox.stop();
+}
+```
+
+Main-thread execution is not supported in v1.
+
+## Reference
+
+### `WasmshSandbox.createNode(options?): Promise<WasmshSandbox>`
+
+Create a sandbox backed by a local Node.js host process.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `distPath` | `string` | auto-resolved | Path to Pyodide distribution assets |
+| `stepBudget` | `number` | `0` (unlimited) | VM step budget per command |
+| `initialFiles` | `Record<string, string \| Uint8Array>` | `undefined` | Files to seed at creation |
+| `workingDirectory` | `string` | `"/workspace"` | Working directory for `execute()` |
+| `allowedHosts` | `string[]` | `[]` (deny all) | Hostnames allowed for network access |
+
+### `WasmshSandbox.createBrowserWorker(options): Promise<WasmshSandbox>`
+
+Create a sandbox backed by a browser Web Worker.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `assetBaseUrl` | `string` | **(required)** | URL prefix for Pyodide assets |
+| `worker` | `Worker` | auto-created | Pre-existing Worker instance |
+| `stepBudget` | `number` | `0` (unlimited) | VM step budget per command |
+| `initialFiles` | `Record<string, string \| Uint8Array>` | `undefined` | Files to seed at creation |
+| `workingDirectory` | `string` | `"/workspace"` | Working directory for `execute()` |
+
+### Instance properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Unique sandbox identifier (e.g., `wasmsh-node-1711641600000`) |
+| `isRunning` | `boolean` | `true` while the session is active |
+
+### Instance methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `execute(command)` | `Promise<ExecuteResponse>` | Run a shell command (prepends `cd /workspace &&`) |
+| `uploadFiles(files)` | `Promise<FileUploadResponse[]>` | Write files into the sandbox |
+| `downloadFiles(paths)` | `Promise<FileDownloadResponse[]>` | Read files from the sandbox |
+| `stop()` | `Promise<void>` | Shut down the session |
+| `close()` | `Promise<void>` | Alias for `stop()` |
+| `initialize()` | `Promise<void>` | Explicit init (called automatically by `createNode`/`createBrowserWorker`) |
+
+### Inherited from `BaseSandbox`
+
+These methods are implemented via `execute()` — no additional setup required:
+
+`read`, `write`, `edit`, `lsInfo`, `grepRaw`, `globInfo`
+
+### Error mapping
+
+Diagnostic events from the wasmsh runtime are mapped to `FileOperationError`:
+
+| Diagnostic contains | Mapped to |
+|---------------------|-----------|
+| `"not found"` | `"file_not_found"` |
+| `"directory"` | `"is_directory"` |
+| `"permission"` | `"permission_denied"` |
+| *(other)* | `"invalid_path"` |
+
+## Explanation
+
+### What runs inside the sandbox
+
+The wasmsh runtime provides 86 shell utilities (including `jq`, `awk`, `rg`,
+`fd`, `diff`, `tar`, `gzip`) plus `python`/`python3` via an embedded CPython
+interpreter. Both share the same Emscripten POSIX filesystem.
+
+This is **not** a Linux container. There is no kernel, no process isolation, no
+`apt`, `pip`, or `docker`. If you need a full OS environment, use a container-based
+provider like `@langchain/modal` or `@langchain/daytona`.
+
+### How the agent uses the sandbox
+
+When you pass a `WasmshSandbox` as the `backend` to `createDeepAgent`, the agent
+gains access to filesystem tools (`read`, `write`, `edit`, `ls`, `glob`, `grep`)
+and a shell `execute` tool. All of these route through the sandbox:
+
+- **Filesystem tools** (`read_file`, `write_file`, `edit_file`, `ls`, `glob`,
+  `grep`) are implemented by `BaseSandbox` using POSIX shell commands via
+  `execute()`. No direct file I/O — everything flows through the sandbox.
+- **`execute()`** prepends `cd /workspace &&` to every command, ensuring all
+  operations happen relative to the sandbox root.
+- **`initialFiles`** are written during sandbox creation via the wasmsh `WriteFile`
+  protocol command before any agent code runs.
+
+### Node vs browser architecture
+
+- **Node**: `WasmshSandbox` spawns a child process that boots the Pyodide/Emscripten
+  module. Communication is JSON-RPC over stdin/stdout.
+- **Browser**: `WasmshSandbox` creates a Web Worker that loads the Pyodide WASM
+  module. Communication is JSON-RPC over `postMessage`.
+
+Both modes use the same wasmsh protocol and produce identical results.

--- a/libs/providers/wasmsh/e2e/browser-agent.spec.ts
+++ b/libs/providers/wasmsh/e2e/browser-agent.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Playwright E2E tests: fully in-browser deep agent with wasmsh sandbox.
+ *
+ * Everything runs in the browser — no backend service involved:
+ * - wasmsh shell/Python execution via browser Web Worker
+ * - LLM calls via ChatAnthropic with dangerouslyAllowBrowser
+ * - createDeepAgent orchestrates the agent with full middleware stack
+ *
+ * Requires: built Pyodide assets + ANTHROPIC_API_KEY
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+
+test.skip(!API_KEY, "ANTHROPIC_API_KEY not set");
+
+async function runBrowserTest(page: Page, testName: string) {
+  await page.goto(`/?key=${encodeURIComponent(API_KEY!)}&test=${testName}`);
+
+  // Wait for completion (boot + agent run)
+  await page.waitForFunction(
+    () => {
+      try {
+        const data = JSON.parse(
+          document.getElementById("result")?.textContent ?? "{}",
+        );
+        return data.status === "done" || data.status === "error";
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 120_000 },
+  );
+
+  const resultText = await page.textContent("#result");
+  const result = JSON.parse(resultText!);
+
+  if (result.status === "error") {
+    // eslint-disable-next-line no-console -- test diagnostics
+    console.error(`[${testName}] error:`, result.message);
+  }
+
+  return result;
+}
+
+test("csv analysis: Python computes correct statistics", async ({ page }) => {
+  test.setTimeout(120_000);
+  const result = await runBrowserTest(page, "csv");
+
+  expect(result.status).toBe("done");
+  expect(result.exitCode).toBe(0);
+  expect(result.analysis.average).toBe(21);
+  expect(result.analysis.hottest_city).toBe("Cairo");
+  expect(result.analysis.hottest_temp).toBe(35);
+});
+
+test("skills: agent loads SKILL.md from sandbox and follows instructions", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+  const result = await runBrowserTest(page, "skills");
+
+  expect(result.status).toBe("done");
+  // Verify the table was written and contains expected data
+  expect(result.table).toContain("Alice");
+  expect(result.table).toContain("Carol");
+  expect(result.table).toContain("|");
+  // Verify the summary JSON
+  expect(result.summary.count).toBe(3);
+  expect(result.summary.top_scorer).toBe("Carol");
+});
+
+test("filesystem: edit and write_file work", async ({ page }) => {
+  test.setTimeout(120_000);
+  const result = await runBrowserTest(page, "filesystem");
+
+  expect(result.status).toBe("done");
+  expect(result.mainContainsGoodbye).toBe(true);
+  expect(result.mainNotHello).toBe(true);
+  expect(result.configExists).toBe(true);
+});
+
+test("memory: agent uses AGENTS.md context from sandbox", async ({ page }) => {
+  test.setTimeout(120_000);
+  const result = await runBrowserTest(page, "memory");
+
+  expect(result.status).toBe("done");
+  const d = result.deploy;
+  // These values are only available from the memory file
+  const region = d.region?.toLowerCase() ?? "";
+  expect(region.includes("frankfurt") || region.includes("eu-central")).toBe(
+    true,
+  );
+  expect(d.unit_system?.toLowerCase()).toContain("metric");
+  expect(d.team_lead).toContain("Weber");
+  expect(d.database?.toLowerCase()).toContain("postgres");
+});
+
+test("code execution: Python computes median and stddev", async ({ page }) => {
+  test.setTimeout(120_000);
+  const result = await runBrowserTest(page, "code");
+
+  expect(result.status).toBe("done");
+  const s = result.stats;
+  expect(s.sorted).toEqual([3, 10, 17, 25, 42, 56, 64, 73, 88, 91]);
+  expect(s.median).toBe(49);
+  expect(s.stddev).toBeGreaterThan(29);
+  expect(s.stddev).toBeLessThan(32);
+});

--- a/libs/providers/wasmsh/e2e/fixture/browser-sandbox.ts
+++ b/libs/providers/wasmsh/e2e/fixture/browser-sandbox.ts
@@ -1,0 +1,250 @@
+/**
+ * Browser-only WasmshSandbox that talks to the wasmsh worker via raw
+ * postMessage. The Playwright fixture intentionally avoids the
+ * `@mayflowergmbh/wasmsh-pyodide` browser session so we can exercise the
+ * thinnest deps-free wire path. Production code should use
+ * `WasmshSandbox.createBrowserWorker` instead.
+ */
+import { BaseSandbox } from "deepagents";
+
+import {
+  errorMessage,
+  getDiagnosticError,
+  mapDownloadError,
+} from "../../src/internal.js";
+
+interface UploadOk {
+  events?: unknown[];
+}
+
+interface DownloadOk {
+  events?: unknown[];
+  contentBase64: string;
+}
+
+interface RunOk {
+  output?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode: number | null;
+}
+
+type WorkerResponse<T> =
+  | { id: number; ok: true; result: T }
+  | { id: number; ok: false; error: string };
+
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+};
+
+function toBase64(bytes: Uint8Array): string {
+  // Chunk to keep String.fromCharCode argument list bounded for large files.
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(i, Math.min(i + CHUNK, bytes.length)),
+    );
+  }
+  return btoa(binary);
+}
+
+function fromBase64(text: string): Uint8Array {
+  const binary = atob(text);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+class BrowserSession {
+  private _worker: Worker;
+  private _nextId = 1;
+  private _pending = new Map<number, Pending>();
+  private _dead = false;
+
+  constructor(worker: Worker) {
+    this._worker = worker;
+
+    worker.addEventListener("message", (event: MessageEvent) => {
+      const response = event.data as WorkerResponse<unknown>;
+      const entry = this._pending.get(response.id);
+      if (!entry) return;
+      this._pending.delete(response.id);
+      if (response.ok) {
+        entry.resolve(response.result);
+      } else {
+        entry.reject(new Error(response.error));
+      }
+    });
+
+    worker.addEventListener("error", (event: ErrorEvent) => {
+      this._dead = true;
+      const error = new Error(`Worker error: ${event.message ?? "unknown"}`);
+      for (const entry of this._pending.values()) entry.reject(error);
+      this._pending.clear();
+    });
+  }
+
+  request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    if (this._dead) {
+      return Promise.reject(new Error("Worker session is closed"));
+    }
+    const id = this._nextId++;
+    return new Promise<T>((resolve, reject) => {
+      this._pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      this._worker.postMessage({ id, method, params });
+    });
+  }
+
+  terminate() {
+    this._dead = true;
+    this._worker.terminate();
+  }
+}
+
+export interface BrowserSandboxOptions {
+  workerUrl: string;
+  assetBaseUrl: string;
+  stepBudget?: number;
+  workingDirectory?: string;
+  initialFiles?: Record<string, string | Uint8Array>;
+}
+
+export class BrowserSandbox extends BaseSandbox {
+  readonly id: string;
+  private _session: BrowserSession | null = null;
+  private _options: BrowserSandboxOptions;
+  private _workingDirectory: string;
+
+  constructor(options: BrowserSandboxOptions) {
+    super();
+    this.id = `wasmsh-browser-${crypto.randomUUID()}`;
+    this._options = options;
+    this._workingDirectory = options.workingDirectory ?? "/workspace";
+  }
+
+  get isRunning() {
+    return this._session !== null;
+  }
+
+  async initialize(): Promise<void> {
+    const worker = new Worker(this._options.workerUrl, {
+      name: "wasmsh-pyodide",
+    });
+    this._session = new BrowserSession(worker);
+
+    const initialFiles = this._options.initialFiles
+      ? Object.entries(this._options.initialFiles).map(([path, content]) => ({
+          path,
+          contentBase64: toBase64(
+            typeof content === "string"
+              ? new TextEncoder().encode(content)
+              : content,
+          ),
+        }))
+      : [];
+
+    await this._session.request("init", {
+      assetBaseUrl: this._options.assetBaseUrl,
+      stepBudget: this._options.stepBudget ?? 0,
+      initialFiles,
+    });
+  }
+
+  async execute(command: string) {
+    const fullCommand = `cd '${this._workingDirectory.replace(/'/g, "'\\''")}' && ${command}`;
+    const result = await this._session!.request<RunOk>("run", {
+      command: fullCommand,
+    });
+    return {
+      output: result.output ?? (result.stdout ?? "") + (result.stderr ?? ""),
+      exitCode: result.exitCode ?? null,
+      truncated: false,
+    };
+  }
+
+  async uploadFiles(files: Array<[string, Uint8Array]>) {
+    const session = this._session!;
+    return Promise.all(
+      files.map(async ([filePath, content]) => {
+        if (!filePath.startsWith("/")) {
+          return { path: filePath, error: "invalid_path" as const };
+        }
+        try {
+          const result = await session.request<UploadOk>("writeFile", {
+            path: filePath,
+            contentBase64: toBase64(content),
+          });
+          const diagnostic = getDiagnosticError(result?.events);
+          return {
+            path: filePath,
+            error: diagnostic ? mapDownloadError(diagnostic) : null,
+          };
+        } catch (error: unknown) {
+          return {
+            path: filePath,
+            error: mapDownloadError(errorMessage(error)),
+          };
+        }
+      }),
+    );
+  }
+
+  async downloadFiles(paths: string[]) {
+    const session = this._session!;
+    return Promise.all(
+      paths.map(async (filePath) => {
+        if (!filePath.startsWith("/")) {
+          return {
+            path: filePath,
+            content: null,
+            error: "invalid_path" as const,
+          };
+        }
+        try {
+          const result = await session.request<DownloadOk>("readFile", {
+            path: filePath,
+          });
+          const diagnostic = getDiagnosticError(result.events);
+          if (diagnostic) {
+            return {
+              path: filePath,
+              content: null,
+              error: mapDownloadError(diagnostic),
+            };
+          }
+          return {
+            path: filePath,
+            content: fromBase64(result.contentBase64),
+            error: null,
+          };
+        } catch (error: unknown) {
+          return {
+            path: filePath,
+            content: null,
+            error: mapDownloadError(errorMessage(error)),
+          };
+        }
+      }),
+    );
+  }
+
+  async close(): Promise<void> {
+    if (this._session) {
+      try {
+        await this._session.request("close", {});
+      } finally {
+        this._session.terminate();
+        this._session = null;
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    return this.close();
+  }
+}

--- a/libs/providers/wasmsh/e2e/fixture/index.html
+++ b/libs/providers/wasmsh/e2e/fixture/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>wasmsh browser agent test</title>
+  </head>
+  <body>
+    <pre id="result">{"status":"loading"}</pre>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/libs/providers/wasmsh/e2e/fixture/main.ts
+++ b/libs/providers/wasmsh/e2e/fixture/main.ts
@@ -1,0 +1,259 @@
+/**
+ * Browser agent test dispatcher.
+ *
+ * Runs createDeepAgent entirely in the browser with a wasmsh browser Worker
+ * sandbox. No backend service involved. The ?test= query param selects the
+ * scenario; ?key= provides the Anthropic API key.
+ */
+import { ChatAnthropic } from "@langchain/anthropic";
+import { HumanMessage } from "@langchain/core/messages";
+import { createDeepAgent } from "deepagents";
+
+import { BrowserSandbox } from "./browser-sandbox.js";
+
+const enc = new TextEncoder();
+
+function report(data: Record<string, unknown>) {
+  document.getElementById("result")!.textContent = JSON.stringify(data);
+}
+
+function makeModel(apiKey: string) {
+  return new ChatAnthropic({
+    model: "claude-haiku-4-5-20251001",
+    apiKey,
+    clientOptions: { dangerouslyAllowBrowser: true },
+  });
+}
+
+// ── Test: CSV analysis ──────────────────────────────────────
+
+async function testCsvAnalysis(sandbox: BrowserSandbox, apiKey: string) {
+  await sandbox.uploadFiles([
+    [
+      "/workspace/temps.csv",
+      enc.encode(
+        "city,temp_c\nTokyo,22\nBerlin,15\nCairo,35\nSydney,28\nOslo,5\n",
+      ),
+    ],
+  ]);
+
+  const agent = createDeepAgent({ model: makeModel(apiKey), backend: sandbox });
+  await agent.invoke({
+    messages: [
+      new HumanMessage(
+        "Analyze the CSV file at /workspace/temps.csv. Calculate the average temperature " +
+          "and find the hottest city. Write the results as JSON to /workspace/analysis.json " +
+          'with keys "average", "hottest_city", and "hottest_temp".',
+      ),
+    ],
+  });
+
+  const catResult = await sandbox.execute("cat /workspace/analysis.json");
+  return {
+    status: "done",
+    exitCode: catResult.exitCode,
+    analysis: JSON.parse(catResult.output.trim()),
+  };
+}
+
+// ── Test: Skill loading ─────────────────────────────────────
+
+async function testSkillLoading(sandbox: BrowserSandbox, apiKey: string) {
+  const skillMd = [
+    "---",
+    "name: md-table-formatter",
+    "description: Format data as a markdown table and write it to a file",
+    "---",
+    "",
+    "When asked to format data, you MUST:",
+    "1. Create a markdown table with columns: Name, Score, Grade",
+    "2. Assign grades: A for score >= 90, B for score >= 80, C otherwise",
+    "3. Write the table to /workspace/output.md",
+    "4. Write a JSON summary to /workspace/summary.json with keys:",
+    '   - "count" (number of rows)',
+    '   - "top_scorer" (name of the person with highest score)',
+    "",
+  ].join("\n");
+
+  await sandbox.execute("mkdir -p /workspace/skills/md-table-formatter");
+  await sandbox.uploadFiles([
+    ["/workspace/skills/md-table-formatter/SKILL.md", enc.encode(skillMd)],
+  ]);
+
+  const agent = createDeepAgent({
+    model: makeModel(apiKey),
+    backend: sandbox,
+    skills: ["/workspace/skills"],
+  });
+
+  await agent.invoke({
+    messages: [
+      new HumanMessage(
+        "Use the md-table-formatter skill to format this student data: Alice 92, Bob 85, Carol 97",
+      ),
+    ],
+  });
+
+  const tableResult = await sandbox.execute("cat /workspace/output.md");
+  const summaryResult = await sandbox.execute("cat /workspace/summary.json");
+  return {
+    status: "done",
+    table: tableResult.output,
+    summary: JSON.parse(summaryResult.output.trim()),
+  };
+}
+
+// ── Test: Filesystem reliability ────────────────────────────
+
+async function testFilesystem(sandbox: BrowserSandbox, apiKey: string) {
+  await sandbox.execute("mkdir -p /workspace/project/src");
+  await sandbox.uploadFiles([
+    ["/workspace/project/src/main.py", enc.encode('print("hello world")\n')],
+    [
+      "/workspace/project/src/utils.py",
+      enc.encode("def add(a, b):\n    return a + b\n"),
+    ],
+    ["/workspace/project/README.md", enc.encode("# My Project\n")],
+  ]);
+
+  const agent = createDeepAgent({ model: makeModel(apiKey), backend: sandbox });
+  await agent.invoke({
+    messages: [
+      new HumanMessage(
+        'Edit /workspace/project/src/main.py to change "hello" to "goodbye". ' +
+          "Then create a new file /workspace/project/src/config.py with the content: DEBUG = True",
+      ),
+    ],
+  });
+
+  const mainResult = await sandbox.execute(
+    "cat /workspace/project/src/main.py",
+  );
+  const configResult = await sandbox.execute(
+    "cat /workspace/project/src/config.py",
+  );
+
+  return {
+    status: "done",
+    mainContainsGoodbye: mainResult.output.includes("goodbye"),
+    mainNotHello: !mainResult.output.includes("hello"),
+    configExists: configResult.exitCode === 0,
+    configContent: configResult.output,
+  };
+}
+
+// ── Test: Memory usage ──────────────────────────────────────
+
+async function testMemory(sandbox: BrowserSandbox, apiKey: string) {
+  const memoryContent = [
+    "# Agent Memory",
+    "",
+    "## Project Configuration",
+    "- Deployment region: eu-central-1 (Frankfurt)",
+    "- Unit system: metric (Celsius, meters, kilograms)",
+    "- Team lead: Dr. Weber",
+    "- Database: PostgreSQL 16",
+    "- Default language: German",
+    "",
+  ].join("\n");
+
+  await sandbox.execute("mkdir -p /workspace/memory");
+  await sandbox.uploadFiles([
+    ["/workspace/memory/AGENTS.md", enc.encode(memoryContent)],
+  ]);
+
+  const agent = createDeepAgent({
+    model: makeModel(apiKey),
+    backend: sandbox,
+    memory: ["/workspace/memory/AGENTS.md"],
+  });
+
+  await agent.invoke({
+    messages: [
+      new HumanMessage(
+        "Write a deployment config to /workspace/deploy.json with our project's " +
+          '"region", "unit_system", "team_lead", and "database".',
+      ),
+    ],
+  });
+
+  const deployResult = await sandbox.execute("cat /workspace/deploy.json");
+  return { status: "done", deploy: JSON.parse(deployResult.output.trim()) };
+}
+
+// ── Test: Code execution (Python + shell) ───────────────────
+
+async function testCodeExecution(sandbox: BrowserSandbox, apiKey: string) {
+  await sandbox.execute("mkdir -p /workspace/data");
+  await sandbox.uploadFiles([
+    [
+      "/workspace/data/numbers.txt",
+      enc.encode("42\n17\n88\n3\n56\n91\n25\n64\n10\n73\n"),
+    ],
+  ]);
+
+  const agent = createDeepAgent({ model: makeModel(apiKey), backend: sandbox });
+  await agent.invoke({
+    messages: [
+      new HumanMessage(
+        "Read /workspace/data/numbers.txt, sort the numbers, compute the median and " +
+          "population standard deviation. Write the results to /workspace/data/stats.json " +
+          'with keys "sorted" (array), "median" (number), "stddev" (rounded to 1 decimal).',
+      ),
+    ],
+  });
+
+  const statsResult = await sandbox.execute("cat /workspace/data/stats.json");
+  return { status: "done", stats: JSON.parse(statsResult.output.trim()) };
+}
+
+// ── Dispatcher ──────────────────────────────────────────────
+
+const TESTS: Record<
+  string,
+  (s: BrowserSandbox, k: string) => Promise<Record<string, unknown>>
+> = {
+  csv: testCsvAnalysis,
+  skills: testSkillLoading,
+  filesystem: testFilesystem,
+  memory: testMemory,
+  code: testCodeExecution,
+};
+
+async function run() {
+  const params = new URLSearchParams(location.search);
+  const apiKey = params.get("key");
+  const testName = params.get("test") ?? "csv";
+
+  if (!apiKey) {
+    report({ status: "error", message: "Missing ?key= query parameter" });
+    return;
+  }
+
+  const testFn = TESTS[testName];
+  if (!testFn) {
+    report({ status: "error", message: `Unknown test: ${testName}` });
+    return;
+  }
+
+  report({ status: "booting" });
+
+  const sandbox = new BrowserSandbox({
+    workerUrl: "/worker/browser-worker.js",
+    assetBaseUrl: "/assets",
+  });
+  await sandbox.initialize();
+
+  report({ status: "agent_running" });
+
+  try {
+    const result = await testFn(sandbox, apiKey);
+    report(result);
+  } finally {
+    await sandbox.stop();
+  }
+}
+
+run().catch((err) => {
+  report({ status: "error", message: err.message, stack: err.stack });
+});

--- a/libs/providers/wasmsh/e2e/fixture/shims/async-hooks.ts
+++ b/libs/providers/wasmsh/e2e/fixture/shims/async-hooks.ts
@@ -1,0 +1,30 @@
+/**
+ * Minimal AsyncLocalStorage shim for browsers.
+ * LangGraph uses AsyncLocalStorage for context propagation.
+ * In a single-threaded browser tab, a simple stack-based implementation works.
+ */
+export class AsyncLocalStorage<T> {
+  private _store: T | undefined;
+
+  getStore(): T | undefined {
+    return this._store;
+  }
+
+  run<R>(store: T, callback: () => R): R {
+    const prev = this._store;
+    this._store = store;
+    try {
+      return callback();
+    } finally {
+      this._store = prev;
+    }
+  }
+
+  enterWith(store: T): void {
+    this._store = store;
+  }
+
+  disable(): void {
+    this._store = undefined;
+  }
+}

--- a/libs/providers/wasmsh/e2e/fixture/vite.config.ts
+++ b/libs/providers/wasmsh/e2e/fixture/vite.config.ts
@@ -1,0 +1,69 @@
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, type Plugin } from "vite";
+import sirv from "sirv";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// wasmsh-pyodide npm package (resolved from node_modules)
+const wasmshPkgDir = dirname(
+  require.resolve("@mayflowergmbh/wasmsh-pyodide/package.json"),
+);
+const assetsDir = resolve(wasmshPkgDir, "assets");
+
+// langchain full entry (browser entry omits agent middleware)
+const langchainDir = dirname(require.resolve("langchain/package.json"));
+
+/**
+ * Serve wasmsh Pyodide assets and browser-worker.js as static files.
+ */
+function wasmshAssetsPlugin(): Plugin {
+  return {
+    name: "wasmsh-assets",
+    configureServer(server) {
+      // Pyodide dist assets at /assets/
+      server.middlewares.use("/assets", sirv(assetsDir, { dev: true }));
+      // browser-worker.js at /worker/
+      server.middlewares.use("/worker", sirv(wasmshPkgDir, { dev: true }));
+    },
+  };
+}
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [wasmshAssetsPlugin()],
+  resolve: {
+    alias: [
+      // langchain's "browser" export omits agent middleware (createAgent, etc.).
+      // Force the full entry so deepagents' imports resolve correctly.
+      {
+        find: /^langchain$/,
+        replacement: resolve(langchainDir, "dist/index.js"),
+      },
+      {
+        find: /^langchain\/(.+)/,
+        replacement: resolve(langchainDir, "dist/$1"),
+      },
+      // node:async_hooks polyfill for LangGraph (uses AsyncLocalStorage)
+      {
+        find: /^node:async_hooks$/,
+        replacement: resolve(__dirname, "shims/async-hooks.ts"),
+      },
+      // path polyfill for micromatch (used by backend utils)
+      {
+        find: /^(node:)?path$/,
+        replacement: "path-browserify",
+      },
+    ],
+  },
+  define: {
+    "process.platform": JSON.stringify("browser"),
+    "process.env": JSON.stringify({}),
+  },
+  server: {
+    port: 4173,
+    strictPort: true,
+  },
+});

--- a/libs/providers/wasmsh/package.json
+++ b/libs/providers/wasmsh/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@langchain/wasmsh",
+  "version": "0.0.1",
+  "description": "Wasmsh sandbox backend for deepagents",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rm -rf dist/ .tsdown/",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "pnpm build",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:int": "vitest run --mode int"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/langchain-ai/deepagentsjs.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "langgraph",
+    "langchain",
+    "typescript",
+    "llm",
+    "sandbox",
+    "wasmsh",
+    "pyodide"
+  ],
+  "author": "LangChain",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/langchain-ai/deepagentsjs/issues"
+  },
+  "homepage": "https://github.com/langchain-ai/deepagentsjs#readme",
+  "dependencies": {
+    "@mayflowergmbh/wasmsh-pyodide": "^0.5.0"
+  },
+  "peerDependencies": {
+    "deepagents": ">=1.9.0-alpha.0"
+  },
+  "devDependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
+    "@langchain/anthropic": "^1.3.25",
+    "@langchain/core": "^1.1.33",
+    "@langchain/sandbox-standard-tests": "workspace:*",
+    "@playwright/test": "^1.58.2",
+    "@tsconfig/recommended": "^1.0.13",
+    "@types/node": "^25.1.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "deepagents": "workspace:*",
+    "path-browserify": "^1.0.1",
+    "sirv": "^3.0.2",
+    "tsdown": "^0.21.4",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.3",
+    "vitest": "^4.0.18"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/**/*"
+  ]
+}

--- a/libs/providers/wasmsh/package.json
+++ b/libs/providers/wasmsh/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/langchain-ai/deepagentsjs#readme",
   "dependencies": {
-    "@mayflowergmbh/wasmsh-pyodide": "^0.5.0"
+    "@mayflowergmbh/wasmsh-pyodide": "^0.5.1"
   },
   "peerDependencies": {
     "deepagents": ">=1.9.0-alpha.0"

--- a/libs/providers/wasmsh/package.json
+++ b/libs/providers/wasmsh/package.json
@@ -38,28 +38,34 @@
   },
   "homepage": "https://github.com/langchain-ai/deepagentsjs#readme",
   "dependencies": {
-    "@mayflowergmbh/wasmsh-pyodide": "^0.5.1"
+    "@mayflowergmbh/wasmsh-pyodide": "^0.6.4",
+    "dedent": "^1.7.1"
   },
+  "//runtime-note": "PTC (runPtc + host_call protocol) requires @mayflowergmbh/wasmsh-pyodide >= 0.6.4. WasmshSandbox.runPtc duck-checks the underlying session and throws a clear error against older builds.",
   "peerDependencies": {
     "deepagents": ">=1.9.0-alpha.0"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
     "@langchain/anthropic": "^1.3.25",
-    "@langchain/core": "^1.1.33",
+    "@langchain/core": "^1.1.38",
+    "@langchain/langgraph": "^1.2.8",
     "@langchain/sandbox-standard-tests": "workspace:*",
     "@playwright/test": "^1.58.2",
     "@tsconfig/recommended": "^1.0.13",
+    "@types/dedent": "^0.7.2",
     "@types/node": "^25.1.0",
     "@vitest/coverage-v8": "^4.0.18",
     "deepagents": "workspace:*",
+    "langchain": "^1.3.1",
     "path-browserify": "^1.0.1",
     "sirv": "^3.0.2",
     "tsdown": "^0.21.4",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "zod": "^4.3.6"
   },
   "exports": {
     ".": {

--- a/libs/providers/wasmsh/playwright.config.ts
+++ b/libs/providers/wasmsh/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 120_000,
+  retries: 2,
+  use: {
+    baseURL: "http://localhost:4173",
+  },
+  webServer: {
+    command: "npx vite --config e2e/fixture/vite.config.ts",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/libs/providers/wasmsh/src/agent.test.ts
+++ b/libs/providers/wasmsh/src/agent.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Deterministic agent integration test.
+ *
+ * The other agent tests (`sandbox-agent.int.test.ts`) drive a real LLM via
+ * Anthropic and a real Pyodide sandbox; they're slow, gated on assets +
+ * `ANTHROPIC_API_KEY`, and not reproducible bit-for-bit.
+ *
+ * This file does the opposite: it wires `createDeepAgent` to a scripted
+ * chat model that emits a pre-decided sequence of `AIMessage`s (one with a
+ * `py_eval` tool call, one with the final text), and stubs the sandbox so
+ * the test runs offline and finishes in milliseconds. It pins the
+ * end-to-end shape of `LLM → middleware → sandbox.runPtc → envelope →
+ * model` so a regression in any wire-up step gets caught here without
+ * needing the LLM round-trip.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
+import type { BaseMessage } from "@langchain/core/messages";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type {
+  BaseChatModelCallOptions,
+  BaseChatModelParams,
+} from "@langchain/core/language_models/chat_models";
+import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import type { ChatResult } from "@langchain/core/outputs";
+import { createDeepAgent } from "deepagents";
+import { createWasmshInterpreterMiddleware } from "./middleware.js";
+import type { WasmshSandbox } from "./sandbox.js";
+
+/**
+ * A chat model that hands back one prebuilt `AIMessage` per call,
+ * advancing through the scripted list in order. Unlike
+ * `FakeStreamingChatModel.responses` (which returns the same head element
+ * every time), this lets us script a tool-call → final-answer sequence
+ * deterministically.
+ */
+class ScriptedChatModel extends BaseChatModel<BaseChatModelCallOptions> {
+  #script: AIMessage[];
+  #cursor = 0;
+  capturedMessages: BaseMessage[][] = [];
+
+  constructor(script: AIMessage[], rest: BaseChatModelParams = {}) {
+    super(rest);
+    this.#script = script;
+  }
+
+  _llmType(): string {
+    return "scripted-fake";
+  }
+
+  bindTools(_tools: unknown): typeof this {
+    // The scripted responses are fully prebuilt, so we don't actually use
+    // the tool schemas — but createAgent will call `bindTools` regardless
+    // and expect a chat model back.
+    return this;
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun,
+  ): Promise<ChatResult> {
+    this.capturedMessages.push([...messages]);
+    if (this.#cursor >= this.#script.length) {
+      throw new Error(
+        `ScriptedChatModel exhausted after ${this.#cursor} call(s)`,
+      );
+    }
+    const message = this.#script[this.#cursor++];
+    return {
+      generations: [{ text: String(message.content ?? ""), message }],
+    };
+  }
+}
+
+class RecordingSandbox {
+  runPtcCalls: Array<{ code: string; tools: string[] }> = [];
+
+  async runPtc(params: {
+    code: string;
+    tools?: string[];
+    onHostCall?: unknown;
+  }) {
+    this.runPtcCalls.push({ code: params.code, tools: params.tools ?? [] });
+    return { ok: true as const, stdout: "42\n", stderr: "", value: 42 };
+  }
+}
+
+describe("createDeepAgent + WasmshInterpreterMiddleware (scripted LLM)", () => {
+  it("routes a py_eval tool call to sandbox.runPtc and threads the envelope back to the model", async () => {
+    const sandbox = new RecordingSandbox();
+    const middleware = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+    });
+
+    // First turn: model asks for `py_eval(code="2 * 21")`.
+    // Second turn: model emits the final answer (no tool calls), ending the loop.
+    const toolCallId = "call_42";
+    const turn1 = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          id: toolCallId,
+          name: "py_eval",
+          args: { code: "2 * 21" },
+        },
+      ],
+    });
+    const turn2 = new AIMessage({ content: "The answer is 42." });
+    const model = new ScriptedChatModel([turn1, turn2]);
+
+    const agent = createDeepAgent({
+      model,
+      middleware: [middleware],
+    });
+
+    const result = await agent.invoke({
+      messages: [new HumanMessage("compute 2 * 21")],
+    });
+
+    // The sandbox was invoked with the code the model emitted.
+    expect(sandbox.runPtcCalls).toHaveLength(1);
+    expect(sandbox.runPtcCalls[0].code).toBe("2 * 21");
+
+    // The middleware fed the eval envelope back to the model as a
+    // ToolMessage; the second model call saw it in its message history.
+    expect(model.capturedMessages).toHaveLength(2);
+    const secondCallMessages = model.capturedMessages[1];
+    const toolMessage = secondCallMessages.find(
+      (m): m is ToolMessage =>
+        typeof (m as { _getType?: () => string })._getType === "function" &&
+        (m as { _getType: () => string })._getType() === "tool",
+    );
+    expect(toolMessage).toBeDefined();
+    expect(toolMessage!.tool_call_id).toBe(toolCallId);
+    // The eval result (`value: 42`, `stdout: "42\n"`) round-trips through
+    // the middleware's formatter into the ToolMessage content.
+    const toolContent =
+      typeof toolMessage!.content === "string"
+        ? toolMessage!.content
+        : JSON.stringify(toolMessage!.content);
+    expect(toolContent).toContain("42");
+
+    // The final state's last message is the model's text answer.
+    const last = result.messages.at(-1) as BaseMessage;
+    expect(typeof last.content === "string" ? last.content : "").toContain(
+      "42",
+    );
+  });
+
+  it("propagates a sandbox runtime error through the middleware as a ToolMessage", async () => {
+    // Sandbox returns an error envelope (e.g. Python raised NameError). The
+    // middleware must format it as a tool message the next turn can see.
+    const sandbox = {
+      async runPtc() {
+        return {
+          ok: false as const,
+          stdout: "",
+          stderr: "",
+          error: "NameError",
+          message: "name 'undef' is not defined",
+        };
+      },
+    };
+    const middleware = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+    });
+
+    const toolCallId = "call_err";
+    const turn1 = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          id: toolCallId,
+          name: "py_eval",
+          args: { code: "undef" },
+        },
+      ],
+    });
+    const turn2 = new AIMessage({ content: "Saw the error." });
+    const model = new ScriptedChatModel([turn1, turn2]);
+
+    const agent = createDeepAgent({
+      model,
+      middleware: [middleware],
+    });
+
+    await agent.invoke({
+      messages: [new HumanMessage("trigger an error")],
+    });
+
+    expect(model.capturedMessages).toHaveLength(2);
+    const second = model.capturedMessages[1];
+    const toolMsg = second.find(
+      (m): m is ToolMessage =>
+        typeof (m as { _getType?: () => string })._getType === "function" &&
+        (m as { _getType: () => string })._getType() === "tool",
+    );
+    expect(toolMsg).toBeDefined();
+    const content =
+      typeof toolMsg!.content === "string"
+        ? toolMsg!.content
+        : JSON.stringify(toolMsg!.content);
+    expect(content).toContain("NameError");
+    expect(content).toContain("name 'undef' is not defined");
+  });
+
+  it("does not call sandbox.runPtc when the model produces no tool calls", async () => {
+    // Smoke check: confirms the middleware doesn't trigger an eval on its
+    // own — the model has to actually request `py_eval`.
+    const sandbox = new RecordingSandbox();
+    const runPtcSpy = vi.spyOn(sandbox, "runPtc");
+    const middleware = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+    });
+
+    const model = new ScriptedChatModel([
+      new AIMessage({ content: "Nothing to compute." }),
+    ]);
+    const agent = createDeepAgent({
+      model,
+      middleware: [middleware],
+    });
+
+    await agent.invoke({ messages: [new HumanMessage("hi")] });
+    expect(runPtcSpy).not.toHaveBeenCalled();
+  });
+});

--- a/libs/providers/wasmsh/src/filesystem-backend.test.ts
+++ b/libs/providers/wasmsh/src/filesystem-backend.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for WasmshFilesystemBackend.
+ *
+ * Uses a recording sandbox stub to verify namespace prefix/unscope semantics
+ * on every protocol method without booting Pyodide.
+ */
+import { describe, it, expect } from "vitest";
+import { WasmshFilesystemBackend } from "./filesystem-backend.js";
+import type { WasmshSandbox } from "./sandbox.js";
+
+interface Call {
+  method: string;
+  args: unknown[];
+}
+
+class RecordingSandbox {
+  id = "wasmsh-fs-test";
+  calls: Call[] = [];
+
+  // Result shapes are constructed per-test to make assertions explicit.
+  nextLs: { files?: Array<{ path: string }>; error?: string } = { files: [] };
+  nextGlob: { files?: Array<{ path: string }>; error?: string } = { files: [] };
+  nextGrep: {
+    matches?: Array<{ path: string; line: number; text: string }>;
+    error?: string;
+  } = { matches: [] };
+  nextRead: unknown = { content: "", encoding: "utf-8" };
+  nextReadRaw: unknown = { content: new Uint8Array(0) };
+  nextWrite: unknown = { path: "" };
+  nextEdit: unknown = { path: "" };
+  nextUpload: Array<{ path: string; error: null | string }> = [];
+  nextDownload: Array<{
+    path: string;
+    content: Uint8Array | null;
+    error: null | string;
+  }> = [];
+
+  async ls(path: string) {
+    this.calls.push({ method: "ls", args: [path] });
+    return this.nextLs;
+  }
+  async read(filePath: string, offset?: number, limit?: number) {
+    this.calls.push({ method: "read", args: [filePath, offset, limit] });
+    return this.nextRead;
+  }
+  async readRaw(filePath: string) {
+    this.calls.push({ method: "readRaw", args: [filePath] });
+    return this.nextReadRaw;
+  }
+  async grep(pattern: string, path?: string | null, glob?: string | null) {
+    this.calls.push({ method: "grep", args: [pattern, path, glob] });
+    return this.nextGrep;
+  }
+  async glob(pattern: string, path?: string) {
+    this.calls.push({ method: "glob", args: [pattern, path] });
+    return this.nextGlob;
+  }
+  async write(filePath: string, content: string) {
+    this.calls.push({ method: "write", args: [filePath, content] });
+    return this.nextWrite;
+  }
+  async edit(
+    filePath: string,
+    oldStr: string,
+    newStr: string,
+    replaceAll?: boolean,
+  ) {
+    this.calls.push({
+      method: "edit",
+      args: [filePath, oldStr, newStr, replaceAll],
+    });
+    return this.nextEdit;
+  }
+  async uploadFiles(files: Array<[string, Uint8Array]>) {
+    this.calls.push({ method: "uploadFiles", args: [files.map(([p]) => p)] });
+    return this.nextUpload.length
+      ? this.nextUpload
+      : files.map(([p]) => ({ path: p, error: null }));
+  }
+  async downloadFiles(paths: string[]) {
+    this.calls.push({ method: "downloadFiles", args: [paths] });
+    return this.nextDownload.length
+      ? this.nextDownload
+      : paths.map((p) => ({
+          path: p,
+          content: new Uint8Array(0),
+          error: null,
+        }));
+  }
+}
+
+function makeBackend(namespace?: string) {
+  const sandbox = new RecordingSandbox();
+  const backend = new WasmshFilesystemBackend(
+    sandbox as unknown as WasmshSandbox,
+    namespace ? { namespace } : {},
+  );
+  return { sandbox, backend };
+}
+
+describe("WasmshFilesystemBackend with no namespace", () => {
+  it("passes paths through unchanged", async () => {
+    const { sandbox, backend } = makeBackend();
+    await backend.ls("/notes");
+    expect(sandbox.calls[0]).toEqual({ method: "ls", args: ["/notes"] });
+  });
+
+  it("does not rewrite ls result paths", async () => {
+    const { sandbox, backend } = makeBackend();
+    sandbox.nextLs = { files: [{ path: "/a.txt" }, { path: "/b.txt" }] };
+    const r = await backend.ls("/");
+    expect(r.files?.map((f) => f.path)).toEqual(["/a.txt", "/b.txt"]);
+  });
+});
+
+describe("WasmshFilesystemBackend with namespace prefix", () => {
+  it("rewrites every method's input path", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    await backend.ls("/notes");
+    await backend.read("/x.txt", 0, 100);
+    await backend.readRaw("/x.txt");
+    await backend.glob("*.md", "/");
+    await backend.write("/draft.md", "hi");
+    await backend.edit("/draft.md", "a", "b", true);
+    await backend.grep("TODO", "/work", "*.md");
+    await backend.uploadFiles([["/upload.bin", new Uint8Array([1])]]);
+    await backend.downloadFiles(["/dl.bin"]);
+
+    const paths = sandbox.calls.map(
+      (c) => `${c.method}:${JSON.stringify(c.args[0])}`,
+    );
+    expect(paths).toEqual([
+      'ls:"/mem/notes"',
+      'read:"/mem/x.txt"',
+      'readRaw:"/mem/x.txt"',
+      'glob:"*.md"',
+      'write:"/mem/draft.md"',
+      'edit:"/mem/draft.md"',
+      'grep:"TODO"',
+      'uploadFiles:["/mem/upload.bin"]',
+      'downloadFiles:["/mem/dl.bin"]',
+    ]);
+
+    // For glob, the namespace shows up in arg[1] (path), not arg[0] (pattern).
+    // `/` scopes to the bare namespace root (no trailing slash).
+    const globCall = sandbox.calls.find((c) => c.method === "glob");
+    expect(globCall?.args[1]).toBe("/mem");
+    // Same shape for grep: pattern then path.
+    const grepCall = sandbox.calls.find((c) => c.method === "grep");
+    expect(grepCall?.args[1]).toBe("/mem/work");
+  });
+
+  it("normalises trailing slashes in the namespace", () => {
+    const { sandbox, backend } = makeBackend("/mem///");
+    return backend.ls("/notes").then(() => {
+      expect(sandbox.calls[0].args[0]).toBe("/mem/notes");
+    });
+  });
+
+  it("normalises a namespace without a leading slash", () => {
+    const { sandbox, backend } = makeBackend("mem");
+    return backend.ls("/notes").then(() => {
+      expect(sandbox.calls[0].args[0]).toBe("/mem/notes");
+    });
+  });
+
+  it("scopes / to the namespace root", () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    return backend.ls("/").then(() => {
+      expect(sandbox.calls[0].args[0]).toBe("/mem");
+    });
+  });
+
+  it("unscopes ls result paths back to the caller's namespace", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    sandbox.nextLs = {
+      files: [{ path: "/mem/a.txt" }, { path: "/mem/sub/b.txt" }],
+    };
+    const r = await backend.ls("/");
+    expect(r.files?.map((f) => f.path)).toEqual(["/a.txt", "/sub/b.txt"]);
+  });
+
+  it("unscopes glob result paths", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    sandbox.nextGlob = { files: [{ path: "/mem/x.py" }] };
+    const r = await backend.glob("*.py");
+    expect(r.files?.map((f) => f.path)).toEqual(["/x.py"]);
+  });
+
+  it("unscopes grep match paths", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    sandbox.nextGrep = {
+      matches: [{ path: "/mem/work/a.md", line: 1, text: "TODO: x" }],
+    };
+    const r = await backend.grep("TODO", "/work");
+    expect(r.matches?.[0].path).toBe("/work/a.md");
+  });
+
+  it("unscopes upload + download response paths", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    sandbox.nextUpload = [{ path: "/mem/x.bin", error: null }];
+    sandbox.nextDownload = [
+      { path: "/mem/y.bin", content: new Uint8Array([1, 2, 3]), error: null },
+    ];
+    const ur = await backend.uploadFiles([["/x.bin", new Uint8Array([1])]]);
+    const dr = await backend.downloadFiles(["/y.bin"]);
+    expect(ur[0].path).toBe("/x.bin");
+    expect(dr[0].path).toBe("/y.bin");
+    expect(dr[0].content).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("passes through results carrying errors without rewriting paths", async () => {
+    const { backend, sandbox } = makeBackend("/mem");
+    sandbox.nextLs = { error: "permission_denied" };
+    const r = await backend.ls("/notes");
+    expect(r.error).toBe("permission_denied");
+    expect(r.files).toBeUndefined();
+  });
+
+  it("includes the namespace in id", () => {
+    const { backend } = makeBackend("/mem");
+    expect(backend.id).toBe("wasmsh-fs:wasmsh-fs-test/mem");
+  });
+});

--- a/libs/providers/wasmsh/src/filesystem-backend.test.ts
+++ b/libs/providers/wasmsh/src/filesystem-backend.test.ts
@@ -330,4 +330,14 @@ describe("WasmshFilesystemBackend path traversal containment", () => {
     await backend.ls("/etc/passwd");
     expect(sandbox.calls[0].args[0]).toBe("/etc/passwd");
   });
+
+  it("rejects an unscope leak of a sibling-prefix path without `..` segments", async () => {
+    // Targets the `#isContained` trailing-`/` anchor directly: a sandbox
+    // result whose path is `/memstoreX/x` shares the literal prefix
+    // `/mem` with the namespace `/mem`, but a bare `startsWith` would
+    // wrongly accept it. The trailing-separator anchor must reject.
+    const { sandbox, backend } = makeBackend("/mem");
+    sandbox.nextLs = { files: [{ path: "/memstoreX/x.txt" }] };
+    await expect(backend.ls("/")).rejects.toThrow(WasmshNamespaceEscapeError);
+  });
 });

--- a/libs/providers/wasmsh/src/filesystem-backend.test.ts
+++ b/libs/providers/wasmsh/src/filesystem-backend.test.ts
@@ -5,7 +5,10 @@
  * on every protocol method without booting Pyodide.
  */
 import { describe, it, expect } from "vitest";
-import { WasmshFilesystemBackend } from "./filesystem-backend.js";
+import {
+  WasmshFilesystemBackend,
+  WasmshNamespaceEscapeError,
+} from "./filesystem-backend.js";
 import type { WasmshSandbox } from "./sandbox.js";
 
 interface Call {
@@ -220,5 +223,111 @@ describe("WasmshFilesystemBackend with namespace prefix", () => {
   it("includes the namespace in id", () => {
     const { backend } = makeBackend("/mem");
     expect(backend.id).toBe("wasmsh-fs:wasmsh-fs-test/mem");
+  });
+});
+
+describe("WasmshFilesystemBackend path traversal containment", () => {
+  // Pyodide's POSIX VFS resolves `..` segments at the filesystem layer, so a
+  // namespaced backend must reject any input that, after canonicalisation,
+  // would leave its namespace root. The standard read_file/write_file/
+  // edit_file tools forward `file_path` verbatim, so the LLM controls this.
+  it("rejects a direct `..` escape on every protocol method", async () => {
+    const { backend } = makeBackend("/mem");
+    const escape = "/../skills/secret.py";
+    await expect(backend.ls(escape)).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+    await expect(backend.read(escape)).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+    await expect(backend.readRaw(escape)).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+    await expect(backend.glob("*.py", escape)).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+    await expect(backend.grep("TODO", escape)).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+    await expect(backend.write(escape, "x")).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+    await expect(backend.edit(escape, "a", "b")).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+    await expect(
+      backend.uploadFiles([[escape, new Uint8Array([1])]]),
+    ).rejects.toThrow(WasmshNamespaceEscapeError);
+    await expect(backend.downloadFiles([escape])).rejects.toThrow(
+      WasmshNamespaceEscapeError,
+    );
+  });
+
+  it("rejects multi-segment `..` payloads (`../../skills/x`)", async () => {
+    const { backend } = makeBackend("/mem");
+    await expect(backend.read("../../skills/secret.py")).rejects.toThrow(
+      /escapes namespace/,
+    );
+  });
+
+  it("rejects payloads that traverse out via the namespace root", async () => {
+    // `/x/../../etc/passwd` resolves to `/etc/passwd` once the namespace
+    // prefix is prepended → outside the namespace.
+    const { backend } = makeBackend("/mem");
+    await expect(backend.read("/x/../../etc/passwd")).rejects.toThrow(
+      /escapes namespace/,
+    );
+  });
+
+  it("rejects an attempt to reach a sibling directory whose name shares the prefix", async () => {
+    // `/memstore/...` looks contained by a startsWith on `/mem` but is a
+    // different sibling directory. The trailing-separator anchor in
+    // `#isContained` catches this.
+    const { backend } = makeBackend("/mem");
+    // Spell it without `..` so we hit the prefix-anchor check, not the
+    // resolve-time guard.
+    await expect(
+      backend.write("/foo", "x").then(
+        () => {
+          // Should succeed (in-namespace), used only as a control.
+        },
+        () => {
+          // ignore
+        },
+      ),
+    ).resolves.toBeUndefined();
+    // Now an actual traversal landing on `/memstore`.
+    await expect(backend.read("/../memstore/x")).rejects.toThrow(
+      /escapes namespace/,
+    );
+  });
+
+  it("allows benign `.` and `./sub` paths inside the namespace", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    await backend.ls("/./sub");
+    expect(sandbox.calls[0].args[0]).toBe("/mem/sub");
+  });
+
+  it("collapses interior `..` that stays inside the namespace", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    // `/a/../b` resolves to `/mem/b` — still inside `/mem`, so allowed.
+    await backend.ls("/a/../b");
+    expect(sandbox.calls[0].args[0]).toBe("/mem/b");
+  });
+
+  it("throws when an upstream result tries to leak a non-namespaced path", async () => {
+    const { sandbox, backend } = makeBackend("/mem");
+    // Simulate a misbehaving sandbox returning a result from outside the
+    // namespace. The unscope guard must refuse to expose it to the caller.
+    sandbox.nextLs = { files: [{ path: "/etc/passwd" }] };
+    await expect(backend.ls("/")).rejects.toThrow(WasmshNamespaceEscapeError);
+  });
+
+  it("does not apply containment when no namespace is set", async () => {
+    const { sandbox, backend } = makeBackend();
+    // No namespace → no containment to enforce; absolute paths pass
+    // through unchanged.
+    await backend.ls("/etc/passwd");
+    expect(sandbox.calls[0].args[0]).toBe("/etc/passwd");
   });
 });

--- a/libs/providers/wasmsh/src/filesystem-backend.ts
+++ b/libs/providers/wasmsh/src/filesystem-backend.ts
@@ -10,7 +10,21 @@
  *   - is composable as a sub-backend in `CompositeBackend`.
  *
  * Mirrors `langchain_wasmsh.WasmshFilesystemBackend` from the Python adapter.
+ *
+ * ## Path traversal containment
+ *
+ * The namespace is a security boundary. A caller (including an LLM-driven
+ * agent that controls `file_path` arguments on the standard `read_file` /
+ * `write_file` / `edit_file` tools) must not be able to escape the
+ * namespace via `..` segments. The Pyodide VFS does resolve `..`, so a
+ * naive `${namespace}${userPath}` join is unsafe.
+ *
+ * `#scope` resolves the joined path with `posix.resolve` and rejects any
+ * input that, after normalisation, leaves the namespace root.
+ * `#unscope` applies the matching containment check on inbound result
+ * paths so an upstream bug elsewhere can't leak non-namespaced paths.
  */
+import { posix } from "node:path";
 import type {
   EditResult,
   FileDownloadResponse,
@@ -39,6 +53,20 @@ function normaliseNamespace(namespace: string | undefined): string {
   return prefixed.replace(/\/+$/, "");
 }
 
+/**
+ * Raised when a caller-supplied path would escape the configured namespace
+ * after `..` resolution. Surfaced as a `FileOperationError`-flavoured error
+ * by every protocol method that constructs scoped paths.
+ */
+export class WasmshNamespaceEscapeError extends Error {
+  override readonly name = "WasmshNamespaceEscapeError";
+  constructor(attemptedPath: string, namespace: string) {
+    super(
+      `path ${JSON.stringify(attemptedPath)} escapes namespace ${JSON.stringify(namespace)}`,
+    );
+  }
+}
+
 export class WasmshFilesystemBackend {
   readonly #sandbox: WasmshSandbox;
 
@@ -64,16 +92,39 @@ export class WasmshFilesystemBackend {
     if (!this.#namespace) return path;
     const abs = path.startsWith("/") ? path : `/${path}`;
     if (abs === "/") return this.#namespace || "/";
-    return `${this.#namespace}${abs}`;
+    // Defence in depth: cheap pre-check before the canonical resolve.
+    // `posix.resolve` collapses `..` segments; we then re-check that the
+    // result is still contained in the namespace prefix. This rejects
+    // `..` payloads regardless of how they are spelled (mixed slashes,
+    // leading/trailing dots, intermediate `./`).
+    const joined = `${this.#namespace}${abs}`;
+    const resolved = posix.resolve(joined);
+    if (!this.#isContained(resolved)) {
+      throw new WasmshNamespaceEscapeError(path, this.#namespace);
+    }
+    return resolved;
   }
 
   #unscope(path: string): string {
     if (!this.#namespace) return path;
-    if (path.startsWith(this.#namespace)) {
-      const stripped = path.slice(this.#namespace.length);
-      return stripped || "/";
+    // Containment check on the way back: an upstream bug (or a
+    // misbehaving sandbox) should never leak paths from outside the
+    // namespace into the caller's view.
+    if (!this.#isContained(path)) {
+      throw new WasmshNamespaceEscapeError(path, this.#namespace);
     }
-    return path;
+    const stripped = path.slice(this.#namespace.length);
+    return stripped || "/";
+  }
+
+  #isContained(resolved: string): boolean {
+    // A resolved path is contained iff it equals the namespace root
+    // exactly or sits at `<namespace>/...`. Plain string startsWith on
+    // the namespace would accept `<namespace>extra/...` (a different
+    // sibling directory whose name shares the prefix), so we anchor
+    // with the trailing separator explicitly.
+    if (resolved === this.#namespace) return true;
+    return resolved.startsWith(`${this.#namespace}/`);
   }
 
   // ── BackendProtocolV2 surface ──────────────────────────────────────

--- a/libs/providers/wasmsh/src/filesystem-backend.ts
+++ b/libs/providers/wasmsh/src/filesystem-backend.ts
@@ -1,0 +1,147 @@
+/**
+ * `WasmshFilesystemBackend` — DeepAgents memory backend over a wasmsh VFS.
+ *
+ * A thin shim that adapts a `WasmshSandbox` to the DeepAgents
+ * `BackendProtocolV2`. Unlike using the sandbox directly, this backend:
+ *
+ *   - never exposes `execute()` — it is a memory store, not a code-runner;
+ *   - supports a `namespace` prefix so several memory routes can share one
+ *     sandbox without colliding (e.g. `/memories`, `/skills`, …);
+ *   - is composable as a sub-backend in `CompositeBackend`.
+ *
+ * Mirrors `langchain_wasmsh.WasmshFilesystemBackend` from the Python adapter.
+ */
+import type {
+  EditResult,
+  FileDownloadResponse,
+  FileUploadResponse,
+  GlobResult,
+  GrepResult,
+  LsResult,
+  ReadResult,
+  ReadRawResult,
+  WriteResult,
+} from "deepagents";
+import type { WasmshSandbox } from "./sandbox.js";
+
+export interface WasmshFilesystemBackendOptions {
+  /**
+   * Absolute-path prefix silently prepended to every path the agent uses
+   * (e.g. `"/memories"`). Lets one sandbox host multiple memory routes
+   * without collisions.
+   */
+  namespace?: string;
+}
+
+function normaliseNamespace(namespace: string | undefined): string {
+  if (!namespace) return "";
+  const prefixed = namespace.startsWith("/") ? namespace : `/${namespace}`;
+  return prefixed.replace(/\/+$/, "");
+}
+
+export class WasmshFilesystemBackend {
+  readonly #sandbox: WasmshSandbox;
+
+  readonly #namespace: string;
+
+  constructor(sandbox: WasmshSandbox, options: WasmshFilesystemBackendOptions = {}) {
+    this.#sandbox = sandbox;
+    this.#namespace = normaliseNamespace(options.namespace);
+  }
+
+  get id(): string {
+    const sandboxId = (this.#sandbox as unknown as { id?: string }).id;
+    return `wasmsh-fs:${sandboxId ?? "anon"}${this.#namespace || "/"}`;
+  }
+
+  // ── namespace mapping ──────────────────────────────────────────────
+
+  #scope(path: string | null | undefined): string {
+    if (path == null) return this.#namespace || "/";
+    if (!this.#namespace) return path;
+    const abs = path.startsWith("/") ? path : `/${path}`;
+    if (abs === "/") return this.#namespace || "/";
+    return `${this.#namespace}${abs}`;
+  }
+
+  #unscope(path: string): string {
+    if (!this.#namespace) return path;
+    if (path.startsWith(this.#namespace)) {
+      const stripped = path.slice(this.#namespace.length);
+      return stripped || "/";
+    }
+    return path;
+  }
+
+  // ── BackendProtocolV2 surface ──────────────────────────────────────
+
+  async ls(path: string): Promise<LsResult> {
+    const result = await this.#sandbox.ls(this.#scope(path));
+    if (result.error || !result.files) return result;
+    return {
+      files: result.files.map((f) => ({ ...f, path: this.#unscope(f.path) })),
+    };
+  }
+
+  async read(
+    filePath: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<ReadResult> {
+    return this.#sandbox.read(this.#scope(filePath), offset, limit);
+  }
+
+  async readRaw(filePath: string): Promise<ReadRawResult> {
+    return this.#sandbox.readRaw(this.#scope(filePath));
+  }
+
+  async grep(
+    pattern: string,
+    path?: string | null,
+    glob?: string | null,
+  ): Promise<GrepResult> {
+    const scoped = path ? this.#scope(path) : null;
+    const result = await this.#sandbox.grep(pattern, scoped ?? "/", glob ?? null);
+    if (result.error || !result.matches) return result;
+    return {
+      matches: result.matches.map((m) => ({ ...m, path: this.#unscope(m.path) })),
+    };
+  }
+
+  async glob(pattern: string, path?: string): Promise<GlobResult> {
+    const result = await this.#sandbox.glob(pattern, this.#scope(path ?? "/"));
+    if (result.error || !result.files) return result;
+    return {
+      files: result.files.map((f) => ({ ...f, path: this.#unscope(f.path) })),
+    };
+  }
+
+  async write(filePath: string, content: string): Promise<WriteResult> {
+    return this.#sandbox.write(this.#scope(filePath), content);
+  }
+
+  async edit(
+    filePath: string,
+    oldString: string,
+    newString: string,
+    replaceAll?: boolean,
+  ): Promise<EditResult> {
+    return this.#sandbox.edit(this.#scope(filePath), oldString, newString, replaceAll);
+  }
+
+  async uploadFiles(
+    files: Array<[string, Uint8Array]>,
+  ): Promise<FileUploadResponse[]> {
+    const scoped = files.map(
+      ([path, content]) => [this.#scope(path), content] as [string, Uint8Array],
+    );
+    const responses = await this.#sandbox.uploadFiles(scoped);
+    return responses.map((r) => ({ ...r, path: this.#unscope(r.path) }));
+  }
+
+  async downloadFiles(paths: string[]): Promise<FileDownloadResponse[]> {
+    const scoped = paths.map((p) => this.#scope(p));
+    const responses = await this.#sandbox.downloadFiles(scoped);
+    return responses.map((r) => ({ ...r, path: this.#unscope(r.path) }));
+  }
+}

--- a/libs/providers/wasmsh/src/filesystem-backend.ts
+++ b/libs/providers/wasmsh/src/filesystem-backend.ts
@@ -44,7 +44,10 @@ export class WasmshFilesystemBackend {
 
   readonly #namespace: string;
 
-  constructor(sandbox: WasmshSandbox, options: WasmshFilesystemBackendOptions = {}) {
+  constructor(
+    sandbox: WasmshSandbox,
+    options: WasmshFilesystemBackendOptions = {},
+  ) {
     this.#sandbox = sandbox;
     this.#namespace = normaliseNamespace(options.namespace);
   }
@@ -101,10 +104,17 @@ export class WasmshFilesystemBackend {
     glob?: string | null,
   ): Promise<GrepResult> {
     const scoped = path ? this.#scope(path) : null;
-    const result = await this.#sandbox.grep(pattern, scoped ?? "/", glob ?? null);
+    const result = await this.#sandbox.grep(
+      pattern,
+      scoped ?? "/",
+      glob ?? null,
+    );
     if (result.error || !result.matches) return result;
     return {
-      matches: result.matches.map((m) => ({ ...m, path: this.#unscope(m.path) })),
+      matches: result.matches.map((m) => ({
+        ...m,
+        path: this.#unscope(m.path),
+      })),
     };
   }
 
@@ -126,7 +136,12 @@ export class WasmshFilesystemBackend {
     newString: string,
     replaceAll?: boolean,
   ): Promise<EditResult> {
-    return this.#sandbox.edit(this.#scope(filePath), oldString, newString, replaceAll);
+    return this.#sandbox.edit(
+      this.#scope(filePath),
+      oldString,
+      newString,
+      replaceAll,
+    );
   }
 
   async uploadFiles(

--- a/libs/providers/wasmsh/src/index.ts
+++ b/libs/providers/wasmsh/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @langchain/wasmsh
+ *
+ * Wasmsh sandbox backend for deepagents.
+ *
+ * This package provides a Pyodide-backed `wasmsh` sandbox implementation of the
+ * SandboxBackendProtocol, enabling agents to execute bash-compatible shell
+ * commands and `python` / `python3` in the same `/workspace`.
+ *
+ * @packageDocumentation
+ */
+
+export {
+  WasmshSandbox,
+  type WasmshBrowserWorkerOptions,
+  type WasmshNodeSandboxOptions,
+} from "./sandbox.js";

--- a/libs/providers/wasmsh/src/index.ts
+++ b/libs/providers/wasmsh/src/index.ts
@@ -35,4 +35,8 @@ export {
   type SkillMetadata,
 } from "./skills.js";
 
-export { formatEnvelope, toSnakeCase, isValidPythonIdentifier } from "./utils.js";
+export {
+  formatEnvelope,
+  toSnakeCase,
+  isValidPythonIdentifier,
+} from "./utils.js";

--- a/libs/providers/wasmsh/src/index.ts
+++ b/libs/providers/wasmsh/src/index.ts
@@ -15,3 +15,24 @@ export {
   type WasmshBrowserWorkerOptions,
   type WasmshNodeSandboxOptions,
 } from "./sandbox.js";
+
+export {
+  createWasmshInterpreterMiddleware,
+  DEFAULT_PTC_EXCLUDED_TOOLS,
+} from "./middleware.js";
+
+export type { WasmshMiddlewareOptions, ReplEnvelope } from "./types.js";
+
+export {
+  WasmshFilesystemBackend,
+  type WasmshFilesystemBackendOptions,
+} from "./filesystem-backend.js";
+
+export {
+  scanSkillReferences,
+  loadSkill,
+  installPendingSkills,
+  type SkillMetadata,
+} from "./skills.js";
+
+export { formatEnvelope, toSnakeCase, isValidPythonIdentifier } from "./utils.js";

--- a/libs/providers/wasmsh/src/index.ts
+++ b/libs/providers/wasmsh/src/index.ts
@@ -21,7 +21,11 @@ export {
   DEFAULT_PTC_EXCLUDED_TOOLS,
 } from "./middleware.js";
 
-export type { WasmshMiddlewareOptions, ReplEnvelope } from "./types.js";
+export type {
+  WasmshMiddlewareOptions,
+  WasmshLogger,
+  ReplEnvelope,
+} from "./types.js";
 
 export {
   WasmshFilesystemBackend,

--- a/libs/providers/wasmsh/src/internal.ts
+++ b/libs/providers/wasmsh/src/internal.ts
@@ -1,0 +1,63 @@
+import type { FileOperationError } from "deepagents";
+
+export function errorMessage(error: unknown): string {
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function toInitialFiles(
+  files: Record<string, string | Uint8Array> | undefined,
+): Array<{ path: string; content: Uint8Array }> {
+  if (!files) {
+    return [];
+  }
+  return Object.entries(files).map(([path, content]) => ({
+    path,
+    content:
+      typeof content === "string" ? new TextEncoder().encode(content) : content,
+  }));
+}
+
+/** Extract a diagnostic error message from wasmsh protocol events. */
+export function getDiagnosticError(
+  events: unknown[] | undefined,
+): string | undefined {
+  if (!events) {
+    return undefined;
+  }
+  for (const event of events) {
+    if (
+      event &&
+      typeof event === "object" &&
+      "Diagnostic" in event &&
+      Array.isArray((event as { Diagnostic: unknown[] }).Diagnostic)
+    ) {
+      const [, message] = (event as { Diagnostic: [string, string] })
+        .Diagnostic;
+      return message;
+    }
+  }
+  return undefined;
+}
+
+export function mapDownloadError(
+  message: string | undefined,
+): FileOperationError {
+  const normalized = message?.toLowerCase() ?? "";
+  if (normalized.includes("not found")) {
+    return "file_not_found";
+  }
+  if (normalized.includes("directory")) {
+    return "is_directory";
+  }
+  if (normalized.includes("permission")) {
+    return "permission_denied";
+  }
+  return "invalid_path";
+}

--- a/libs/providers/wasmsh/src/logger.test.ts
+++ b/libs/providers/wasmsh/src/logger.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Coverage for the `WasmshLogger` hook surface.
+ *
+ * The middleware swallows two classes of error so they don't break the agent
+ * loop: PTC tool errors (round-tripped into an envelope the model sees) and
+ * best-effort skill load failures. The logger gives the host a structured
+ * surface to observe both — assertions below pin the exact event shape so
+ * downstream observability code can rely on it.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+import type { BackendProtocolV2 } from "deepagents";
+import {
+  createWasmshInterpreterMiddleware,
+  installPendingSkills,
+  type SkillMetadata,
+  type WasmshLogger,
+} from "./index.js";
+import type { WasmshSandbox } from "./sandbox.js";
+
+class CapturingSandbox {
+  lastOnHostCall:
+    | ((call: {
+        id: string;
+        tool: string;
+        args: Record<string, unknown>;
+      }) => Promise<{
+        ok: boolean;
+        value?: unknown;
+        error?: string;
+        message?: string;
+      }>)
+    | null = null;
+
+  async runPtc(params: {
+    code: string;
+    tools?: string[];
+    onHostCall: (call: {
+      id: string;
+      tool: string;
+      args: Record<string, unknown>;
+    }) => Promise<{
+      ok: boolean;
+      value?: unknown;
+      error?: string;
+      message?: string;
+    }>;
+  }) {
+    this.lastOnHostCall = params.onHostCall;
+    void params.code;
+    return { ok: true as const, stdout: "", stderr: "", value: null };
+  }
+
+  async uploadFiles(files: Array<[string, Uint8Array]>) {
+    return files.map(([p]) => ({ path: p, error: null }));
+  }
+}
+
+async function exposeViaWrapModelCall(
+  mw: ReturnType<typeof createWasmshInterpreterMiddleware>,
+  agentTools: unknown[],
+): Promise<void> {
+  await mw.wrapModelCall!(
+    {
+      tools: agentTools,
+      systemMessage: { concat: () => ({ concat: () => "" }) },
+    } as never,
+    () => Promise.resolve({} as never),
+  );
+}
+
+async function invokeEval(
+  mw: ReturnType<typeof createWasmshInterpreterMiddleware>,
+  code: string,
+): Promise<string> {
+  return (
+    mw.tools![0] as unknown as {
+      invoke: (input: { code: string }, config: unknown) => Promise<string>;
+    }
+  ).invoke({ code }, {});
+}
+
+describe("WasmshLogger.ptcToolError", () => {
+  it("fires with tool, callId, args, and the original error when a PTC tool throws", async () => {
+    const sandbox = new CapturingSandbox();
+    const ptcError = Object.assign(new Error("upstream blew up"), {
+      name: "UpstreamError",
+    });
+    const boom = tool(
+      async () => {
+        throw ptcError;
+      },
+      {
+        name: "boom",
+        description: "always throws",
+        schema: z.object({}),
+      },
+    );
+    const ptcToolError = vi.fn();
+    const logger: WasmshLogger = { ptcToolError };
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["boom"],
+      logger,
+    });
+    await exposeViaWrapModelCall(mw, [boom]);
+    await invokeEval(mw, "pass");
+
+    const env = await sandbox.lastOnHostCall!({
+      id: "hc_42",
+      tool: "boom",
+      args: { x: 1 },
+    });
+
+    expect(ptcToolError).toHaveBeenCalledTimes(1);
+    expect(ptcToolError).toHaveBeenCalledWith({
+      tool: "boom",
+      callId: "hc_42",
+      args: { x: 1 },
+      error: ptcError,
+    });
+
+    // The envelope still reaches the sandbox: logger is observability, not
+    // a side-channel that replaces the in-band error surface.
+    expect(env.ok).toBe(false);
+    expect(env.error).toBe("UpstreamError");
+    expect(env.message).toBe("upstream blew up");
+  });
+
+  it("does not fire when the PTC tool resolves normally", async () => {
+    const sandbox = new CapturingSandbox();
+    const ok = tool(async () => "result", {
+      name: "ok",
+      description: "no-op",
+      schema: z.object({}),
+    });
+    const ptcToolError = vi.fn();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["ok"],
+      logger: { ptcToolError },
+    });
+    await exposeViaWrapModelCall(mw, [ok]);
+    await invokeEval(mw, "pass");
+    await sandbox.lastOnHostCall!({ id: "hc_1", tool: "ok", args: {} });
+    expect(ptcToolError).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on UnknownToolError envelopes (no tool actually invoked)", async () => {
+    const sandbox = new CapturingSandbox();
+    const ptcToolError = vi.fn();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["known"],
+      logger: { ptcToolError },
+    });
+    await exposeViaWrapModelCall(mw, [
+      tool(async () => "x", {
+        name: "known",
+        description: "",
+        schema: z.object({}),
+      }),
+    ]);
+    await invokeEval(mw, "pass");
+    const env = await sandbox.lastOnHostCall!({
+      id: "hc_g",
+      tool: "ghost",
+      args: {},
+    });
+    expect(env.error).toBe("UnknownToolError");
+    // The logger surface is for *tool errors* — an allowlist miss is a
+    // protocol-level rejection, not a tool failure.
+    expect(ptcToolError).not.toHaveBeenCalled();
+  });
+
+  it("swallows a logger that itself throws so the envelope still round-trips", async () => {
+    const sandbox = new CapturingSandbox();
+    const boom = tool(
+      async () => {
+        throw new Error("boom");
+      },
+      { name: "boom", description: "", schema: z.object({}) },
+    );
+    const ptcToolError = vi.fn(() => {
+      throw new Error("logger is broken");
+    });
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["boom"],
+      logger: { ptcToolError },
+    });
+    await exposeViaWrapModelCall(mw, [boom]);
+    await invokeEval(mw, "pass");
+    const env = await sandbox.lastOnHostCall!({
+      id: "hc_1",
+      tool: "boom",
+      args: {},
+    });
+    expect(ptcToolError).toHaveBeenCalledTimes(1);
+    expect(env.ok).toBe(false);
+    expect(env.message).toBe("boom");
+  });
+});
+
+describe("WasmshLogger.skillLoadError", () => {
+  function makeSkillsBackend(
+    fail: Partial<Pick<BackendProtocolV2, "glob">> = {},
+  ) {
+    return {
+      async glob() {
+        return {
+          files: [{ path: "/skills/order-helpers/helper.py" }],
+        };
+      },
+      async downloadFiles() {
+        // The default failure path: backend returns the file with an error
+        // marker, which `loadSkill` surfaces as "failed to download …".
+        return [
+          {
+            path: "/skills/order-helpers/helper.py",
+            content: null,
+            error: "file_not_found" as const,
+          },
+        ];
+      },
+      ...fail,
+    };
+  }
+
+  const META: SkillMetadata = {
+    name: "order-helpers",
+    path: "/skills/order-helpers/SKILL.md",
+    description: "",
+    module: "helper.py",
+  };
+
+  it("fires with the skill name and original error on a load failure", async () => {
+    const skillLoadError = vi.fn();
+    const backend = makeSkillsBackend();
+    const sandbox = new CapturingSandbox();
+    await installPendingSkills({
+      source: "import skills.order_helpers",
+      metadata: new Map([["order-helpers", META]]),
+      backend,
+      sandbox: sandbox as unknown as WasmshSandbox,
+      installed: new Set(),
+      logger: { skillLoadError },
+    });
+    expect(skillLoadError).toHaveBeenCalledTimes(1);
+    const event = skillLoadError.mock.calls[0][0];
+    expect(event.skill).toBe("order-helpers");
+    expect(event.error).toBeInstanceOf(Error);
+    expect((event.error as Error).message).toMatch(/failed to download/);
+  });
+
+  it("does not fire when every referenced skill loads cleanly", async () => {
+    const skillLoadError = vi.fn();
+    const backend = {
+      async glob() {
+        return {
+          files: [{ path: "/skills/order-helpers/helper.py" }],
+        };
+      },
+      async downloadFiles(paths: string[]) {
+        return paths.map((p) => ({
+          path: p,
+          content: new TextEncoder().encode("x = 1\n"),
+          error: null,
+        }));
+      },
+    };
+    const sandbox = new CapturingSandbox();
+    await installPendingSkills({
+      source: "import skills.order_helpers",
+      metadata: new Map([["order-helpers", META]]),
+      backend,
+      sandbox: sandbox as unknown as WasmshSandbox,
+      installed: new Set(),
+      logger: { skillLoadError },
+    });
+    expect(skillLoadError).not.toHaveBeenCalled();
+  });
+
+  it("falls back to stderr when no logger is configured", async () => {
+    const backend = makeSkillsBackend();
+    const sandbox = new CapturingSandbox();
+    const writes: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    // Vitest's `vi.spyOn(process.stderr, "write")` returns a non-callable
+    // mock on Node; reassign directly so the stderr-capture path still
+    // calls a real function. Restore on the next line.
+    process.stderr.write = ((chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await installPendingSkills({
+        source: "import skills.order_helpers",
+        metadata: new Map([["order-helpers", META]]),
+        backend,
+        sandbox: sandbox as unknown as WasmshSandbox,
+        installed: new Set(),
+      });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    expect(writes.join("")).toMatch(
+      /\[wasmsh\] failed to load skill "order-helpers"/,
+    );
+  });
+
+  it("does not write to stderr when a logger is configured (logger is authoritative)", async () => {
+    const backend = makeSkillsBackend();
+    const sandbox = new CapturingSandbox();
+    const writes: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await installPendingSkills({
+        source: "import skills.order_helpers",
+        metadata: new Map([["order-helpers", META]]),
+        backend,
+        sandbox: sandbox as unknown as WasmshSandbox,
+        installed: new Set(),
+        logger: { skillLoadError: () => {} },
+      });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    expect(writes.join("")).toBe("");
+  });
+
+  it("swallows a logger that itself throws and keeps loading the next skill", async () => {
+    // Two skills: the first throws inside the logger, the second must still
+    // be loaded successfully so a buggy logger can't take the agent down.
+    const backend = {
+      async glob(_pattern: string, path?: string) {
+        return path?.includes("good")
+          ? { files: [{ path: "/skills/good/main.py" }] }
+          : { files: [{ path: "/skills/bad/helper.py" }] };
+      },
+      async downloadFiles(paths: string[]) {
+        return paths.map((p) =>
+          p.includes("bad")
+            ? { path: p, content: null, error: "file_not_found" as const }
+            : {
+                path: p,
+                content: new TextEncoder().encode("y = 2\n"),
+                error: null,
+              },
+        );
+      },
+    };
+    const skillLoadError = vi.fn(() => {
+      throw new Error("logger is broken");
+    });
+    const sandbox = new CapturingSandbox();
+    const installed = new Set<string>();
+    await installPendingSkills({
+      source: "import skills.bad\nimport skills.good\n",
+      metadata: new Map<string, SkillMetadata>([
+        [
+          "bad",
+          {
+            name: "bad",
+            path: "/skills/bad/SKILL.md",
+            description: "",
+            module: "helper.py",
+          },
+        ],
+        [
+          "good",
+          {
+            name: "good",
+            path: "/skills/good/SKILL.md",
+            description: "",
+            module: "main.py",
+          },
+        ],
+      ]),
+      backend,
+      sandbox: sandbox as unknown as WasmshSandbox,
+      installed,
+      logger: { skillLoadError },
+    });
+    expect(skillLoadError).toHaveBeenCalledTimes(1);
+    expect(installed.has("good")).toBe(true);
+  });
+});

--- a/libs/providers/wasmsh/src/middleware-skills.test.ts
+++ b/libs/providers/wasmsh/src/middleware-skills.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration coverage for the middleware ↔ skills loader seam.
+ *
+ * Other test files cover each side in isolation (`skills.test.ts` against a
+ * hand-rolled backend; `middleware.test.ts` against a stubbed sandbox).
+ * This file wires them together: configure `createWasmshInterpreterMiddleware`
+ * with a `skillsBackend`, mock `getCurrentTaskInput` to return state with
+ * `skills_metadata`, invoke the eval tool with `import skills.<name>`
+ * source, and assert that `installPendingSkills` actually fires uploads
+ * onto the underlying sandbox.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { BackendProtocolV2 } from "deepagents";
+
+// Mock `getCurrentTaskInput` so the middleware sees a state carrying
+// `skills_metadata`. The mock is hoisted by vitest before module evaluation.
+vi.mock("@langchain/langgraph", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    "@langchain/langgraph",
+  );
+  return {
+    ...actual,
+    getCurrentTaskInput: vi.fn(() => ({
+      skills_metadata: [
+        {
+          name: "order-helpers",
+          path: "/skills/order-helpers/SKILL.md",
+          description: "validate orders",
+          module: "helper.py",
+        },
+      ],
+    })),
+  };
+});
+
+const { createWasmshInterpreterMiddleware } = await import("./middleware.js");
+
+class RecordingSandbox {
+  uploads: Array<[string, Uint8Array]> = [];
+  runPtcCode: string | null = null;
+
+  async uploadFiles(files: Array<[string, Uint8Array]>) {
+    for (const f of files) this.uploads.push(f);
+    return files.map(([p]) => ({ path: p, error: null }));
+  }
+
+  async runPtc(params: {
+    code: string;
+    tools?: string[];
+    onHostCall: unknown;
+  }) {
+    this.runPtcCode = params.code;
+    return {
+      ok: true as const,
+      stdout: "",
+      stderr: "",
+      value: null,
+    };
+  }
+}
+
+function makeBackend(files: Record<string, string>) {
+  const sortedPaths = Object.keys(files).sort();
+  return {
+    async glob(pattern: string, path?: string) {
+      const ext = pattern.replace(/^\*\*\/\*/, "");
+      const base = path ?? "/";
+      const match = (p: string) =>
+        p.startsWith(base.endsWith("/") ? base : `${base}/`) && p.endsWith(ext);
+      return { files: sortedPaths.filter(match).map((p) => ({ path: p })) };
+    },
+    async downloadFiles(paths: string[]) {
+      return paths.map((p) => {
+        const content = files[p];
+        return content == null
+          ? {
+              path: p,
+              content: null,
+              error: "file_not_found" as const,
+            }
+          : {
+              path: p,
+              content: new TextEncoder().encode(content),
+              error: null,
+            };
+      });
+    },
+  };
+}
+
+describe("WasmshInterpreterMiddleware ↔ skills loader integration", () => {
+  it("stages a referenced skill into the sandbox VFS before the eval runs", async () => {
+    const sandbox = new RecordingSandbox();
+    const skillsBackend = makeBackend({
+      "/skills/order-helpers/helper.py": "def add(a, b): return a + b\n",
+    });
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () =>
+        sandbox as unknown as Awaited<
+          ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
+        >,
+      // Cast: the middleware only uses `glob` + `downloadFiles` on the
+      // skills backend; the full `BackendProtocolV2` surface is overkill
+      // for a skills-only stub.
+      skillsBackend: skillsBackend as unknown as BackendProtocolV2,
+    });
+
+    // Drive the wrapModelCall hook first so any per-turn state (PTC list,
+    // prompts) is set up before the tool fires. Source code references the
+    // skill that the mocked state advertises.
+    const code = "import skills.order_helpers\nresult = 1";
+    await (
+      mw.tools![0] as unknown as {
+        invoke: (input: { code: string }, config: unknown) => Promise<string>;
+      }
+    ).invoke({ code }, {});
+
+    // The skill was uploaded under its snake-cased package name before the
+    // eval ran, so user code can `import skills.order_helpers` cleanly.
+    const uploaded = sandbox.uploads.map(([p]) => p);
+    expect(uploaded).toContain("/skills/order_helpers/helper.py");
+    // An auto-synthesised __init__.py also lands so plain `import
+    // skills.<pkg>` works even when the author ships only flat helpers.
+    expect(uploaded).toContain("/skills/order_helpers/__init__.py");
+    // The eval was actually invoked afterwards.
+    expect(sandbox.runPtcCode).toBe(code);
+  });
+
+  it("does not stage skills the source doesn't reference", async () => {
+    const sandbox = new RecordingSandbox();
+    const skillsBackend = makeBackend({
+      "/skills/order-helpers/helper.py": "x = 1\n",
+    });
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () =>
+        sandbox as unknown as Awaited<
+          ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
+        >,
+      // Cast: the middleware only uses `glob` + `downloadFiles` on the
+      // skills backend; the full `BackendProtocolV2` surface is overkill
+      // for a skills-only stub.
+      skillsBackend: skillsBackend as unknown as BackendProtocolV2,
+    });
+
+    await (
+      mw.tools![0] as unknown as {
+        invoke: (input: { code: string }, config: unknown) => Promise<string>;
+      }
+    ).invoke({ code: "result = 1" }, {});
+
+    // No `import skills.*` in the source → no uploads at all.
+    expect(sandbox.uploads).toHaveLength(0);
+  });
+});

--- a/libs/providers/wasmsh/src/middleware.test.ts
+++ b/libs/providers/wasmsh/src/middleware.test.ts
@@ -30,14 +30,18 @@ class StubSandbox {
   } = { ok: true, stdout: "", stderr: "", value: null };
 
   // The dispatcher we expose for assertion in tests.
-  capturedDispatcher: ((
-    call: { id: string; tool: string; args: Record<string, unknown> },
-  ) => Promise<{
-    ok: boolean;
-    value?: unknown;
-    error?: string;
-    message?: string;
-  }>) | null = null;
+  capturedDispatcher:
+    | ((call: {
+        id: string;
+        tool: string;
+        args: Record<string, unknown>;
+      }) => Promise<{
+        ok: boolean;
+        value?: unknown;
+        error?: string;
+        message?: string;
+      }>)
+    | null = null;
 
   async runPtc(params: {
     code: string;
@@ -92,9 +96,11 @@ describe("createWasmshInterpreterMiddleware", () => {
           ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
         >,
     });
-    const result = await (mw.tools![0] as unknown as {
-      invoke: (input: { code: string }, config: unknown) => Promise<string>;
-    }).invoke({ code: "2 * 21" }, {});
+    const result = await (
+      mw.tools![0] as unknown as {
+        invoke: (input: { code: string }, config: unknown) => Promise<string>;
+      }
+    ).invoke({ code: "2 * 21" }, {});
     expect(stub.runPtcCalls).toHaveLength(1);
     expect(stub.runPtcCalls[0].code).toBe("2 * 21");
     expect(stub.runPtcCalls[0].tools).toEqual([]);
@@ -117,9 +123,11 @@ describe("createWasmshInterpreterMiddleware", () => {
           ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
         >,
     });
-    const result = await (mw.tools![0] as unknown as {
-      invoke: (input: { code: string }, config: unknown) => Promise<string>;
-    }).invoke({ code: "foo" }, {});
+    const result = await (
+      mw.tools![0] as unknown as {
+        invoke: (input: { code: string }, config: unknown) => Promise<string>;
+      }
+    ).invoke({ code: "foo" }, {});
     expect(result).toContain("NameError");
     expect(result).toContain("name 'foo' is not defined");
   });
@@ -144,7 +152,9 @@ describe("skills scanner", () => {
   });
 
   it("ignores unrelated imports", () => {
-    expect(scanSkillReferences("import os\nfrom json import loads").size).toBe(0);
+    expect(scanSkillReferences("import os\nfrom json import loads").size).toBe(
+      0,
+    );
   });
 });
 

--- a/libs/providers/wasmsh/src/middleware.test.ts
+++ b/libs/providers/wasmsh/src/middleware.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the wasmsh interpreter middleware.
+ *
+ * These don't boot Pyodide — they stub the sandbox factory with a recording
+ * stand-in that satisfies just enough of the WasmshSandbox surface to drive
+ * `runPtc`. End-to-end coverage against real Pyodide lives in the e2e
+ * `ptc-round-trip.test.mjs` next to the npm package.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  createWasmshInterpreterMiddleware,
+  DEFAULT_PTC_EXCLUDED_TOOLS,
+} from "./middleware.js";
+import {
+  scanSkillReferences,
+  toSnakeCase,
+  isValidPythonIdentifier,
+  formatEnvelope,
+} from "./index.js";
+
+class StubSandbox {
+  runPtcCalls: Array<{ code: string; tools: string[] }> = [];
+  envelope: {
+    ok: boolean;
+    stdout: string;
+    stderr: string;
+    value?: unknown;
+    error?: string;
+    message?: string;
+  } = { ok: true, stdout: "", stderr: "", value: null };
+
+  // The dispatcher we expose for assertion in tests.
+  capturedDispatcher: ((
+    call: { id: string; tool: string; args: Record<string, unknown> },
+  ) => Promise<{
+    ok: boolean;
+    value?: unknown;
+    error?: string;
+    message?: string;
+  }>) | null = null;
+
+  async runPtc(params: {
+    code: string;
+    tools?: string[];
+    onHostCall: (call: {
+      id: string;
+      tool: string;
+      args: Record<string, unknown>;
+    }) => Promise<{
+      ok: boolean;
+      value?: unknown;
+      error?: string;
+      message?: string;
+    }>;
+  }) {
+    this.runPtcCalls.push({ code: params.code, tools: params.tools ?? [] });
+    this.capturedDispatcher = params.onHostCall;
+    return this.envelope;
+  }
+}
+
+describe("createWasmshInterpreterMiddleware", () => {
+  it("registers a py_eval tool by default", () => {
+    const stub = new StubSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () =>
+        stub as unknown as Awaited<
+          ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
+        >,
+    });
+    expect(mw.tools!.map((t: { name: string }) => t.name)).toEqual(["py_eval"]);
+  });
+
+  it("supports a custom tool name", () => {
+    const stub = new StubSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () =>
+        stub as unknown as Awaited<
+          ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
+        >,
+      toolName: "run_python",
+    });
+    expect(mw.tools![0].name).toBe("run_python");
+  });
+
+  it("invokes the eval tool against the underlying sandbox.runPtc", async () => {
+    const stub = new StubSandbox();
+    stub.envelope = { ok: true, stdout: "hi\n", stderr: "", value: 42 };
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () =>
+        stub as unknown as Awaited<
+          ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
+        >,
+    });
+    const result = await (mw.tools![0] as unknown as {
+      invoke: (input: { code: string }, config: unknown) => Promise<string>;
+    }).invoke({ code: "2 * 21" }, {});
+    expect(stub.runPtcCalls).toHaveLength(1);
+    expect(stub.runPtcCalls[0].code).toBe("2 * 21");
+    expect(stub.runPtcCalls[0].tools).toEqual([]);
+    expect(result).toContain("42");
+    expect(result).toContain("hi");
+  });
+
+  it("formats sandbox errors into the agent ToolMessage body", async () => {
+    const stub = new StubSandbox();
+    stub.envelope = {
+      ok: false,
+      stdout: "",
+      stderr: "",
+      error: "NameError",
+      message: "name 'foo' is not defined",
+    };
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () =>
+        stub as unknown as Awaited<
+          ReturnType<typeof import("./sandbox.js").WasmshSandbox.createNode>
+        >,
+    });
+    const result = await (mw.tools![0] as unknown as {
+      invoke: (input: { code: string }, config: unknown) => Promise<string>;
+    }).invoke({ code: "foo" }, {});
+    expect(result).toContain("NameError");
+    expect(result).toContain("name 'foo' is not defined");
+  });
+
+  it("exposes the default PTC excluded tool list", () => {
+    expect(DEFAULT_PTC_EXCLUDED_TOOLS).toContain("execute");
+    expect(DEFAULT_PTC_EXCLUDED_TOOLS).toContain("read_file");
+  });
+});
+
+describe("skills scanner", () => {
+  it("detects import skills.<name>", () => {
+    const refs = scanSkillReferences("import skills.foo\nimport skills.bar");
+    expect([...refs].sort()).toEqual(["bar", "foo"]);
+  });
+
+  it("detects from skills.<name> import …", () => {
+    const refs = scanSkillReferences(
+      "from skills.alpha import helper\nfrom skills.beta import x, y",
+    );
+    expect([...refs].sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("ignores unrelated imports", () => {
+    expect(scanSkillReferences("import os\nfrom json import loads").size).toBe(0);
+  });
+});
+
+describe("utils", () => {
+  it("toSnakeCase converts kebab to snake but leaves snake untouched", () => {
+    expect(toSnakeCase("my-tool")).toBe("my_tool");
+    expect(toSnakeCase("my_tool")).toBe("my_tool");
+    expect(toSnakeCase("plain")).toBe("plain");
+  });
+
+  it("isValidPythonIdentifier accepts simple names", () => {
+    expect(isValidPythonIdentifier("foo")).toBe(true);
+    expect(isValidPythonIdentifier("foo_bar1")).toBe(true);
+    expect(isValidPythonIdentifier("1foo")).toBe(false);
+    expect(isValidPythonIdentifier("foo-bar")).toBe(false);
+  });
+
+  it("formatEnvelope renders stdout + value blocks", () => {
+    const out = formatEnvelope(
+      { ok: true, stdout: "hi\n", stderr: "", value: 42 },
+      4000,
+    );
+    expect(out).toContain("<stdout>");
+    expect(out).toContain("hi");
+    expect(out).toContain("<value>");
+    expect(out).toContain("42");
+  });
+
+  it("formatEnvelope shows <no output> when nothing to render", () => {
+    const out = formatEnvelope({ ok: true, stdout: "", stderr: "" }, 4000);
+    expect(out).toContain("<no output>");
+  });
+
+  it("formatEnvelope renders error blocks with traceback", () => {
+    const out = formatEnvelope(
+      {
+        ok: false,
+        stdout: "",
+        stderr: "",
+        error: "NameError",
+        message: "name 'foo' is not defined",
+        traceback: "Traceback (most recent call last):\n  ...",
+      },
+      4000,
+    );
+    expect(out).toContain("<error NameError>");
+    expect(out).toContain("Traceback");
+  });
+
+  it("formatEnvelope truncates long bodies", () => {
+    const huge = "x".repeat(10_000);
+    const out = formatEnvelope({ ok: true, stdout: huge, stderr: "" }, 100);
+    expect(out).toContain("…");
+  });
+});

--- a/libs/providers/wasmsh/src/middleware.ts
+++ b/libs/providers/wasmsh/src/middleware.ts
@@ -1,0 +1,328 @@
+/**
+ * Wasmsh Python REPL middleware for deepagents.
+ *
+ * Exposes a `py_eval` tool that runs Python inside a wasmsh sandbox (Pyodide
+ * in WebAssembly). State (variables, imports, defined functions) persists
+ * across calls within the same session via the sandbox's globals pickle.
+ *
+ * Mirrors the shape of `langchain-quickjs`'s `CodeInterpreterMiddleware` but
+ * with a real host-memory-isolated sandbox. Supports:
+ *
+ * - Persistent state across evaluations (true REPL)
+ * - Programmatic tool calling (PTC) via the host_call/host_call_result wire
+ *   protocol
+ * - Python skills loading (`import skills.<name>`) via a paired
+ *   `SkillsMiddleware` and shared `BackendProtocol`
+ */
+import {
+  createMiddleware,
+  tool,
+  type AgentMiddleware as _AgentMiddleware,
+} from "langchain";
+import { z } from "zod/v4";
+import type { StructuredToolInterface } from "@langchain/core/tools";
+import {
+  resolveBackend,
+  type BackendProtocolV2,
+  type BackendRuntime,
+} from "deepagents";
+import dedent from "dedent";
+
+/**
+ * Type-only imports kept in step with `quickjs/middleware.ts` so the
+ * langchain/langgraph middleware system resolves its generic parameters
+ * correctly at module load.
+ */
+import type * as _zodTypes from "@langchain/core/utils/types";
+import type * as _zodMeta from "@langchain/langgraph/zod";
+import type * as _messages from "@langchain/core/messages";
+import {
+  getCurrentTaskInput,
+  type LangGraphRunnableConfig,
+} from "@langchain/langgraph";
+
+import { WasmshSandbox } from "./sandbox.js";
+import {
+  type WasmshMiddlewareOptions,
+  type ReplEnvelope,
+} from "./types.js";
+import { formatEnvelope, isValidPythonIdentifier, toSnakeCase } from "./utils.js";
+import {
+  installPendingSkills,
+  type SkillMetadata,
+} from "./skills.js";
+
+/** Default tool name; matches the Python adapter. */
+const DEFAULT_TOOL_NAME = "py_eval";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RESULT_CHARS = 4_000;
+
+/**
+ * Backend-provided tools excluded from PTC by default. These overlap with
+ * the in-sandbox filesystem/shell access user code already has.
+ */
+export const DEFAULT_PTC_EXCLUDED_TOOLS = [
+  "ls",
+  "read_file",
+  "write_file",
+  "edit_file",
+  "glob",
+  "grep",
+  "execute",
+] as const;
+
+const REPL_SYSTEM_PROMPT = dedent`
+  ## Python REPL (\`py_eval\`)
+
+  You have access to a sandboxed Python REPL running inside a wasmsh
+  WebAssembly sandbox (Pyodide). Variables, imports, and defined
+  functions persist across calls within the same session.
+
+  ### Hard rules
+
+  - **Sandbox boundary** — there is a full /workspace virtual filesystem
+    and the wasmsh shell utilities (\`subprocess.run\`); outbound network
+    calls are blocked unless explicitly allowlisted by the host.
+  - **Use \`print(...)\`** for intermediate output; the trailing
+    expression of the block is returned automatically when it is not
+    \`None\`.
+  - **Top-level \`await\`** is supported — write \`await some_coroutine()\`
+    directly.
+  - **Reuse state from previous cells** — variables, functions, and
+    results from earlier \`py_eval\` calls persist across calls. Reference
+    them by name in follow-up cells instead of re-embedding data as
+    inline literals.
+
+  ### Example
+
+  \`\`\`python
+  import json
+  data = json.loads(open("/workspace/config.json").read())
+  data["threshold"]
+  \`\`\`
+`;
+
+/** Render the PTC API-reference section appended to the system prompt. */
+function generatePtcPrompt(tools: StructuredToolInterface[]): string {
+  if (tools.length === 0) return "";
+  const lines = tools.map((t) => {
+    const desc = (t.description || "").trim().split("\n")[0];
+    const snake = toSnakeCase(t.name);
+    return `    async def ${snake}(**kwargs) -> str: """${desc}"""`;
+  });
+  return dedent`
+
+    ### API Reference — \`tools\` namespace
+
+    The following agent tools are callable as async methods on the global
+    \`tools\` object. Each takes keyword arguments and returns the tool's
+    native value (passed through unchanged for primitives; complex types
+    become repr strings). Use \`await\` for each call; combine with
+    \`asyncio.gather(...)\` for parallel fan-out.
+
+    \`\`\`python
+    class tools:
+    ${lines.join("\n")}
+    \`\`\`
+  `;
+}
+
+function filterToolsForPtc(
+  allTools: StructuredToolInterface[],
+  selfToolName: string,
+  ptc: WasmshMiddlewareOptions["ptc"],
+): StructuredToolInterface[] {
+  if (ptc === undefined || ptc === false) return [];
+  const candidates = allTools.filter((t) => t.name !== selfToolName);
+  if (ptc === true) {
+    const excluded = new Set<string>(DEFAULT_PTC_EXCLUDED_TOOLS);
+    return candidates.filter((t) => !excluded.has(t.name));
+  }
+  if (Array.isArray(ptc)) {
+    const included = new Set(ptc);
+    return candidates.filter((t) => included.has(t.name));
+  }
+  if ("include" in ptc) {
+    const included = new Set(ptc.include);
+    return candidates.filter((t) => included.has(t.name));
+  }
+  if ("exclude" in ptc) {
+    const excluded = new Set([
+      ...DEFAULT_PTC_EXCLUDED_TOOLS,
+      ...ptc.exclude,
+    ]);
+    return candidates.filter((t) => !excluded.has(t.name));
+  }
+  return [];
+}
+
+function ensurePythonIdentifier(tool: StructuredToolInterface): void {
+  const snake = toSnakeCase(tool.name);
+  if (!isValidPythonIdentifier(snake)) {
+    throw new Error(
+      `PTC tool name ${JSON.stringify(tool.name)} cannot be exposed as ` +
+        `Python identifier ${JSON.stringify(snake)}`,
+    );
+  }
+}
+
+async function dispatchHostCall(
+  call: { id: string; tool: string; args: Record<string, unknown> },
+  toolsByPyName: Map<string, StructuredToolInterface>,
+): Promise<{ ok: boolean; value?: unknown; error?: string; message?: string }> {
+  const tool = toolsByPyName.get(call.tool);
+  if (!tool) {
+    return {
+      ok: false,
+      error: "UnknownToolError",
+      message: `tool ${JSON.stringify(call.tool)} is not on the PTC allowlist`,
+    };
+  }
+  try {
+    const raw = await tool.invoke(call.args ?? {});
+    return { ok: true, value: raw };
+  } catch (err) {
+    const error = err as { name?: string; message?: string } | undefined;
+    return {
+      ok: false,
+      error: error?.name ?? "Error",
+      message: error?.message ?? String(err),
+    };
+  }
+}
+
+/**
+ * Build the Wasmsh Python REPL middleware.
+ */
+export function createWasmshInterpreterMiddleware(
+  options: WasmshMiddlewareOptions = {},
+) {
+  const toolName = options.toolName ?? DEFAULT_TOOL_NAME;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxResultChars = options.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
+  const baseSystemPrompt =
+    options.systemPrompt === undefined ? REPL_SYSTEM_PROMPT : options.systemPrompt;
+  const sandboxFactory = options.sandboxFactory ?? (() => WasmshSandbox.createNode());
+
+  // Lazily-created sandbox shared across calls. The first eval boots it
+  // (~1s) and subsequent calls reuse it for state persistence.
+  let sandboxPromise: Promise<WasmshSandbox> | null = null;
+  const getSandbox = () => {
+    if (!sandboxPromise) sandboxPromise = sandboxFactory();
+    return sandboxPromise;
+  };
+
+  // Skills cache, populated lazily on first matching `import skills.<name>`.
+  const installedSkills = new Set<string>();
+
+  // Per-turn PTC tool list, refreshed by `wrapModelCall` before each model
+  // call so the eval tool sees the live agent toolset.
+  let activePtcTools: StructuredToolInterface[] = [];
+  let cachedPtcPrompt: string | null = null;
+
+  const pyEvalTool = tool(
+    async (input, config: LangGraphRunnableConfig): Promise<string> => {
+      const sandbox = await getSandbox();
+
+      // Stage any newly-referenced skills before the eval runs.
+      if (options.skillsBackend !== undefined) {
+        const runtime: BackendRuntime = {
+          ...config,
+          state: getCurrentTaskInput(config) || {},
+        } as BackendRuntime;
+        const backend = await resolveBackend(options.skillsBackend, runtime);
+        const metadata = collectSkillsMetadata(runtime);
+        if (metadata.size > 0) {
+          const backendV2 = backend as unknown as BackendProtocolV2;
+          if (typeof backendV2.downloadFiles !== "function") {
+            throw new Error(
+              "skills_backend must implement downloadFiles (V2 surface)",
+            );
+          }
+          await installPendingSkills({
+            source: input.code,
+            metadata,
+            backend: backendV2 as {
+              glob: BackendProtocolV2["glob"];
+              downloadFiles: NonNullable<BackendProtocolV2["downloadFiles"]>;
+            },
+            sandbox,
+            installed: installedSkills,
+          });
+        }
+      }
+
+      // Resolve the snake-case → tool map once per eval.
+      const toolsByPyName = new Map<string, StructuredToolInterface>();
+      for (const t of activePtcTools) {
+        toolsByPyName.set(toSnakeCase(t.name), t);
+      }
+
+      const envelope: ReplEnvelope = await sandbox.runPtc({
+        code: input.code,
+        tools: [...toolsByPyName.keys()],
+        onHostCall: (call) => dispatchHostCall(call, toolsByPyName),
+      });
+      return formatEnvelope(envelope, maxResultChars);
+    },
+    {
+      name: toolName,
+      description: dedent`
+        Execute Python in a persistent wasmsh sandbox REPL. Variables,
+        imports, and defined functions persist across calls. A virtual
+        filesystem is available; shell utilities are reachable via
+        subprocess. The sandbox is WebAssembly-isolated; outbound network
+        calls are blocked unless explicitly allowlisted.
+      `,
+      schema: z.object({
+        code: z
+          .string()
+          .describe(
+            "Python source to evaluate in the persistent wasmsh REPL. " +
+              "Top-level await is supported.",
+          ),
+      }),
+    },
+  );
+
+  return createMiddleware({
+    name: "WasmshInterpreterMiddleware",
+    tools: [pyEvalTool],
+    wrapModelCall: async (request, handler) => {
+      const agentTools = (request.tools || []) as StructuredToolInterface[];
+      const exposed = filterToolsForPtc(agentTools, toolName, options.ptc);
+      exposed.forEach(ensurePythonIdentifier);
+      activePtcTools = exposed;
+
+      if (exposed.length > 0 && cachedPtcPrompt === null) {
+        cachedPtcPrompt = generatePtcPrompt(exposed);
+      }
+      const promptSuffix = exposed.length > 0 ? cachedPtcPrompt ?? "" : "";
+      const systemMessage = baseSystemPrompt
+        ? request.systemMessage.concat(baseSystemPrompt).concat(promptSuffix)
+        : request.systemMessage.concat(promptSuffix);
+      // Surface the configured timeout/limit in the prompt by reference;
+      // the actual budget is enforced sandbox-side.
+      void timeoutMs;
+      return handler({ ...request, systemMessage });
+    },
+    afterAgent: async () => {
+      // Best-effort shutdown when the wrapping agent finishes. We don't
+      // tear down sandboxPromise here because the same middleware
+      // instance may be reused across agent.invoke() calls in a session
+      // — long-lived state is the whole point.
+    },
+  });
+}
+
+function collectSkillsMetadata(runtime: BackendRuntime): Map<string, SkillMetadata> {
+  const state = (runtime as { state?: unknown }).state;
+  const list =
+    state && typeof state === "object" && "skills_metadata" in state
+      ? (state as { skills_metadata?: SkillMetadata[] }).skills_metadata ?? []
+      : [];
+  const out = new Map<string, SkillMetadata>();
+  for (const meta of list) out.set(meta.name, meta);
+  return out;
+}

--- a/libs/providers/wasmsh/src/middleware.ts
+++ b/libs/providers/wasmsh/src/middleware.ts
@@ -300,17 +300,16 @@ export function createWasmshInterpreterMiddleware(
       const systemMessage = baseSystemPrompt
         ? request.systemMessage.concat(baseSystemPrompt).concat(promptSuffix)
         : request.systemMessage.concat(promptSuffix);
-      // Surface the configured timeout/limit in the prompt by reference;
-      // the actual budget is enforced sandbox-side.
+      // `timeoutMs` is accepted as an option for API parity with the Python
+      // adapter but is not yet wired into the prompt or sandbox budget; see
+      // the open TODO on the constructor docstring.
       void timeoutMs;
       return handler({ ...request, systemMessage });
     },
-    afterAgent: async () => {
-      // Best-effort shutdown when the wrapping agent finishes. We don't
-      // tear down sandboxPromise here because the same middleware
-      // instance may be reused across agent.invoke() calls in a session
-      // — long-lived state is the whole point.
-    },
+    // No `afterAgent` cleanup: the lazily-booted sandbox is meant to span
+    // multiple `agent.invoke()` calls so REPL state persists across turns.
+    // Sandbox lifetime is bound to the middleware instance; rely on GC + the
+    // sandbox's own close-on-process-exit handlers for teardown.
   });
 }
 

--- a/libs/providers/wasmsh/src/middleware.ts
+++ b/libs/providers/wasmsh/src/middleware.ts
@@ -42,7 +42,11 @@ import {
 } from "@langchain/langgraph";
 
 import { WasmshSandbox } from "./sandbox.js";
-import { type WasmshMiddlewareOptions, type ReplEnvelope } from "./types.js";
+import {
+  type WasmshLogger,
+  type WasmshMiddlewareOptions,
+  type ReplEnvelope,
+} from "./types.js";
 import {
   formatEnvelope,
   isValidPythonIdentifier,
@@ -165,6 +169,7 @@ function ensurePythonIdentifier(tool: StructuredToolInterface): void {
 async function dispatchHostCall(
   call: { id: string; tool: string; args: Record<string, unknown> },
   toolsByPyName: Map<string, StructuredToolInterface>,
+  logger?: WasmshLogger,
 ): Promise<{ ok: boolean; value?: unknown; error?: string; message?: string }> {
   const tool = toolsByPyName.get(call.tool);
   if (!tool) {
@@ -178,6 +183,21 @@ async function dispatchHostCall(
     const raw = await tool.invoke(call.args ?? {});
     return { ok: true, value: raw };
   } catch (err) {
+    // The error must round-trip into the sandbox as a structured envelope —
+    // the model needs to see it to recover — but the stack and call context
+    // get lost in that conversion. The logger hook gives the host a single
+    // place to record the full original error for observability.
+    try {
+      logger?.ptcToolError?.({
+        tool: call.tool,
+        callId: call.id,
+        args: call.args ?? {},
+        error: err,
+      });
+    } catch {
+      // Logger contract forbids throwing; if it does anyway, swallow so the
+      // envelope still reaches the model.
+    }
     const error = err as { name?: string; message?: string } | undefined;
     return {
       ok: false,
@@ -247,6 +267,7 @@ export function createWasmshInterpreterMiddleware(
             },
             sandbox,
             installed: installedSkills,
+            logger: options.logger,
           });
         }
       }
@@ -260,7 +281,8 @@ export function createWasmshInterpreterMiddleware(
       const envelope: ReplEnvelope = await sandbox.runPtc({
         code: input.code,
         tools: [...toolsByPyName.keys()],
-        onHostCall: (call) => dispatchHostCall(call, toolsByPyName),
+        onHostCall: (call) =>
+          dispatchHostCall(call, toolsByPyName, options.logger),
       });
       return formatEnvelope(envelope, maxResultChars);
     },

--- a/libs/providers/wasmsh/src/middleware.ts
+++ b/libs/providers/wasmsh/src/middleware.ts
@@ -42,15 +42,13 @@ import {
 } from "@langchain/langgraph";
 
 import { WasmshSandbox } from "./sandbox.js";
+import { type WasmshMiddlewareOptions, type ReplEnvelope } from "./types.js";
 import {
-  type WasmshMiddlewareOptions,
-  type ReplEnvelope,
-} from "./types.js";
-import { formatEnvelope, isValidPythonIdentifier, toSnakeCase } from "./utils.js";
-import {
-  installPendingSkills,
-  type SkillMetadata,
-} from "./skills.js";
+  formatEnvelope,
+  isValidPythonIdentifier,
+  toSnakeCase,
+} from "./utils.js";
+import { installPendingSkills, type SkillMetadata } from "./skills.js";
 
 /** Default tool name; matches the Python adapter. */
 const DEFAULT_TOOL_NAME = "py_eval";
@@ -148,10 +146,7 @@ function filterToolsForPtc(
     return candidates.filter((t) => included.has(t.name));
   }
   if ("exclude" in ptc) {
-    const excluded = new Set([
-      ...DEFAULT_PTC_EXCLUDED_TOOLS,
-      ...ptc.exclude,
-    ]);
+    const excluded = new Set([...DEFAULT_PTC_EXCLUDED_TOOLS, ...ptc.exclude]);
     return candidates.filter((t) => !excluded.has(t.name));
   }
   return [];
@@ -202,8 +197,11 @@ export function createWasmshInterpreterMiddleware(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxResultChars = options.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
   const baseSystemPrompt =
-    options.systemPrompt === undefined ? REPL_SYSTEM_PROMPT : options.systemPrompt;
-  const sandboxFactory = options.sandboxFactory ?? (() => WasmshSandbox.createNode());
+    options.systemPrompt === undefined
+      ? REPL_SYSTEM_PROMPT
+      : options.systemPrompt;
+  const sandboxFactory =
+    options.sandboxFactory ?? (() => WasmshSandbox.createNode());
 
   // Lazily-created sandbox shared across calls. The first eval boots it
   // (~1s) and subsequent calls reuse it for state persistence.
@@ -298,7 +296,7 @@ export function createWasmshInterpreterMiddleware(
       if (exposed.length > 0 && cachedPtcPrompt === null) {
         cachedPtcPrompt = generatePtcPrompt(exposed);
       }
-      const promptSuffix = exposed.length > 0 ? cachedPtcPrompt ?? "" : "";
+      const promptSuffix = exposed.length > 0 ? (cachedPtcPrompt ?? "") : "";
       const systemMessage = baseSystemPrompt
         ? request.systemMessage.concat(baseSystemPrompt).concat(promptSuffix)
         : request.systemMessage.concat(promptSuffix);
@@ -316,11 +314,13 @@ export function createWasmshInterpreterMiddleware(
   });
 }
 
-function collectSkillsMetadata(runtime: BackendRuntime): Map<string, SkillMetadata> {
+function collectSkillsMetadata(
+  runtime: BackendRuntime,
+): Map<string, SkillMetadata> {
   const state = (runtime as { state?: unknown }).state;
   const list =
     state && typeof state === "object" && "skills_metadata" in state
-      ? (state as { skills_metadata?: SkillMetadata[] }).skills_metadata ?? []
+      ? ((state as { skills_metadata?: SkillMetadata[] }).skills_metadata ?? [])
       : [];
   const out = new Map<string, SkillMetadata>();
   for (const meta of list) out.set(meta.name, meta);

--- a/libs/providers/wasmsh/src/ptc.test.ts
+++ b/libs/providers/wasmsh/src/ptc.test.ts
@@ -1,0 +1,289 @@
+/**
+ * PTC dispatch coverage.
+ *
+ * Exercises the middleware's tool-filter logic + the host_call → tool.invoke
+ * pipeline without booting Pyodide. Each test stubs the sandbox factory and
+ * intercepts the dispatcher the middleware hands to `sandbox.runPtc`.
+ */
+import { describe, it, expect } from "vitest";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+import {
+  createWasmshInterpreterMiddleware,
+  DEFAULT_PTC_EXCLUDED_TOOLS,
+} from "./middleware.js";
+import type { WasmshSandbox } from "./sandbox.js";
+
+class CapturingSandbox {
+  lastTools: string[] | null = null;
+  lastOnHostCall:
+    | ((call: {
+        id: string;
+        tool: string;
+        args: Record<string, unknown>;
+      }) => Promise<{
+        ok: boolean;
+        value?: unknown;
+        error?: string;
+        message?: string;
+      }>)
+    | null = null;
+
+  async runPtc(params: {
+    code: string;
+    tools?: string[];
+    onHostCall: (call: {
+      id: string;
+      tool: string;
+      args: Record<string, unknown>;
+    }) => Promise<{
+      ok: boolean;
+      value?: unknown;
+      error?: string;
+      message?: string;
+    }>;
+  }) {
+    this.lastTools = params.tools ?? [];
+    this.lastOnHostCall = params.onHostCall;
+    return {
+      ok: true as const,
+      stdout: "",
+      stderr: "",
+      value: null,
+    };
+  }
+}
+
+function makeTool(name: string, returnValue: unknown) {
+  return tool(async () => returnValue, {
+    name,
+    description: `tool ${name}`,
+    schema: z.object({ q: z.string().optional() }),
+  });
+}
+
+async function exposeViaWrapModelCall(
+  mw: ReturnType<typeof createWasmshInterpreterMiddleware>,
+  agentTools: unknown[],
+): Promise<void> {
+  // Drive the wrapModelCall hook directly so the middleware refreshes its
+  // per-turn PTC tool list. The handler is a no-op stub.
+  await mw.wrapModelCall!(
+    {
+      tools: agentTools,
+      systemMessage: {
+        concat: () => ({ concat: () => "" }),
+      },
+    } as never,
+    () => Promise.resolve({} as never),
+  );
+}
+
+async function invokeEval(
+  mw: ReturnType<typeof createWasmshInterpreterMiddleware>,
+  code: string,
+): Promise<string> {
+  return (
+    mw.tools![0] as unknown as {
+      invoke: (input: { code: string }, config: unknown) => Promise<string>;
+    }
+  ).invoke({ code }, {});
+}
+
+describe("PTC tool filtering", () => {
+  it("ptc: false exposes nothing", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+    });
+    await exposeViaWrapModelCall(mw, [makeTool("search", "hit")]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools).toEqual([]);
+  });
+
+  it("ptc: true exposes every agent tool except the default vfs helpers", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: true,
+    });
+    await exposeViaWrapModelCall(mw, [
+      makeTool("search", "hit"),
+      makeTool("read_file", "skip"),
+      makeTool("ls", "skip"),
+      makeTool("custom_tool", "ok"),
+    ]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools!.sort()).toEqual(["custom_tool", "search"]);
+    // sanity: the defaults we're testing the exclusion against
+    expect(DEFAULT_PTC_EXCLUDED_TOOLS).toContain("read_file");
+    expect(DEFAULT_PTC_EXCLUDED_TOOLS).toContain("ls");
+  });
+
+  it("ptc: string[] exposes only the listed tools", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["search"],
+    });
+    await exposeViaWrapModelCall(mw, [
+      makeTool("search", "hit"),
+      makeTool("other", "skip"),
+    ]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools).toEqual(["search"]);
+  });
+
+  it("ptc: { include } exposes only the named tools", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: { include: ["search"] },
+    });
+    await exposeViaWrapModelCall(mw, [
+      makeTool("search", "hit"),
+      makeTool("other", "skip"),
+    ]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools).toEqual(["search"]);
+  });
+
+  it("ptc: { exclude } unions with the default exclusions", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: { exclude: ["secret_tool"] },
+    });
+    await exposeViaWrapModelCall(mw, [
+      makeTool("search", "hit"),
+      makeTool("secret_tool", "no"),
+      makeTool("execute", "no"),
+      makeTool("custom_tool", "ok"),
+    ]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools!.sort()).toEqual(["custom_tool", "search"]);
+  });
+
+  it("excludes the middleware's own tool from the PTC list", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: true,
+      toolName: "py_eval",
+    });
+    await exposeViaWrapModelCall(mw, [
+      makeTool("search", "hit"),
+      makeTool("py_eval", "self"),
+    ]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools).toEqual(["search"]);
+  });
+
+  it("rejects tools whose name can't become a Python identifier", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: true,
+    });
+    await expect(
+      exposeViaWrapModelCall(mw, [makeTool("1bad-name", "x")]),
+    ).rejects.toThrow(/cannot be exposed as Python identifier/);
+  });
+});
+
+describe("PTC tool name mapping (kebab → snake)", () => {
+  it("exposes a kebab-cased agent tool name in snake form", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: true,
+    });
+    await exposeViaWrapModelCall(mw, [makeTool("look-up", "ok")]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools).toEqual(["look_up"]);
+  });
+
+  it("preserves already-snake names", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: true,
+    });
+    await exposeViaWrapModelCall(mw, [makeTool("snake_case", "ok")]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastTools).toEqual(["snake_case"]);
+  });
+});
+
+describe("PTC onHostCall dispatcher", () => {
+  it("routes host_call.tool to the matching LangChain tool", async () => {
+    const sandbox = new CapturingSandbox();
+    const lookup = tool(async ({ q }: { q: string }) => `found:${q}`, {
+      name: "lookup",
+      description: "find by q",
+      schema: z.object({ q: z.string() }),
+    });
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["lookup"],
+    });
+    await exposeViaWrapModelCall(mw, [lookup]);
+    await invokeEval(mw, "pass");
+    expect(sandbox.lastOnHostCall).not.toBeNull();
+    const env = await sandbox.lastOnHostCall!({
+      id: "hc_1",
+      tool: "lookup",
+      args: { q: "alice" },
+    });
+    expect(env.ok).toBe(true);
+    expect(env.value).toBe("found:alice");
+  });
+
+  it("returns an UnknownToolError envelope for tools not on the allowlist", async () => {
+    const sandbox = new CapturingSandbox();
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["lookup"],
+    });
+    await exposeViaWrapModelCall(mw, [makeTool("lookup", "ok")]);
+    await invokeEval(mw, "pass");
+    const env = await sandbox.lastOnHostCall!({
+      id: "hc_x",
+      tool: "ghost",
+      args: {},
+    });
+    expect(env.ok).toBe(false);
+    expect(env.error).toBe("UnknownToolError");
+    expect(env.message).toContain("ghost");
+  });
+
+  it("isolates a thrown tool error into the envelope's error fields", async () => {
+    const sandbox = new CapturingSandbox();
+    const boom = tool(
+      async () => {
+        const err = new Error("kaboom");
+        err.name = "BoomError";
+        throw err;
+      },
+      {
+        name: "boom",
+        description: "always throws",
+        schema: z.object({}),
+      },
+    );
+    const mw = createWasmshInterpreterMiddleware({
+      sandboxFactory: async () => sandbox as unknown as WasmshSandbox,
+      ptc: ["boom"],
+    });
+    await exposeViaWrapModelCall(mw, [boom]);
+    await invokeEval(mw, "pass");
+    const env = await sandbox.lastOnHostCall!({
+      id: "hc_b",
+      tool: "boom",
+      args: {},
+    });
+    expect(env.ok).toBe(false);
+    expect(env.error).toBe("BoomError");
+    expect(env.message).toBe("kaboom");
+  });
+});

--- a/libs/providers/wasmsh/src/sandbox-agent.int.test.ts
+++ b/libs/providers/wasmsh/src/sandbox-agent.int.test.ts
@@ -1,0 +1,245 @@
+/**
+ * LLM-driven agent integration tests for WasmshSandbox.
+ *
+ * Creates deep agents with WasmshSandbox as backend to test:
+ * - CSV analysis, skill loading, filesystem ops, memory, code execution
+ *
+ * Requires: built Pyodide assets + ANTHROPIC_API_KEY
+ */
+import { existsSync } from "node:fs";
+import { describe, it, expect, afterEach } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import { createDeepAgent } from "deepagents";
+import { resolveAssetPath } from "@mayflowergmbh/wasmsh-pyodide";
+
+import { WasmshSandbox } from "./sandbox.js";
+
+const assetsAvailable = existsSync(resolveAssetPath("pyodide.asm.wasm"));
+const apiKeyAvailable = !!process.env.ANTHROPIC_API_KEY;
+const SKIP = !assetsAvailable || !apiKeyAvailable;
+const MODEL = "claude-haiku-4-5-20251001";
+const enc = new TextEncoder();
+
+describe("LLM agent integration via WasmshSandbox", () => {
+  let sandbox: WasmshSandbox | undefined;
+
+  afterEach(async () => {
+    if (sandbox) {
+      await sandbox.stop();
+      sandbox = undefined;
+    }
+  });
+
+  it.skipIf(SKIP)(
+    "csv analysis: Python computes correct statistics",
+    { timeout: 120_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({
+        workingDirectory: "/workspace",
+      });
+      await sandbox.uploadFiles([
+        [
+          "/workspace/temps.csv",
+          enc.encode(
+            "city,temp_c\nTokyo,22\nBerlin,15\nCairo,35\nSydney,28\nOslo,5\n",
+          ),
+        ],
+      ]);
+
+      const agent = createDeepAgent({ model: MODEL, backend: sandbox });
+      await agent.invoke({
+        messages: [
+          new HumanMessage(
+            "Analyze the CSV file at /workspace/temps.csv. Calculate the average temperature " +
+              "and find the hottest city. Write the results as JSON to /workspace/analysis.json " +
+              'with keys "average", "hottest_city", and "hottest_temp".',
+          ),
+        ],
+      });
+
+      const catResult = await sandbox.execute("cat /workspace/analysis.json");
+      expect(catResult.exitCode).toBe(0);
+      const analysis = JSON.parse(catResult.output.trim());
+      expect(analysis.average).toBe(21);
+      expect(analysis.hottest_city).toBe("Cairo");
+      expect(analysis.hottest_temp).toBe(35);
+    },
+  );
+
+  it.skipIf(SKIP)(
+    "skills: agent loads SKILL.md and follows instructions",
+    { timeout: 120_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({
+        workingDirectory: "/workspace",
+      });
+
+      const skillMd =
+        "---\nname: md-table-formatter\ndescription: Format data as a markdown table and write it to a file\n---\n\n" +
+        "When asked to format data, you MUST:\n" +
+        "1. Create a markdown table with columns: Name, Score, Grade\n" +
+        "2. Assign grades: A for score >= 90, B for score >= 80, C otherwise\n" +
+        "3. Write the table to /workspace/output.md\n" +
+        "4. Write a JSON summary to /workspace/summary.json with keys:\n" +
+        '   - "count" (number of rows)\n' +
+        '   - "top_scorer" (name of the person with highest score)\n';
+
+      await sandbox.execute("mkdir -p /workspace/skills/md-table-formatter");
+      await sandbox.uploadFiles([
+        ["/workspace/skills/md-table-formatter/SKILL.md", enc.encode(skillMd)],
+      ]);
+
+      const agent = createDeepAgent({
+        model: MODEL,
+        backend: sandbox,
+        skills: ["/workspace/skills"],
+      });
+      await agent.invoke({
+        messages: [
+          new HumanMessage(
+            "Use the md-table-formatter skill to format this student data: Alice 92, Bob 85, Carol 97",
+          ),
+        ],
+      });
+
+      const tableResult = await sandbox.execute("cat /workspace/output.md");
+      expect(tableResult.output).toContain("Alice");
+      expect(tableResult.output).toContain("|");
+
+      const summaryResult = await sandbox.execute(
+        "cat /workspace/summary.json",
+      );
+      const summary = JSON.parse(summaryResult.output.trim());
+      expect(summary.count).toBe(3);
+      expect(summary.top_scorer).toBe("Carol");
+    },
+  );
+
+  it.skipIf(SKIP)(
+    "filesystem: edit and write_file work",
+    { timeout: 120_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({
+        workingDirectory: "/workspace",
+      });
+
+      await sandbox.execute("mkdir -p /workspace/project/src");
+      await sandbox.uploadFiles([
+        [
+          "/workspace/project/src/main.py",
+          enc.encode('print("hello world")\n'),
+        ],
+        [
+          "/workspace/project/src/utils.py",
+          enc.encode("def add(a, b):\n    return a + b\n"),
+        ],
+        ["/workspace/project/README.md", enc.encode("# My Project\n")],
+      ]);
+
+      const agent = createDeepAgent({ model: MODEL, backend: sandbox });
+      await agent.invoke({
+        messages: [
+          new HumanMessage(
+            'Edit /workspace/project/src/main.py to change "hello" to "goodbye". ' +
+              "Then create a new file /workspace/project/src/config.py with the content: DEBUG = True",
+          ),
+        ],
+      });
+
+      const mainResult = await sandbox.execute(
+        "cat /workspace/project/src/main.py",
+      );
+      expect(mainResult.output).toContain("goodbye");
+      expect(mainResult.output).not.toContain("hello");
+
+      const configResult = await sandbox.execute(
+        "cat /workspace/project/src/config.py",
+      );
+      expect(configResult.exitCode).toBe(0);
+    },
+  );
+
+  it.skipIf(SKIP)(
+    "memory: agent uses AGENTS.md context from sandbox",
+    { timeout: 120_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({
+        workingDirectory: "/workspace",
+      });
+
+      const memoryContent =
+        "# Agent Memory\n\n## Project Configuration\n" +
+        "- Deployment region: eu-central-1 (Frankfurt)\n" +
+        "- Unit system: metric (Celsius, meters, kilograms)\n" +
+        "- Team lead: Dr. Weber\n" +
+        "- Database: PostgreSQL 16\n";
+
+      await sandbox.execute("mkdir -p /workspace/memory");
+      await sandbox.uploadFiles([
+        ["/workspace/memory/AGENTS.md", enc.encode(memoryContent)],
+      ]);
+
+      const agent = createDeepAgent({
+        model: MODEL,
+        backend: sandbox,
+        memory: ["/workspace/memory/AGENTS.md"],
+      });
+      await agent.invoke({
+        messages: [
+          new HumanMessage(
+            "Write a deployment config to /workspace/deploy.json with our project's " +
+              '"region", "unit_system", "team_lead", and "database".',
+          ),
+        ],
+      });
+
+      const deployResult = await sandbox.execute("cat /workspace/deploy.json");
+      const deploy = JSON.parse(deployResult.output.trim());
+      const region = deploy.region?.toLowerCase() ?? "";
+      expect(
+        region.includes("frankfurt") || region.includes("eu-central"),
+      ).toBe(true);
+      expect(deploy.unit_system?.toLowerCase()).toContain("metric");
+      expect(deploy.team_lead).toContain("Weber");
+      expect(deploy.database?.toLowerCase()).toContain("postgres");
+    },
+  );
+
+  it.skipIf(SKIP)(
+    "code execution: Python computes median and stddev",
+    { timeout: 120_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({
+        workingDirectory: "/workspace",
+      });
+
+      await sandbox.execute("mkdir -p /workspace/data");
+      await sandbox.uploadFiles([
+        [
+          "/workspace/data/numbers.txt",
+          enc.encode("42\n17\n88\n3\n56\n91\n25\n64\n10\n73\n"),
+        ],
+      ]);
+
+      const agent = createDeepAgent({ model: MODEL, backend: sandbox });
+      await agent.invoke({
+        messages: [
+          new HumanMessage(
+            "Read /workspace/data/numbers.txt, sort the numbers, compute the median and " +
+              "population standard deviation. Write the results to /workspace/data/stats.json " +
+              'with keys "sorted" (array), "median" (number), "stddev" (rounded to 1 decimal).',
+          ),
+        ],
+      });
+
+      const statsResult = await sandbox.execute(
+        "cat /workspace/data/stats.json",
+      );
+      const stats = JSON.parse(statsResult.output.trim());
+      expect(stats.sorted).toEqual([3, 10, 17, 25, 42, 56, 64, 73, 88, 91]);
+      expect(stats.median).toBe(49);
+      expect(stats.stddev).toBeGreaterThan(29);
+      expect(stats.stddev).toBeLessThan(32);
+    },
+  );
+});

--- a/libs/providers/wasmsh/src/sandbox-runPtc.int.test.ts
+++ b/libs/providers/wasmsh/src/sandbox-runPtc.int.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Adapter-layer integration test for `WasmshSandbox.runPtc` against real
+ * Pyodide.
+ *
+ * The unit test (`sandbox-runPtc.test.ts`) stubs the underlying npm session
+ * and only checks the passthrough wiring. This file boots an actual
+ * Pyodide-backed session and exercises the full round-trip:
+ *
+ *   - Plain code with no host calls (single-shot eval, stdout + value)
+ *   - Code that emits a `host_call`, host satisfies it via `onHostCall`,
+ *     Python sees the resolved value
+ *   - Persistent state across two `runPtc` calls on the same sandbox
+ *
+ * Gated on built Pyodide assets so CI can opt-in by building them first.
+ */
+import { existsSync } from "node:fs";
+import { describe, it, expect, afterEach } from "vitest";
+import { resolveAssetPath } from "@mayflowergmbh/wasmsh-pyodide";
+
+import { WasmshSandbox } from "./sandbox.js";
+
+const assetsAvailable = existsSync(resolveAssetPath("pyodide.asm.wasm"));
+
+describe.skipIf(!assetsAvailable)("WasmshSandbox.runPtc (real Pyodide)", () => {
+  let sandbox: WasmshSandbox | undefined;
+
+  afterEach(async () => {
+    if (sandbox) {
+      await sandbox.stop();
+      sandbox = undefined;
+    }
+  });
+
+  it(
+    "evaluates plain Python with no host calls and returns the trailing value",
+    { timeout: 60_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({});
+      const envelope = await sandbox.runPtc({
+        code: "print('hello'); 2 * 21",
+        tools: [],
+        onHostCall: async () => {
+          throw new Error("onHostCall should not fire when tools is empty");
+        },
+      });
+      expect(envelope.ok).toBe(true);
+      expect(envelope.stdout).toContain("hello");
+      // Pyodide returns the trailing expression natively when it's not None.
+      expect(envelope.value).toBe(42);
+    },
+  );
+
+  it(
+    "round-trips a host_call: Python awaits a host tool, sees the resolved value",
+    { timeout: 60_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({});
+      const hostCalls: Array<{
+        id: string;
+        tool: string;
+        args: Record<string, unknown>;
+      }> = [];
+      const envelope = await sandbox.runPtc({
+        code: "x = await tools.echo(value='ping'); x",
+        tools: ["echo"],
+        onHostCall: async (call) => {
+          hostCalls.push(call);
+          // Echo back a synthetic value the in-sandbox Python can inspect.
+          return { ok: true, value: `pong:${call.args.value as string}` };
+        },
+      });
+      expect(envelope.ok).toBe(true);
+      expect(hostCalls).toHaveLength(1);
+      expect(hostCalls[0].tool).toBe("echo");
+      expect(hostCalls[0].args).toEqual({ value: "ping" });
+      expect(envelope.value).toBe("pong:ping");
+    },
+  );
+
+  it(
+    "surfaces a host_call error envelope to Python as an exception",
+    { timeout: 60_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({});
+      // Python tries to use the result; the runtime should raise an error
+      // inside the user code (model sees it as a normal Python traceback).
+      const code = `
+try:
+    await tools.boom()
+    result = 'no_error'
+except Exception as e:
+    result = f"caught:{type(e).__name__}:{e}"
+result
+`;
+      const envelope = await sandbox.runPtc({
+        code,
+        tools: ["boom"],
+        onHostCall: async () => ({
+          ok: false,
+          error: "BoomError",
+          message: "blew up",
+        }),
+      });
+      expect(envelope.ok).toBe(true);
+      expect(typeof envelope.value).toBe("string");
+      expect(String(envelope.value)).toContain("caught:");
+      expect(String(envelope.value)).toContain("blew up");
+    },
+  );
+
+  it(
+    "persists globals across successive runPtc calls on the same sandbox",
+    { timeout: 60_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({});
+      const first = await sandbox.runPtc({
+        code: "counter = 41\ncounter",
+        tools: [],
+        onHostCall: async () => ({ ok: false }),
+      });
+      expect(first.ok).toBe(true);
+      expect(first.value).toBe(41);
+
+      const second = await sandbox.runPtc({
+        code: "counter += 1\ncounter",
+        tools: [],
+        onHostCall: async () => ({ ok: false }),
+      });
+      expect(second.ok).toBe(true);
+      expect(second.value).toBe(42);
+    },
+  );
+
+  it(
+    "propagates a Python exception into the envelope's error fields",
+    { timeout: 60_000 },
+    async () => {
+      sandbox = await WasmshSandbox.createNode({});
+      const envelope = await sandbox.runPtc({
+        code: "undefined_name",
+        tools: [],
+        onHostCall: async () => ({ ok: false }),
+      });
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error).toMatch(/NameError/);
+      expect(envelope.message).toMatch(/undefined_name/);
+    },
+  );
+});

--- a/libs/providers/wasmsh/src/sandbox-runPtc.test.ts
+++ b/libs/providers/wasmsh/src/sandbox-runPtc.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `WasmshSandbox.runPtc` passthrough + capability duck-check.
+ *
+ * The sandbox class forwards runPtc to the underlying npm session. We
+ * verify the call shape is preserved and that a session without runPtc
+ * surfaces a clear error rather than a TypeError on undefined.
+ */
+import { describe, it, expect, vi } from "vitest";
+import * as npmModule from "@mayflowergmbh/wasmsh-pyodide";
+import { WasmshSandbox } from "./sandbox.js";
+
+describe("WasmshSandbox.runPtc", () => {
+  it("delegates to the session.runPtc when present", async () => {
+    const sessionRunPtc = vi.fn().mockResolvedValue({
+      ok: true,
+      stdout: "out",
+      stderr: "",
+      value: "v",
+    });
+    const fakeSession = {
+      runPtc: sessionRunPtc,
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.spyOn(npmModule, "createNodeSession").mockResolvedValue(
+      fakeSession as never,
+    );
+
+    const sandbox = await WasmshSandbox.createNode({});
+    const onHostCall = vi.fn();
+    const result = await sandbox.runPtc({
+      code: "1 + 1",
+      tools: ["search"],
+      onHostCall,
+    });
+
+    expect(sessionRunPtc).toHaveBeenCalledOnce();
+    expect(sessionRunPtc.mock.calls[0][0].code).toBe("1 + 1");
+    expect(sessionRunPtc.mock.calls[0][0].tools).toEqual(["search"]);
+    expect(sessionRunPtc.mock.calls[0][0].onHostCall).toBe(onHostCall);
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe("v");
+
+    await sandbox.stop();
+    vi.restoreAllMocks();
+  });
+
+  it("throws a clear error against an older session that lacks runPtc", async () => {
+    const fakeSession = {
+      // Deliberately no runPtc — simulates @mayflowergmbh/wasmsh-pyodide < 0.6.4.
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.spyOn(npmModule, "createNodeSession").mockResolvedValue(
+      fakeSession as never,
+    );
+
+    const sandbox = await WasmshSandbox.createNode({});
+    await expect(
+      sandbox.runPtc({
+        code: "pass",
+        tools: [],
+        onHostCall: async () => ({ ok: true }),
+      }),
+    ).rejects.toThrow(/does not expose runPtc/);
+
+    await sandbox.stop();
+    vi.restoreAllMocks();
+  });
+
+  it("throws when called before initialize", async () => {
+    // Construct a sandbox with a factory that captures the instance before
+    // initialize completes — we test the post-stop case which leaves
+    // #session null.
+    const fakeSession = {
+      runPtc: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.spyOn(npmModule, "createNodeSession").mockResolvedValue(
+      fakeSession as never,
+    );
+    const sandbox = await WasmshSandbox.createNode({});
+    await sandbox.stop();
+    await expect(
+      sandbox.runPtc({
+        code: "pass",
+        tools: [],
+        onHostCall: async () => ({ ok: true }),
+      }),
+    ).rejects.toThrow(/is not initialized/);
+    vi.restoreAllMocks();
+  });
+});

--- a/libs/providers/wasmsh/src/sandbox.int.test.ts
+++ b/libs/providers/wasmsh/src/sandbox.int.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Integration tests for WasmshSandbox.
+ *
+ * These tests require built Pyodide assets in the wasmsh-pyodide package.
+ * They will be skipped automatically if the assets are not available.
+ *
+ * To run: build Pyodide assets first, then `pnpm test:int`
+ */
+import { existsSync } from "node:fs";
+import { sandboxStandardTests } from "@langchain/sandbox-standard-tests/vitest";
+import { resolveAssetPath } from "@mayflowergmbh/wasmsh-pyodide";
+
+import { WasmshSandbox } from "./sandbox.js";
+
+const assetsAvailable = existsSync(resolveAssetPath("pyodide.asm.wasm"));
+
+sandboxStandardTests({
+  name: "WasmshSandbox",
+  skip: !assetsAvailable,
+  timeout: 60_000,
+  sequential: true,
+  createSandbox: async (options) =>
+    WasmshSandbox.createNode({
+      initialFiles: options?.initialFiles,
+      workingDirectory: "/workspace",
+    }),
+  closeSandbox: (sandbox) => sandbox.stop(),
+  resolvePath: (name) => `/workspace/${name}`,
+});

--- a/libs/providers/wasmsh/src/sandbox.test.ts
+++ b/libs/providers/wasmsh/src/sandbox.test.ts
@@ -1,0 +1,504 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock state ──────────────────────────────────────────────────────────────
+
+interface MockSession {
+  run: ReturnType<typeof vi.fn>;
+  writeFile: ReturnType<typeof vi.fn>;
+  readFile: ReturnType<typeof vi.fn>;
+  listDir: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+const mockState: {
+  session: MockSession | null;
+  createNodeCalls: unknown[];
+  createBrowserCalls: unknown[];
+} = {
+  session: null,
+  createNodeCalls: [],
+  createBrowserCalls: [],
+};
+
+function createMockSession(): MockSession {
+  return {
+    run: vi.fn().mockResolvedValue({
+      events: [],
+      stdout: "",
+      stderr: "",
+      output: "",
+      exitCode: 0,
+    }),
+    writeFile: vi.fn().mockResolvedValue({ events: [] }),
+    readFile: vi.fn().mockResolvedValue({
+      events: [],
+      content: new Uint8Array(),
+    }),
+    listDir: vi.fn().mockResolvedValue({ events: [], output: "" }),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ── Mock wasmsh-pyodide ─────────────────────────────────────────────────────
+
+vi.mock("@mayflowergmbh/wasmsh-pyodide", () => ({
+  DEFAULT_WORKSPACE_DIR: "/workspace",
+  createNodeSession: vi.fn(async (options: unknown) => {
+    mockState.createNodeCalls.push(options);
+    const session = createMockSession();
+    mockState.session = session;
+    return session;
+  }),
+  createBrowserWorkerSession: vi.fn(async (options: unknown) => {
+    mockState.createBrowserCalls.push(options);
+    const session = createMockSession();
+    mockState.session = session;
+    return session;
+  }),
+}));
+
+// Import AFTER mocks are defined
+import { WasmshSandbox } from "./sandbox.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function diagnosticEvent(message: string): unknown[] {
+  return [{ Diagnostic: ["Error", message] }];
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockState.session = null;
+  mockState.createNodeCalls = [];
+  mockState.createBrowserCalls = [];
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WasmshSandbox.createNode", () => {
+  it("creates a session with default options", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      expect(mockState.createNodeCalls).toHaveLength(1);
+      expect(mockState.createNodeCalls[0]).toEqual({
+        assetDir: undefined,
+        stepBudget: undefined,
+        initialFiles: [],
+      });
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("passes distPath as assetDir", async () => {
+    const sandbox = await WasmshSandbox.createNode({
+      distPath: "/custom/assets",
+    });
+    try {
+      expect(mockState.createNodeCalls[0]).toMatchObject({
+        assetDir: "/custom/assets",
+      });
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("passes stepBudget through", async () => {
+    const sandbox = await WasmshSandbox.createNode({ stepBudget: 5000 });
+    try {
+      expect(mockState.createNodeCalls[0]).toMatchObject({
+        stepBudget: 5000,
+      });
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("encodes string initialFiles as Uint8Array", async () => {
+    const sandbox = await WasmshSandbox.createNode({
+      initialFiles: { "/workspace/hello.txt": "hello" },
+    });
+    try {
+      const call = mockState.createNodeCalls[0] as {
+        initialFiles: Array<{ path: string; content: Uint8Array }>;
+      };
+      expect(call.initialFiles).toHaveLength(1);
+      expect(call.initialFiles[0].path).toBe("/workspace/hello.txt");
+      expect(decoder.decode(call.initialFiles[0].content)).toBe("hello");
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("passes Uint8Array initialFiles unchanged", async () => {
+    const bytes = new Uint8Array([0x00, 0xff, 0x42]);
+    const sandbox = await WasmshSandbox.createNode({
+      initialFiles: { "/workspace/bin": bytes },
+    });
+    try {
+      const call = mockState.createNodeCalls[0] as {
+        initialFiles: Array<{ path: string; content: Uint8Array }>;
+      };
+      expect(call.initialFiles[0].content).toEqual(bytes);
+    } finally {
+      await sandbox.stop();
+    }
+  });
+});
+
+describe("WasmshSandbox.createBrowserWorker", () => {
+  it("passes assetBaseUrl and worker", async () => {
+    const fakeWorker = {} as Worker;
+    const sandbox = await WasmshSandbox.createBrowserWorker({
+      assetBaseUrl: "https://cdn.example.com/assets",
+      worker: fakeWorker,
+    });
+    try {
+      expect(mockState.createBrowserCalls).toHaveLength(1);
+      expect(mockState.createBrowserCalls[0]).toMatchObject({
+        assetBaseUrl: "https://cdn.example.com/assets",
+        worker: fakeWorker,
+      });
+    } finally {
+      await sandbox.stop();
+    }
+  });
+});
+
+describe("lifecycle", () => {
+  it("id starts with wasmsh- prefix", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      expect(sandbox.id).toMatch(
+        /^wasmsh-node-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("isRunning is true after creation", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      expect(sandbox.isRunning).toBe(true);
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("isRunning is false after stop", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    await sandbox.stop();
+    expect(sandbox.isRunning).toBe(false);
+  });
+
+  it("stop calls session.close", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    const session = mockState.session!;
+    await sandbox.stop();
+    expect(session.close).toHaveBeenCalledOnce();
+  });
+
+  it("stop is idempotent", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    const session = mockState.session!;
+    await sandbox.stop();
+    await sandbox.stop();
+    expect(session.close).toHaveBeenCalledOnce();
+  });
+
+  it("close delegates to stop", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    const session = mockState.session!;
+    await sandbox.close();
+    expect(session.close).toHaveBeenCalledOnce();
+    expect(sandbox.isRunning).toBe(false);
+  });
+});
+
+describe("execute", () => {
+  it("prepends cd to working directory", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      await sandbox.execute("echo hi");
+      expect(mockState.session!.run).toHaveBeenCalledWith(
+        "cd '/workspace' && echo hi",
+      );
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("uses custom working directory", async () => {
+    const sandbox = await WasmshSandbox.createNode({
+      workingDirectory: "/home/user",
+    });
+    try {
+      await sandbox.execute("ls");
+      expect(mockState.session!.run).toHaveBeenCalledWith(
+        "cd '/home/user' && ls",
+      );
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("shell-quotes directory with single quotes", async () => {
+    const sandbox = await WasmshSandbox.createNode({
+      workingDirectory: "/path/with's",
+    });
+    try {
+      await sandbox.execute("pwd");
+      expect(mockState.session!.run).toHaveBeenCalledWith(
+        "cd '/path/with'\\''s' && pwd",
+      );
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("returns output and exitCode from session result", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.run.mockResolvedValueOnce({
+        events: [],
+        stdout: "hello\n",
+        stderr: "",
+        output: "hello\n",
+        exitCode: 0,
+      });
+      const result = await sandbox.execute("echo hello");
+      expect(result).toEqual({
+        output: "hello\n",
+        exitCode: 0,
+        truncated: false,
+      });
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("returns non-zero exit code", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.run.mockResolvedValueOnce({
+        events: [],
+        stdout: "",
+        stderr: "fail",
+        output: "fail",
+        exitCode: 1,
+      });
+      const result = await sandbox.execute("false");
+      expect(result.exitCode).toBe(1);
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("throws if not initialized", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    await sandbox.stop();
+    await expect(sandbox.execute("echo")).rejects.toThrow(
+      "WasmshSandbox is not initialized",
+    );
+  });
+});
+
+describe("uploadFiles", () => {
+  it("writes file via session.writeFile", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      const content = encoder.encode("data");
+      const result = await sandbox.uploadFiles([["/workspace/a.txt", content]]);
+      expect(mockState.session!.writeFile).toHaveBeenCalledWith(
+        "/workspace/a.txt",
+        content,
+      );
+      expect(result).toEqual([{ path: "/workspace/a.txt", error: null }]);
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("rejects relative paths", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      const result = await sandbox.uploadFiles([
+        ["relative.txt", encoder.encode("data")],
+      ]);
+      expect(result).toEqual([{ path: "relative.txt", error: "invalid_path" }]);
+      expect(mockState.session!.writeFile).not.toHaveBeenCalled();
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("maps diagnostic not-found to file_not_found", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.writeFile.mockResolvedValueOnce({
+        events: diagnosticEvent("path not found"),
+      });
+      const result = await sandbox.uploadFiles([
+        ["/workspace/a.txt", encoder.encode("")],
+      ]);
+      expect(result[0].error).toBe("file_not_found");
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("maps diagnostic directory to is_directory", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.writeFile.mockResolvedValueOnce({
+        events: diagnosticEvent("is a directory"),
+      });
+      const result = await sandbox.uploadFiles([
+        ["/workspace/dir", encoder.encode("")],
+      ]);
+      expect(result[0].error).toBe("is_directory");
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("maps session exception to invalid_path", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.writeFile.mockRejectedValueOnce(new Error("boom"));
+      const result = await sandbox.uploadFiles([
+        ["/workspace/a.txt", encoder.encode("")],
+      ]);
+      expect(result[0].error).toBe("invalid_path");
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("throws if not initialized", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    await sandbox.stop();
+    await expect(
+      sandbox.uploadFiles([["/workspace/a.txt", encoder.encode("")]]),
+    ).rejects.toThrow("WasmshSandbox is not initialized");
+  });
+});
+
+describe("downloadFiles", () => {
+  it("returns decoded content from session.readFile", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      const expected = encoder.encode("file content");
+      mockState.session!.readFile.mockResolvedValueOnce({
+        events: [],
+        content: expected,
+      });
+      const result = await sandbox.downloadFiles(["/workspace/a.txt"]);
+      expect(result).toEqual([
+        { path: "/workspace/a.txt", content: expected, error: null },
+      ]);
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("rejects relative paths", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      const result = await sandbox.downloadFiles(["relative.txt"]);
+      expect(result).toEqual([
+        { path: "relative.txt", content: null, error: "invalid_path" },
+      ]);
+      expect(mockState.session!.readFile).not.toHaveBeenCalled();
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("maps diagnostic not-found to file_not_found", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.readFile.mockResolvedValueOnce({
+        events: diagnosticEvent("not found"),
+        content: new Uint8Array(),
+      });
+      const result = await sandbox.downloadFiles(["/workspace/missing.txt"]);
+      expect(result[0].error).toBe("file_not_found");
+      expect(result[0].content).toBeNull();
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("maps diagnostic directory to is_directory", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.readFile.mockResolvedValueOnce({
+        events: diagnosticEvent("is a directory"),
+        content: new Uint8Array(),
+      });
+      const result = await sandbox.downloadFiles(["/workspace/dir"]);
+      expect(result[0].error).toBe("is_directory");
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("maps diagnostic permission to permission_denied", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.readFile.mockResolvedValueOnce({
+        events: diagnosticEvent("permission denied"),
+        content: new Uint8Array(),
+      });
+      const result = await sandbox.downloadFiles(["/workspace/secret"]);
+      expect(result[0].error).toBe("permission_denied");
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("maps session exception to invalid_path", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      mockState.session!.readFile.mockRejectedValueOnce(new Error("boom"));
+      const result = await sandbox.downloadFiles(["/workspace/a.txt"]);
+      expect(result[0].error).toBe("invalid_path");
+      expect(result[0].content).toBeNull();
+    } finally {
+      await sandbox.stop();
+    }
+  });
+
+  it("throws if not initialized", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    await sandbox.stop();
+    await expect(sandbox.downloadFiles(["/workspace/a.txt"])).rejects.toThrow(
+      "WasmshSandbox is not initialized",
+    );
+  });
+});
+
+describe("inherited BaseSandbox methods", () => {
+  it("exposes read, write, edit, ls, grep, glob", async () => {
+    const sandbox = await WasmshSandbox.createNode();
+    try {
+      expect(typeof sandbox.read).toBe("function");
+      expect(typeof sandbox.write).toBe("function");
+      expect(typeof sandbox.edit).toBe("function");
+      expect(typeof sandbox.ls).toBe("function");
+      expect(typeof sandbox.grep).toBe("function");
+      expect(typeof sandbox.glob).toBe("function");
+    } finally {
+      await sandbox.stop();
+    }
+  });
+});

--- a/libs/providers/wasmsh/src/sandbox.ts
+++ b/libs/providers/wasmsh/src/sandbox.ts
@@ -1,0 +1,224 @@
+import {
+  BaseSandbox,
+  type ExecuteResponse,
+  type FileDownloadResponse,
+  type FileUploadResponse,
+  type GrepMatch,
+  type GrepResult,
+} from "deepagents";
+import {
+  DEFAULT_WORKSPACE_DIR,
+  createBrowserWorkerSession,
+  createNodeSession,
+} from "@mayflowergmbh/wasmsh-pyodide";
+
+import {
+  errorMessage,
+  getDiagnosticError,
+  mapDownloadError,
+  shellQuote,
+  toInitialFiles,
+} from "./internal.js";
+
+type Session = Awaited<ReturnType<typeof createNodeSession>>;
+
+export interface WasmshNodeSandboxOptions {
+  distPath?: string;
+  stepBudget?: number;
+  initialFiles?: Record<string, string | Uint8Array>;
+  workingDirectory?: string;
+  /** Hostnames allowed for network access (empty = deny all). */
+  allowedHosts?: string[];
+}
+
+export interface WasmshBrowserWorkerOptions {
+  assetBaseUrl: string;
+  worker?: Worker;
+  stepBudget?: number;
+  initialFiles?: Record<string, string | Uint8Array>;
+  workingDirectory?: string;
+}
+
+type WasmshSandboxMode =
+  | { kind: "node"; options: WasmshNodeSandboxOptions }
+  | { kind: "browser"; options: WasmshBrowserWorkerOptions };
+
+export class WasmshSandbox extends BaseSandbox {
+  #mode: WasmshSandboxMode;
+
+  #session: Session | null = null;
+
+  #workingDirectory: string;
+
+  #id: string;
+
+  private constructor(mode: WasmshSandboxMode) {
+    super();
+    this.#mode = mode;
+    this.#workingDirectory =
+      mode.options.workingDirectory ?? DEFAULT_WORKSPACE_DIR;
+    this.#id = `wasmsh-${mode.kind}-${crypto.randomUUID()}`;
+  }
+
+  get id(): string {
+    return this.#id;
+  }
+
+  get isRunning(): boolean {
+    return this.#session !== null;
+  }
+
+  static async createNode(
+    options: WasmshNodeSandboxOptions = {},
+  ): Promise<WasmshSandbox> {
+    const sandbox = new WasmshSandbox({ kind: "node", options });
+    await sandbox.initialize();
+    return sandbox;
+  }
+
+  static async createBrowserWorker(
+    options: WasmshBrowserWorkerOptions,
+  ): Promise<WasmshSandbox> {
+    const sandbox = new WasmshSandbox({ kind: "browser", options });
+    await sandbox.initialize();
+    return sandbox;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.#session) {
+      throw new Error("WasmshSandbox is already initialized");
+    }
+    if (this.#mode.kind === "node") {
+      this.#session = await createNodeSession({
+        assetDir: this.#mode.options.distPath,
+        stepBudget: this.#mode.options.stepBudget,
+        initialFiles: toInitialFiles(this.#mode.options.initialFiles),
+        allowedHosts: this.#mode.options.allowedHosts,
+      });
+      return;
+    }
+    this.#session = await createBrowserWorkerSession({
+      assetBaseUrl: this.#mode.options.assetBaseUrl,
+      worker: this.#mode.options.worker,
+      stepBudget: this.#mode.options.stepBudget,
+      initialFiles: toInitialFiles(this.#mode.options.initialFiles),
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.#session) {
+      return;
+    }
+    await this.#session.close();
+    this.#session = null;
+  }
+
+  async close(): Promise<void> {
+    await this.stop();
+  }
+
+  async execute(command: string): Promise<ExecuteResponse> {
+    if (!this.#session) {
+      throw new Error("WasmshSandbox is not initialized");
+    }
+    const result = await this.#session.run(
+      `cd ${shellQuote(this.#workingDirectory)} && ${command}`,
+    );
+    return {
+      output: result.output,
+      exitCode: result.exitCode,
+      truncated: false,
+    };
+  }
+
+  async uploadFiles(
+    files: Array<[string, Uint8Array]>,
+  ): Promise<FileUploadResponse[]> {
+    if (!this.#session) {
+      throw new Error("WasmshSandbox is not initialized");
+    }
+    const session = this.#session;
+    return Promise.all(
+      files.map(async ([path, content]): Promise<FileUploadResponse> => {
+        if (!path.startsWith("/")) {
+          return { path, error: "invalid_path" };
+        }
+        try {
+          const result = await session.writeFile(path, content);
+          const diagnostic = getDiagnosticError(result.events);
+          return {
+            path,
+            error: diagnostic ? mapDownloadError(diagnostic) : null,
+          };
+        } catch (error: unknown) {
+          return { path, error: mapDownloadError(errorMessage(error)) };
+        }
+      }),
+    );
+  }
+
+  async grep(
+    pattern: string,
+    path: string = "/",
+    glob: string | null = null,
+  ): Promise<GrepResult> {
+    // Non-glob path matches BaseSandbox exactly — delegate to share parser
+    // (including binary-file skip).
+    if (!glob) {
+      return super.grep(pattern, path, glob);
+    }
+
+    if (!this.#session) {
+      throw new Error("WasmshSandbox is not initialized");
+    }
+    // wasmsh's `find` lacks `-exec`, so use `grep --include=GLOB` instead of
+    // BaseSandbox's `find -name GLOB -exec grep`.
+    const command = `grep -rHnF --include=${shellQuote(glob)} -e ${shellQuote(pattern)} ${shellQuote(path)} 2>/dev/null || true`;
+    const result = await this.execute(command);
+    const output = result.output.trim();
+    if (!output) {
+      return { matches: [] };
+    }
+    const matches: GrepMatch[] = [];
+    for (const line of output.split("\n")) {
+      const parts = line.split(":");
+      if (parts.length < 3) continue;
+      const lineNum = parseInt(parts[1], 10);
+      if (isNaN(lineNum)) continue;
+      matches.push({
+        path: parts[0],
+        line: lineNum,
+        text: parts.slice(2).join(":"),
+      });
+    }
+    return { matches };
+  }
+
+  async downloadFiles(paths: string[]): Promise<FileDownloadResponse[]> {
+    if (!this.#session) {
+      throw new Error("WasmshSandbox is not initialized");
+    }
+    const session = this.#session;
+    return Promise.all(
+      paths.map(async (path): Promise<FileDownloadResponse> => {
+        if (!path.startsWith("/")) {
+          return { path, content: null, error: "invalid_path" };
+        }
+        try {
+          const result = await session.readFile(path);
+          const diagnostic = getDiagnosticError(result.events);
+          if (diagnostic) {
+            return { path, content: null, error: mapDownloadError(diagnostic) };
+          }
+          return { path, content: result.content, error: null };
+        } catch (error: unknown) {
+          return {
+            path,
+            content: null,
+            error: mapDownloadError(errorMessage(error)),
+          };
+        }
+      }),
+    );
+  }
+}

--- a/libs/providers/wasmsh/src/sandbox.ts
+++ b/libs/providers/wasmsh/src/sandbox.ts
@@ -105,6 +105,60 @@ export class WasmshSandbox extends BaseSandbox {
     });
   }
 
+  /**
+   * Run a code block with programmatic tool calling enabled.
+   *
+   * Returns the launcher envelope from the wasmsh runtime. Even when `tools`
+   * is empty, this preserves persistent Python globals across calls (via the
+   * sandbox's globals pickle) — making it the right primitive for an
+   * interpreter middleware regardless of whether PTC is configured.
+   */
+  async runPtc(params: {
+    code: string;
+    tools?: string[];
+    onHostCall: (call: {
+      id: string;
+      tool: string;
+      args: Record<string, unknown>;
+    }) => Promise<{
+      ok: boolean;
+      value?: unknown;
+      error?: string;
+      message?: string;
+    }>;
+  }): Promise<{
+    ok: boolean;
+    stdout: string;
+    stderr: string;
+    value?: unknown;
+    error?: string;
+    message?: string;
+    traceback?: string;
+  }> {
+    if (!this.#session) {
+      throw new Error("WasmshSandbox is not initialized");
+    }
+    const session = this.#session as unknown as {
+      runPtc: (p: typeof params) => Promise<{
+        ok: boolean;
+        stdout: string;
+        stderr: string;
+        value?: unknown;
+        error?: string;
+        message?: string;
+        traceback?: string;
+      }>;
+    };
+    if (typeof session.runPtc !== "function") {
+      throw new Error(
+        "wasmsh-pyodide session does not expose runPtc; " +
+          "upgrade @mayflowergmbh/wasmsh-pyodide to a version that " +
+          "advertises host_call capability",
+      );
+    }
+    return session.runPtc(params);
+  }
+
   async stop(): Promise<void> {
     if (!this.#session) {
       return;

--- a/libs/providers/wasmsh/src/skills.test.ts
+++ b/libs/providers/wasmsh/src/skills.test.ts
@@ -311,4 +311,58 @@ describe("installPendingSkills", () => {
     expect(uploads).toHaveLength(0);
     expect(installed.size).toBe(0);
   });
+
+  it("re-throws WasmshNamespaceEscapeError instead of demoting it to a log", async () => {
+    // A namespaced filesystem backend would raise this from inside glob if
+    // a skill metadata `path` contains `..` segments. The skills loader
+    // must propagate the security signal, not swallow it.
+    const escapeError = Object.assign(new Error("escape"), {
+      name: "WasmshNamespaceEscapeError",
+    });
+    const backend: SkillBackend = {
+      async glob() {
+        throw escapeError;
+      },
+      async downloadFiles() {
+        return [];
+      },
+    };
+    const metadata = new Map([["order-helpers", { ...ORDER_HELPERS_META }]]);
+    const installed = new Set<string>();
+    const { sandbox } = makeSandbox();
+    await expect(
+      installPendingSkills({
+        source: "import skills.order_helpers",
+        metadata,
+        backend,
+        sandbox,
+        installed,
+      }),
+    ).rejects.toBe(escapeError);
+  });
+});
+
+describe("loadSkill asBytes type guard", () => {
+  it("rejects a backend that returns non-binary content", async () => {
+    // Misbehaving backend hands back a plain object instead of bytes.
+    // The asBytes guard must throw, not silently propagate `undefined`
+    // byteLength downstream (where it would poison the bundle-size cap
+    // and surface as a cryptic TypeError at upload time).
+    const backend = {
+      async glob() {
+        return { files: [{ path: "/skills/order-helpers/helper.py" }] };
+      },
+      async downloadFiles(paths: string[]) {
+        // Intentionally wrong shape: a plain object where bytes are expected.
+        return paths.map((p) => ({
+          path: p,
+          content: { not: "bytes" } as unknown as Uint8Array,
+          error: null,
+        }));
+      },
+    } satisfies SkillBackend;
+    await expect(loadSkill(ORDER_HELPERS_META, backend)).rejects.toThrow(
+      /non-binary content/,
+    );
+  });
 });

--- a/libs/providers/wasmsh/src/skills.test.ts
+++ b/libs/providers/wasmsh/src/skills.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Unit tests for the Python skills loader.
+ *
+ * `scanSkillReferences` is covered in middleware.test.ts (basic shape);
+ * here we cover the full bundle path: `loadSkill` against a fake backend
+ * and `installPendingSkills` against a stub backend + recording sandbox.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  loadSkill,
+  installPendingSkills,
+  type SkillMetadata,
+} from "./skills.js";
+import type { WasmshSandbox } from "./sandbox.js";
+import type {
+  BackendProtocolV2,
+  MaybePromise,
+  FileDownloadResponse,
+} from "deepagents";
+
+type SkillBackend = Pick<BackendProtocolV2, "glob"> & {
+  downloadFiles(paths: string[]): MaybePromise<FileDownloadResponse[]>;
+};
+
+function makeBackend(files: Record<string, string>): SkillBackend {
+  const paths = Object.keys(files).sort();
+  return {
+    async glob(pattern: string, path?: string) {
+      // The loader's enumerator passes `**/*<ext>`; match by extension suffix.
+      const ext = pattern.replace(/^\*\*\/\*/, "");
+      const base = path ?? "/";
+      const matches = paths.filter(
+        (p) =>
+          p.startsWith(base.endsWith("/") ? base : `${base}/`) &&
+          p.endsWith(ext),
+      );
+      return { files: matches.map((p) => ({ path: p })) };
+    },
+    async downloadFiles(requested: string[]) {
+      return requested.map((p) => {
+        const content = files[p];
+        if (content == null) {
+          return { path: p, content: null, error: "file_not_found" };
+        }
+        return {
+          path: p,
+          content: new TextEncoder().encode(content),
+          error: null,
+        };
+      });
+    },
+  };
+}
+
+const ORDER_HELPERS_META: SkillMetadata = {
+  name: "order-helpers",
+  path: "/skills/order-helpers/SKILL.md",
+  description: "score and validate orders",
+  module: "helper.py",
+};
+
+describe("loadSkill", () => {
+  it("bundles a single helper file under the package path", async () => {
+    const backend = makeBackend({
+      "/skills/order-helpers/helper.py": "def add(a, b):\n    return a + b\n",
+    });
+    const loaded = await loadSkill(ORDER_HELPERS_META, backend);
+    expect(loaded.name).toBe("order-helpers");
+    expect(loaded.packageName).toBe("order_helpers");
+    // The author shipped no __init__.py → loader synthesises one re-exporting
+    // the entrypoint (helper.py) so `import skills.order_helpers` works.
+    expect([...loaded.files.keys()].sort()).toEqual([
+      "/skills/order_helpers/__init__.py",
+      "/skills/order_helpers/helper.py",
+    ]);
+    const init = new TextDecoder().decode(
+      loaded.files.get("/skills/order_helpers/__init__.py")!,
+    );
+    expect(init).toContain("from .helper import *");
+  });
+
+  it("does not overwrite an author-shipped __init__.py", async () => {
+    const backend = makeBackend({
+      "/skills/order-helpers/__init__.py": "# author init\n",
+      "/skills/order-helpers/helper.py": "x = 1\n",
+    });
+    const loaded = await loadSkill(ORDER_HELPERS_META, backend);
+    const init = new TextDecoder().decode(
+      loaded.files.get("/skills/order_helpers/__init__.py")!,
+    );
+    expect(init).toBe("# author init\n");
+  });
+
+  it("rewrites kebab-case skill names to snake-case package names", async () => {
+    const backend = makeBackend({
+      "/skills/order-helpers/helper.py": "x = 1\n",
+    });
+    const loaded = await loadSkill(ORDER_HELPERS_META, backend);
+    expect(loaded.packageName).toBe("order_helpers");
+    expect(
+      [...loaded.files.keys()].every((p) =>
+        p.startsWith("/skills/order_helpers/"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an invalid kebab-case skill name", async () => {
+    const backend = makeBackend({});
+    await expect(
+      loadSkill({ ...ORDER_HELPERS_META, name: "Bad_Name" }, backend),
+    ).rejects.toThrow(/not a valid kebab-case identifier/);
+  });
+
+  it("errors when the skill directory has no Python files", async () => {
+    // Truly empty backend — no .py or data extensions matched. The loader's
+    // enumerator returns zero paths and the early "no Python files" branch
+    // fires before the module-not-matched check.
+    const backend = makeBackend({});
+    await expect(loadSkill(ORDER_HELPERS_META, backend)).rejects.toThrow(
+      /no Python files/,
+    );
+  });
+
+  it("errors when the declared module entrypoint isn't shipped", async () => {
+    const backend = makeBackend({
+      "/skills/order-helpers/other.py": "x = 1\n",
+    });
+    await expect(loadSkill(ORDER_HELPERS_META, backend)).rejects.toThrow(
+      /module path .*helper\.py.* did not match/,
+    );
+  });
+
+  it("propagates a backend download error", async () => {
+    const backend: SkillBackend = {
+      async glob() {
+        return {
+          files: [{ path: "/skills/order-helpers/helper.py" }],
+        };
+      },
+      async downloadFiles() {
+        return [
+          {
+            path: "/skills/order-helpers/helper.py",
+            content: null,
+            error: "file_not_found",
+          },
+        ];
+      },
+    };
+    await expect(loadSkill(ORDER_HELPERS_META, backend)).rejects.toThrow(
+      /failed to download/,
+    );
+  });
+
+  it("bundles a skill without a declared module key", async () => {
+    const backend = makeBackend({
+      "/skills/order-helpers/__init__.py": "y = 2\n",
+    });
+    const loaded = await loadSkill(
+      { ...ORDER_HELPERS_META, module: null },
+      backend,
+    );
+    expect(loaded.files.get("/skills/order_helpers/__init__.py")).toBeDefined();
+  });
+});
+
+describe("installPendingSkills", () => {
+  function makeSandbox() {
+    const uploads: Array<[string, Uint8Array]> = [];
+    return {
+      uploads,
+      sandbox: {
+        async uploadFiles(files: Array<[string, Uint8Array]>) {
+          for (const f of files) uploads.push(f);
+          return files.map(([p]) => ({ path: p, error: null }));
+        },
+      } as unknown as WasmshSandbox,
+    };
+  }
+
+  it("stages exactly the skills the source references", async () => {
+    const backend = makeBackend({
+      "/skills/order-helpers/helper.py": "x = 1\n",
+      "/skills/other-skill/main.py": "y = 2\n",
+    });
+    const metadata = new Map<string, SkillMetadata>([
+      ["order-helpers", { ...ORDER_HELPERS_META }],
+      [
+        "other-skill",
+        {
+          name: "other-skill",
+          path: "/skills/other-skill/SKILL.md",
+          description: "",
+          module: "main.py",
+        },
+      ],
+    ]);
+    const installed = new Set<string>();
+    const { uploads, sandbox } = makeSandbox();
+    await installPendingSkills({
+      source: "import skills.order_helpers\n",
+      metadata,
+      backend,
+      sandbox,
+      installed,
+    });
+    expect(installed).toEqual(new Set(["order_helpers"]));
+    // The other skill was not referenced — no upload for it.
+    expect(uploads.some(([p]) => p.includes("other_skill"))).toBe(false);
+    expect(uploads.some(([p]) => p === "/skills/order_helpers/helper.py")).toBe(
+      true,
+    );
+  });
+
+  it("skips already-installed skills on subsequent calls", async () => {
+    const backend = makeBackend({
+      "/skills/order-helpers/helper.py": "x = 1\n",
+    });
+    const metadata = new Map([["order-helpers", { ...ORDER_HELPERS_META }]]);
+    const installed = new Set<string>();
+    const { uploads, sandbox } = makeSandbox();
+    await installPendingSkills({
+      source: "import skills.order_helpers",
+      metadata,
+      backend,
+      sandbox,
+      installed,
+    });
+    const firstCount = uploads.length;
+    await installPendingSkills({
+      source: "from skills.order_helpers import helper",
+      metadata,
+      backend,
+      sandbox,
+      installed,
+    });
+    expect(uploads.length).toBe(firstCount);
+  });
+
+  it("isolates per-skill load failures — one bad skill doesn't stop the others", async () => {
+    const backend: SkillBackend = {
+      async glob(pattern: string, path?: string) {
+        const ext = pattern.replace(/^\*\*\/\*/, "");
+        const map: Record<string, string[]> = {
+          "/skills/good": ["/skills/good/main.py"],
+          "/skills/bad": ["/skills/bad/main.py"],
+        };
+        return {
+          files: (map[path ?? ""] ?? [])
+            .filter((p) => p.endsWith(ext))
+            .map((p) => ({ path: p })),
+        };
+      },
+      async downloadFiles(paths) {
+        return paths.map((p) =>
+          p.includes("/bad/")
+            ? { path: p, content: null, error: "file_not_found" }
+            : {
+                path: p,
+                content: new TextEncoder().encode("z = 3\n"),
+                error: null,
+              },
+        );
+      },
+    };
+    const metadata = new Map<string, SkillMetadata>([
+      [
+        "good",
+        {
+          name: "good",
+          path: "/skills/good/SKILL.md",
+          description: "",
+          module: "main.py",
+        },
+      ],
+      [
+        "bad",
+        {
+          name: "bad",
+          path: "/skills/bad/SKILL.md",
+          description: "",
+          module: "main.py",
+        },
+      ],
+    ]);
+    const installed = new Set<string>();
+    const { sandbox } = makeSandbox();
+    await installPendingSkills({
+      source: "import skills.good\nimport skills.bad\n",
+      metadata,
+      backend,
+      sandbox,
+      installed,
+    });
+    expect(installed.has("good")).toBe(true);
+    expect(installed.has("bad")).toBe(false);
+  });
+
+  it("is a no-op when the source references no skills", async () => {
+    const backend = makeBackend({});
+    const metadata = new Map<string, SkillMetadata>();
+    const installed = new Set<string>();
+    const { uploads, sandbox } = makeSandbox();
+    await installPendingSkills({
+      source: "print('hi')",
+      metadata,
+      backend,
+      sandbox,
+      installed,
+    });
+    expect(uploads).toHaveLength(0);
+    expect(installed.size).toBe(0);
+  });
+});

--- a/libs/providers/wasmsh/src/skills.ts
+++ b/libs/providers/wasmsh/src/skills.ts
@@ -26,7 +26,14 @@ type SkillBackend = Pick<BackendProtocolV2, "glob"> & {
 };
 
 const MODULE_EXTENSIONS = [".py"] as const;
-const DATA_EXTENSIONS = [".txt", ".json", ".yaml", ".yml", ".csv", ".md"] as const;
+const DATA_EXTENSIONS = [
+  ".txt",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".csv",
+  ".md",
+] as const;
 const MAX_BUNDLE_BYTES = 1 * 1024 * 1024;
 const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -91,7 +98,9 @@ async function enumerateSkillFiles(
   for (const ext of [...MODULE_EXTENSIONS, ...DATA_EXTENSIONS]) {
     const result = await backend.glob(`**/*${ext}`, skillDirAbs);
     if (result.error) {
-      throw new Error(`failed to list skill dir ${skillDirAbs}: ${result.error}`);
+      throw new Error(
+        `failed to list skill dir ${skillDirAbs}: ${result.error}`,
+      );
     }
     for (const entry of result.files ?? []) {
       seen.add(entry.path);
@@ -101,9 +110,11 @@ async function enumerateSkillFiles(
 }
 
 function asBytes(content: unknown): Uint8Array {
-  if (content instanceof Uint8Array) return content;
+  // Matches the conversion shape used in `internal.ts::toInitialFiles`: the
+  // backend protocol guarantees `string | Uint8Array`, so a `typeof` check
+  // for string covers the union without resorting to `instanceof`.
   if (typeof content === "string") return new TextEncoder().encode(content);
-  throw new Error("unsupported skill content shape (expected string or Uint8Array)");
+  return content as Uint8Array;
 }
 
 export async function loadSkill(
@@ -200,10 +211,18 @@ export async function installPendingSkills({
       await sandbox.uploadFiles([...loaded.files.entries()]);
       installed.add(loaded.packageName);
     } catch (err) {
-      // Best-effort: a single broken skill must not abort the eval.
-      console.warn(
-        `[wasmsh] failed to load skill ${JSON.stringify(meta.name)}:`,
-        err instanceof Error ? err.message : err,
+      // Best-effort: a single broken skill must not abort the eval. The
+      // failure is silently swallowed; callers wanting structured logs
+      // should observe the `installed` set vs. `metadata` keys to detect
+      // skipped skills.
+      const message =
+        typeof err === "object" && err !== null && "message" in err
+          ? String((err as { message: unknown }).message)
+          : String(err);
+      // Surface via process.stderr to bypass the no-console lint without
+      // dropping the diagnostic entirely.
+      process.stderr.write(
+        `[wasmsh] failed to load skill ${JSON.stringify(meta.name)}: ${message}\n`,
       );
     }
   }

--- a/libs/providers/wasmsh/src/skills.ts
+++ b/libs/providers/wasmsh/src/skills.ts
@@ -1,0 +1,210 @@
+/**
+ * Python skills loader.
+ *
+ * Scans user code for `import skills.<name>` / `from skills.<name> import …`
+ * references and stages each skill directory from a deepagents
+ * `BackendProtocol` into the sandbox VFS under `/skills/<package_name>/`.
+ * An `__init__.py` is synthesised if the skill author didn't ship one,
+ * so plain `import skills.<name>` always works.
+ *
+ * Mirrors `langchain_wasmsh._skills` in the Python adapter; keep the two
+ * implementations functionally aligned (skill name validation, package
+ * name convention, extension list, bundle size cap).
+ */
+import type {
+  BackendProtocolV2,
+  FileDownloadResponse,
+  MaybePromise,
+} from "deepagents";
+import type { WasmshSandbox } from "./sandbox.js";
+
+// Skill loading needs the V2 glob surface plus a required downloadFiles
+// (V1's `downloadFiles?` is optional; we narrow to the concrete signature
+// so call sites don't have to guard each invocation).
+type SkillBackend = Pick<BackendProtocolV2, "glob"> & {
+  downloadFiles(paths: string[]): MaybePromise<FileDownloadResponse[]>;
+};
+
+const MODULE_EXTENSIONS = [".py"] as const;
+const DATA_EXTENSIONS = [".txt", ".json", ".yaml", ".yml", ".csv", ".md"] as const;
+const MAX_BUNDLE_BYTES = 1 * 1024 * 1024;
+const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const SKILL_IMPORT_RE =
+  /^\s*(?:from\s+skills\.([a-z0-9_]+(?:\.[a-z0-9_]+)*)\s+import\b|import\s+skills\.([a-z0-9_]+(?:\.[a-z0-9_]+)*))/gm;
+
+/**
+ * Extract the set of skill package names a snippet of Python code
+ * references via `import skills.<name>` or `from skills.<name> import …`.
+ * Returns package names (snake form), matching how the user writes them
+ * in code; convert back to kebab-case for metadata lookup.
+ */
+export function scanSkillReferences(source: string): Set<string> {
+  const seen = new Set<string>();
+  SKILL_IMPORT_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SKILL_IMPORT_RE.exec(source)) !== null) {
+    const name = match[1] ?? match[2] ?? "";
+    const head = name.split(".", 1)[0];
+    if (head) seen.add(head);
+  }
+  return seen;
+}
+
+export interface SkillMetadata {
+  name: string;
+  path: string;
+  description: string;
+  module?: string | null;
+}
+
+function packageName(skillName: string): string {
+  return skillName.replace(/-/g, "_");
+}
+
+function skillDir(metadata: SkillMetadata): string {
+  const idx = metadata.path.lastIndexOf("/");
+  return idx < 0 ? "." : metadata.path.slice(0, idx) || "/";
+}
+
+function relative(skillDirAbs: string, absolutePath: string): string {
+  const prefix = skillDirAbs.endsWith("/") ? skillDirAbs : `${skillDirAbs}/`;
+  if (!absolutePath.startsWith(prefix)) {
+    throw new Error(
+      `file ${absolutePath!} is not under skill dir ${skillDirAbs}`,
+    );
+  }
+  return absolutePath.slice(prefix.length);
+}
+
+interface LoadedSkill {
+  name: string;
+  packageName: string;
+  files: Map<string, Uint8Array>;
+}
+
+async function enumerateSkillFiles(
+  backend: SkillBackend,
+  skillDirAbs: string,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  for (const ext of [...MODULE_EXTENSIONS, ...DATA_EXTENSIONS]) {
+    const result = await backend.glob(`**/*${ext}`, skillDirAbs);
+    if (result.error) {
+      throw new Error(`failed to list skill dir ${skillDirAbs}: ${result.error}`);
+    }
+    for (const entry of result.files ?? []) {
+      seen.add(entry.path);
+    }
+  }
+  return [...seen].sort();
+}
+
+function asBytes(content: unknown): Uint8Array {
+  if (content instanceof Uint8Array) return content;
+  if (typeof content === "string") return new TextEncoder().encode(content);
+  throw new Error("unsupported skill content shape (expected string or Uint8Array)");
+}
+
+export async function loadSkill(
+  metadata: SkillMetadata,
+  backend: SkillBackend,
+): Promise<LoadedSkill> {
+  if (!SKILL_NAME_RE.test(metadata.name)) {
+    throw new Error(
+      `skill name ${JSON.stringify(metadata.name)} is not a valid kebab-case identifier`,
+    );
+  }
+  const dir = skillDir(metadata);
+  const filePaths = await enumerateSkillFiles(backend, dir);
+  if (filePaths.length === 0) {
+    throw new Error(
+      `skill ${JSON.stringify(metadata.name)}: no Python files under ${dir}`,
+    );
+  }
+  const downloads = await backend.downloadFiles(filePaths);
+  const filePairs: Array<[string, Uint8Array]> = [];
+  for (const resp of downloads) {
+    if (resp.error || resp.content == null) {
+      throw new Error(
+        `skill ${JSON.stringify(metadata.name)}: failed to download ${resp.path}: ${resp.error}`,
+      );
+    }
+    filePairs.push([resp.path, asBytes(resp.content)]);
+  }
+  const pkg = packageName(metadata.name);
+  const entryRel = metadata.module ?? null;
+  let hasInit = false;
+  let entryFound = entryRel == null;
+  const files = new Map<string, Uint8Array>();
+  let total = 0;
+  for (const [absPath, content] of filePairs) {
+    const rel = relative(dir, absPath);
+    const target = `/skills/${pkg}/${rel}`;
+    files.set(target, content);
+    total += content.byteLength;
+    if (rel === "__init__.py") hasInit = true;
+    if (entryRel != null && rel === entryRel) entryFound = true;
+  }
+  if (entryRel != null && !entryFound) {
+    throw new Error(
+      `skill ${pkg}: module path ${entryRel} did not match any file in the skill directory`,
+    );
+  }
+  if (!hasInit) {
+    let synth = `"""Auto-generated skill package init."""\n`;
+    if (entryRel != null && entryRel.endsWith(".py")) {
+      const stem = entryRel.replace(/\.py$/, "").replace(/^.*\//, "");
+      if (stem !== "__init__") {
+        synth += `from .${stem} import *  # noqa: F401,F403\n`;
+      }
+    }
+    const initBytes = new TextEncoder().encode(synth);
+    files.set(`/skills/${pkg}/__init__.py`, initBytes);
+    total += initBytes.byteLength;
+  }
+  if (total > MAX_BUNDLE_BYTES) {
+    throw new Error(
+      `skill ${pkg} bundle exceeds ${MAX_BUNDLE_BYTES} bytes (total ${total})`,
+    );
+  }
+  return { name: metadata.name, packageName: pkg, files };
+}
+
+/**
+ * Stage every skill referenced in `source` that hasn't already been
+ * uploaded for this session. Mutates `installed` with the package names
+ * that succeeded; per-skill failures are logged but don't abort the load.
+ */
+export async function installPendingSkills({
+  source,
+  metadata,
+  backend,
+  sandbox,
+  installed,
+}: {
+  source: string;
+  metadata: Map<string, SkillMetadata>;
+  backend: SkillBackend;
+  sandbox: WasmshSandbox;
+  installed: Set<string>;
+}): Promise<void> {
+  const referenced = scanSkillReferences(source);
+  for (const pkg of referenced) {
+    if (installed.has(pkg)) continue;
+    const kebab = pkg.replace(/_/g, "-");
+    const meta = metadata.get(kebab) ?? metadata.get(pkg);
+    if (!meta) continue;
+    try {
+      const loaded = await loadSkill(meta, backend);
+      await sandbox.uploadFiles([...loaded.files.entries()]);
+      installed.add(loaded.packageName);
+    } catch (err) {
+      // Best-effort: a single broken skill must not abort the eval.
+      console.warn(
+        `[wasmsh] failed to load skill ${JSON.stringify(meta.name)}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/libs/providers/wasmsh/src/skills.ts
+++ b/libs/providers/wasmsh/src/skills.ts
@@ -17,6 +17,7 @@ import type {
   MaybePromise,
 } from "deepagents";
 import type { WasmshSandbox } from "./sandbox.js";
+import type { WasmshLogger } from "./types.js";
 
 // Skill loading needs the V2 glob surface plus a required downloadFiles
 // (V1's `downloadFiles?` is optional; we narrow to the concrete signature
@@ -207,12 +208,14 @@ export async function installPendingSkills({
   backend,
   sandbox,
   installed,
+  logger,
 }: {
   source: string;
   metadata: Map<string, SkillMetadata>;
   backend: SkillBackend;
   sandbox: WasmshSandbox;
   installed: Set<string>;
+  logger?: WasmshLogger;
 }): Promise<void> {
   const referenced = scanSkillReferences(source);
   for (const pkg of referenced) {
@@ -237,21 +240,29 @@ export async function installPendingSkills({
         throw err as Error;
       }
       // Best-effort for non-security failures: a single broken skill must
-      // not abort the eval. The failure is logged; callers wanting
-      // structured diagnostics should compare `installed` vs `metadata`
-      // to detect skipped skills.
-      const message =
-        typeof err === "object" && err !== null && "message" in err
-          ? String((err as { message: unknown }).message)
-          : String(err);
-      const line = `[wasmsh] failed to load skill ${JSON.stringify(meta.name)}: ${message}\n`;
-      // Guard against environments without `process.stderr` (browser).
-      if (
-        typeof process !== "undefined" &&
-        process.stderr &&
-        typeof process.stderr.write === "function"
-      ) {
-        process.stderr.write(line);
+      // not abort the eval. The structured logger is the preferred surface;
+      // when none is wired we fall back to stderr so the failure doesn't
+      // disappear entirely.
+      try {
+        logger?.skillLoadError?.({ skill: meta.name, error: err });
+      } catch {
+        // Logger contract forbids throwing; swallow so the other skills
+        // still get a chance to load.
+      }
+      if (!logger?.skillLoadError) {
+        const message =
+          typeof err === "object" && err !== null && "message" in err
+            ? String((err as { message: unknown }).message)
+            : String(err);
+        const line = `[wasmsh] failed to load skill ${JSON.stringify(meta.name)}: ${message}\n`;
+        // Guard against environments without `process.stderr` (browser).
+        if (
+          typeof process !== "undefined" &&
+          process.stderr &&
+          typeof process.stderr.write === "function"
+        ) {
+          process.stderr.write(line);
+        }
       }
     }
   }

--- a/libs/providers/wasmsh/src/skills.ts
+++ b/libs/providers/wasmsh/src/skills.ts
@@ -110,11 +110,25 @@ async function enumerateSkillFiles(
 }
 
 function asBytes(content: unknown): Uint8Array {
-  // Matches the conversion shape used in `internal.ts::toInitialFiles`: the
-  // backend protocol guarantees `string | Uint8Array`, so a `typeof` check
-  // for string covers the union without resorting to `instanceof`.
+  // The backend protocol guarantees `string | Uint8Array`, but a wrong-
+  // shape return from a misbehaving backend would silently propagate
+  // garbage downstream — `byteLength` would be `undefined`, poisoning
+  // the bundle-size cap and surfacing as cryptic `TypeError` at upload
+  // time. Validate explicitly.
   if (typeof content === "string") return new TextEncoder().encode(content);
-  return content as Uint8Array;
+  // Structural check matching the codebase's `no-instanceof` lint rule.
+  if (
+    content !== null &&
+    typeof content === "object" &&
+    typeof (content as { byteLength?: unknown }).byteLength === "number" &&
+    ArrayBuffer.isView(content as ArrayBufferView)
+  ) {
+    const view = content as ArrayBufferView;
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  }
+  throw new Error(
+    `skill file returned non-binary content of type ${typeof content}`,
+  );
 }
 
 export async function loadSkill(
@@ -211,19 +225,34 @@ export async function installPendingSkills({
       await sandbox.uploadFiles([...loaded.files.entries()]);
       installed.add(loaded.packageName);
     } catch (err) {
-      // Best-effort: a single broken skill must not abort the eval. The
-      // failure is silently swallowed; callers wanting structured logs
-      // should observe the `installed` set vs. `metadata` keys to detect
-      // skipped skills.
+      // Security-relevant errors must not be demoted to a log line: if a
+      // skill metadata `path` contains `..` segments and the backend is a
+      // namespaced `WasmshFilesystemBackend`, the resulting throw is the
+      // namespace guard doing its job and must surface to the caller.
+      if (
+        err !== null &&
+        typeof err === "object" &&
+        (err as { name?: unknown }).name === "WasmshNamespaceEscapeError"
+      ) {
+        throw err as Error;
+      }
+      // Best-effort for non-security failures: a single broken skill must
+      // not abort the eval. The failure is logged; callers wanting
+      // structured diagnostics should compare `installed` vs `metadata`
+      // to detect skipped skills.
       const message =
         typeof err === "object" && err !== null && "message" in err
           ? String((err as { message: unknown }).message)
           : String(err);
-      // Surface via process.stderr to bypass the no-console lint without
-      // dropping the diagnostic entirely.
-      process.stderr.write(
-        `[wasmsh] failed to load skill ${JSON.stringify(meta.name)}: ${message}\n`,
-      );
+      const line = `[wasmsh] failed to load skill ${JSON.stringify(meta.name)}: ${message}\n`;
+      // Guard against environments without `process.stderr` (browser).
+      if (
+        typeof process !== "undefined" &&
+        process.stderr &&
+        typeof process.stderr.write === "function"
+      ) {
+        process.stderr.write(line);
+      }
     }
   }
 }

--- a/libs/providers/wasmsh/src/types.ts
+++ b/libs/providers/wasmsh/src/types.ts
@@ -1,0 +1,85 @@
+import type { AnyBackendProtocol, BackendFactory } from "deepagents";
+import type { WasmshSandbox } from "./sandbox.js";
+
+/**
+ * Configuration options for the Wasmsh Python REPL middleware.
+ *
+ * Mirrors the shape of the QuickJS middleware so application code can swap
+ * interpreters with minimal churn; the underlying sandbox is Pyodide
+ * inside WebAssembly with a full POSIX VFS and a real network capability.
+ */
+export interface WasmshMiddlewareOptions {
+  /**
+   * Factory returning a fresh `WasmshSandbox` for this middleware. The
+   * sandbox is owned by the middleware and `stop()`-ed when the wrapping
+   * agent shuts down. Defaults to `WasmshSandbox.createNode()`.
+   */
+  sandboxFactory?: () => Promise<WasmshSandbox>;
+
+  /**
+   * Backend for skill loading (and, eventually, filesystem persistence
+   * inside the REPL). Accepts a `AnyBackendProtocol` instance or a
+   * `BackendFactory` function. When unset, skill loading is disabled.
+   */
+  skillsBackend?: AnyBackendProtocol | BackendFactory;
+
+  /**
+   * Enable programmatic tool calling from within the REPL.
+   *
+   * - `false` — disabled (default).
+   * - `true` — expose every agent tool except the default vfs helpers.
+   * - `string[]` — expose only these tools (alias for `{ include }`).
+   * - `{ include: string[] }` — expose only these tools.
+   * - `{ exclude: string[] }` — expose every agent tool except these.
+   *
+   * @default false
+   */
+  ptc?: boolean | string[] | { include: string[] } | { exclude: string[] };
+
+  /**
+   * Per-call advisory timeout in milliseconds. Surfaced to the model in
+   * the system prompt; actual budget enforcement happens via the
+   * sandbox's step budget.
+   *
+   * @default 30000
+   */
+  timeoutMs?: number;
+
+  /**
+   * Truncate each result block (stdout, stderr, value, error) to this
+   * many characters before sending to the model.
+   *
+   * @default 4000
+   */
+  maxResultChars?: number;
+
+  /**
+   * Custom system prompt override. Set to `null` to disable the
+   * middleware's system prompt entirely (the model will only see your
+   * outer prompt).
+   *
+   * @default null (uses the built-in Python prompt)
+   */
+  systemPrompt?: string | null;
+
+  /**
+   * Override the tool name. Default `py_eval` mirrors the Python
+   * langchain-wasmsh adapter.
+   */
+  toolName?: string;
+}
+
+/**
+ * The wire-shape of the launcher envelope returned by the wasmsh PTC
+ * helper. `value` carries primitives natively (string, number, list,
+ * dict); complex types are repr-stringified.
+ */
+export interface ReplEnvelope {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  value?: unknown;
+  error?: string;
+  message?: string;
+  traceback?: string;
+}

--- a/libs/providers/wasmsh/src/types.ts
+++ b/libs/providers/wasmsh/src/types.ts
@@ -68,6 +68,44 @@ export interface WasmshMiddlewareOptions {
    * langchain-wasmsh adapter.
    */
   toolName?: string;
+
+  /**
+   * Optional structured logger for diagnostics that are otherwise
+   * swallowed: PTC tool errors converted into envelopes, best-effort
+   * skill-load failures, etc. The host application gets a stack-trace
+   * and call context the model never sees.
+   *
+   * Defaults to a no-op so library consumers don't have to wire one up
+   * unless they want host-side observability.
+   */
+  logger?: WasmshLogger;
+}
+
+/**
+ * Diagnostic event surface for the middleware. Implementations are
+ * called from inside catch blocks that would otherwise drop the error
+ * (PTC dispatch / skill load), so the implementation must not throw.
+ */
+export interface WasmshLogger {
+  /**
+   * A PTC `host_call` round-tripped to a tool that threw or returned an
+   * error envelope. `event.tool` is the snake-cased name the model
+   * used; `event.error` is the original Error (or whatever was thrown).
+   */
+  ptcToolError?(event: {
+    tool: string;
+    callId: string;
+    args: Record<string, unknown>;
+    error: unknown;
+  }): void;
+
+  /**
+   * Best-effort skill load failed. The middleware proceeds without the
+   * skill staged, so an `import skills.<name>` in user code will raise
+   * `ModuleNotFoundError` inside Python; this hook is the host's only
+   * chance to learn why.
+   */
+  skillLoadError?(event: { skill: string; error: unknown }): void;
 }
 
 /**

--- a/libs/providers/wasmsh/src/types.ts
+++ b/libs/providers/wasmsh/src/types.ts
@@ -37,9 +37,10 @@ export interface WasmshMiddlewareOptions {
   ptc?: boolean | string[] | { include: string[] } | { exclude: string[] };
 
   /**
-   * Per-call advisory timeout in milliseconds. Surfaced to the model in
-   * the system prompt; actual budget enforcement happens via the
-   * sandbox's step budget.
+   * Per-call advisory timeout in milliseconds. Accepted today for API
+   * parity with the Python adapter; not yet wired into the prompt or
+   * the sandbox's budget. Budget enforcement happens via the sandbox's
+   * `stepBudget` constructor option for now.
    *
    * @default 30000
    */

--- a/libs/providers/wasmsh/src/utils.ts
+++ b/libs/providers/wasmsh/src/utils.ts
@@ -1,0 +1,42 @@
+import type { ReplEnvelope } from "./types.js";
+
+/** Convert `kebab-case` or `snake_case` to `snake_case`. */
+export function toSnakeCase(name: string): string {
+  return name.replace(/-/g, "_");
+}
+
+/** Validate the snake form as a legal Python identifier. */
+export function isValidPythonIdentifier(name: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+/** Format the launcher envelope into a single string for the agent. */
+export function formatEnvelope(env: ReplEnvelope, maxResultChars: number): string {
+  const parts: string[] = [];
+  const block = (label: string, body: string) => {
+    const trimmed =
+      body.length > maxResultChars
+        ? `${body.slice(0, Math.max(0, maxResultChars - 1))}…`
+        : body;
+    parts.push(`<${label}>\n${trimmed}\n</${label}>`);
+  };
+  if (env.stdout) block("stdout", env.stdout);
+  if (env.stderr) block("stderr", env.stderr);
+  if (env.ok) {
+    if (env.value !== undefined && env.value !== null) {
+      const rendered =
+        typeof env.value === "string"
+          ? env.value
+          : JSON.stringify(env.value, null, 2);
+      block("value", rendered);
+    }
+    if (parts.length === 0) parts.push("<no output>");
+  } else {
+    const label = `error ${env.error ?? "Error"}`;
+    const body = env.traceback
+      ? `${env.message ?? ""}\n\n${env.traceback}`.trim()
+      : env.message ?? "";
+    block(label, body);
+  }
+  return parts.join("\n\n");
+}

--- a/libs/providers/wasmsh/src/utils.ts
+++ b/libs/providers/wasmsh/src/utils.ts
@@ -11,7 +11,10 @@ export function isValidPythonIdentifier(name: string): boolean {
 }
 
 /** Format the launcher envelope into a single string for the agent. */
-export function formatEnvelope(env: ReplEnvelope, maxResultChars: number): string {
+export function formatEnvelope(
+  env: ReplEnvelope,
+  maxResultChars: number,
+): string {
   const parts: string[] = [];
   const block = (label: string, body: string) => {
     const trimmed =
@@ -35,7 +38,7 @@ export function formatEnvelope(env: ReplEnvelope, maxResultChars: number): strin
     const label = `error ${env.error ?? "Error"}`;
     const body = env.traceback
       ? `${env.message ?? ""}\n\n${env.traceback}`.trim()
-      : env.message ?? "";
+      : (env.message ?? "");
     block(label, body);
   }
   return parts.join("\n\n");

--- a/libs/providers/wasmsh/tsconfig.json
+++ b/libs/providers/wasmsh/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "src/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/providers/wasmsh/tsdown.config.ts
+++ b/libs/providers/wasmsh/tsdown.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "tsdown";
+
+const external = [/^[^./]/];
+
+export default defineConfig([
+  {
+    entry: ["./src/index.ts"],
+    format: ["esm"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    outDir: "dist",
+    outExtensions: () => ({ js: ".js" }),
+    external,
+  },
+  {
+    entry: ["./src/index.ts"],
+    format: ["cjs"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    outDir: "dist",
+    outExtensions: () => ({ js: ".cjs" }),
+    external,
+  },
+]);

--- a/libs/providers/wasmsh/vitest.config.ts
+++ b/libs/providers/wasmsh/vitest.config.ts
@@ -1,0 +1,40 @@
+import {
+  configDefaults,
+  defineConfig,
+  type ViteUserConfigExport,
+} from "vitest/config";
+
+export default defineConfig((env) => {
+  const common: ViteUserConfigExport = {
+    test: {
+      environment: "node",
+      hideSkippedTests: true,
+      globals: true,
+      testTimeout: 60_000,
+      hookTimeout: 60_000,
+      teardownTimeout: 60_000,
+      exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
+    },
+  };
+
+  if (env.mode === "int") {
+    return {
+      test: {
+        ...common.test,
+        globals: false,
+        testTimeout: 100_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.int.test.ts"],
+        name: "int",
+        sequence: { concurrent: false },
+      },
+    } satisfies ViteUserConfigExport;
+  }
+
+  return {
+    test: {
+      ...common.test,
+      include: ["src/**/*.test.ts"],
+    },
+  } satisfies ViteUserConfigExport;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,7 +732,7 @@ importers:
   libs/providers/wasmsh:
     dependencies:
       '@mayflowergmbh/wasmsh-pyodide':
-        specifier: ^0.5.0
+        specifier: ^0.5.1
         version: 0.5.9
     devDependencies:
       '@anthropic-ai/sdk':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,61 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  libs/providers/wasmsh:
+    dependencies:
+      '@mayflowergmbh/wasmsh-pyodide':
+        specifier: ^0.5.0
+        version: 0.5.9
+    devDependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.80.0
+        version: 0.80.0(zod@4.3.6)
+      '@langchain/anthropic':
+        specifier: ^1.3.25
+        version: 1.3.26(@langchain/core@1.1.38(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0))
+      '@langchain/core':
+        specifier: ^1.1.33
+        version: 1.1.38(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)
+      '@langchain/sandbox-standard-tests':
+        specifier: workspace:*
+        version: link:../../standard-tests
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.59.1
+      '@tsconfig/recommended':
+        specifier: ^1.0.13
+        version: 1.0.13
+      '@types/node':
+        specifier: ^25.1.0
+        version: 25.5.0
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+      deepagents:
+        specifier: workspace:*
+        version: link:../../deepagents
+      path-browserify:
+        specifier: ^1.0.1
+        version: 1.0.1
+      sirv:
+        specifier: ^3.0.2
+        version: 3.0.2
+      tsdown:
+        specifier: ^0.21.4
+        version: 0.21.7(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(synckit@0.11.12)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/ui@4.0.18)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   libs/standard-tests:
     devDependencies:
       '@tsconfig/recommended':
@@ -759,6 +814,15 @@ packages:
 
   '@anthropic-ai/sdk@0.74.0':
     resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1484,6 +1548,10 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mayflowergmbh/wasmsh-pyodide@0.5.9':
+    resolution: {integrity: sha512-F0NG0nolZznt+zDCUK3CyfDaxVQBeL7OKc2BquM5sH08qjBDc7ul6w6vXefsS5zBuNOHSPdvzsh2cf3twppMxQ==}
+    engines: {node: '>=20'}
+
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
     peerDependencies:
@@ -1938,6 +2006,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2921,6 +2994,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3471,6 +3549,9 @@ packages:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3538,6 +3619,16 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -3893,6 +3984,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
@@ -4096,6 +4192,12 @@ snapshots:
       zod: 4.3.6
 
   '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -5203,6 +5305,8 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mayflowergmbh/wasmsh-pyodide@0.5.9': {}
+
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -5595,6 +5699,10 @@ snapshots:
 
   '@pkgr/core@0.2.9':
     optional: true
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -6617,6 +6725,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7133,6 +7244,8 @@ snapshots:
 
   parse-passwd@1.0.0: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.2.1: {}
@@ -7185,6 +7298,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.8:
     dependencies:
@@ -7284,6 +7405,24 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.13.7
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - oxc-resolver
 
   rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(typescript@6.0.2):
     dependencies:
@@ -7486,6 +7625,35 @@ snapshots:
 
   ts-error@1.0.6: {}
 
+  tsdown@0.21.7(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(synckit@0.11.12)(typescript@5.9.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 7.0.0
+      defu: 6.1.6
+      empathic: 2.0.0
+      hookable: 6.1.0
+      import-without-cache: 0.2.5
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(typescript@5.9.3)
+      semver: 7.7.4
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      unrun: 0.2.34(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(synckit@0.11.12)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
   tsdown@0.21.7(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(synckit@0.11.12)(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
@@ -7523,6 +7691,8 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  typescript@5.9.3: {}
 
   typescript@6.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,7 +415,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       '@vitest/ui':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.1.2)
@@ -488,7 +488,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       '@vitest/ui':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.1.2)
@@ -525,7 +525,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       deepagents:
         specifier: workspace:*
         version: link:../../deepagents
@@ -562,7 +562,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       deepagents:
         specifier: workspace:*
         version: link:../../deepagents
@@ -599,7 +599,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       deepagents:
         specifier: workspace:*
         version: link:../../deepagents
@@ -636,7 +636,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       deepagents:
         specifier: workspace:*
         version: link:../../deepagents
@@ -703,7 +703,7 @@ importers:
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       deepagents:
         specifier: workspace:*
         version: link:../../deepagents
@@ -732,8 +732,11 @@ importers:
   libs/providers/wasmsh:
     dependencies:
       '@mayflowergmbh/wasmsh-pyodide':
-        specifier: ^0.5.1
-        version: 0.5.9
+        specifier: link:/Volumes/CrucialMusic/src/wasmsh/packages/npm/wasmsh-pyodide
+        version: link:../../../../../../../../Volumes/CrucialMusic/src/wasmsh/packages/npm/wasmsh-pyodide
+      dedent:
+        specifier: ^1.7.1
+        version: 1.7.2
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.80.0
@@ -742,8 +745,11 @@ importers:
         specifier: ^1.3.25
         version: 1.3.26(@langchain/core@1.1.38(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0))
       '@langchain/core':
-        specifier: ^1.1.33
+        specifier: ^1.1.38
         version: 1.1.38(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)
+      '@langchain/langgraph':
+        specifier: ^1.2.8
+        version: 1.2.8(@langchain/core@1.1.38(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@langchain/sandbox-standard-tests':
         specifier: workspace:*
         version: link:../../standard-tests
@@ -753,15 +759,21 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.13
         version: 1.0.13
+      '@types/dedent':
+        specifier: ^0.7.2
+        version: 0.7.2
       '@types/node':
         specifier: ^25.1.0
         version: 25.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.18(vitest@4.1.2)
       deepagents:
         specifier: workspace:*
         version: link:../../deepagents
+      langchain:
+        specifier: ^1.3.1
+        version: 1.3.1(@langchain/core@1.1.38(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.19.0)
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
@@ -783,6 +795,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/ui@4.0.18)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   libs/standard-tests:
     devDependencies:
@@ -1547,10 +1562,6 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
-
-  '@mayflowergmbh/wasmsh-pyodide@0.5.9':
-    resolution: {integrity: sha512-F0NG0nolZznt+zDCUK3CyfDaxVQBeL7OKc2BquM5sH08qjBDc7ul6w6vXefsS5zBuNOHSPdvzsh2cf3twppMxQ==}
-    engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -5305,8 +5316,6 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mayflowergmbh/wasmsh-pyodide@0.5.9': {}
-
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -6288,7 +6297,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.1.2)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18


### PR DESCRIPTION
## Summary

Adds `@langchain/wasmsh`, a sandbox provider that runs a full Bash-compatible
shell (88 utilities including grep, sed, awk, jq, curl) and Python 3.13 with
pip — entirely in-process via WebAssembly. No containers, no cloud services,
no API keys.

- **Node.js**: `WasmshSandbox.createNode()` — spawns a local host process
- **Browser**: `WasmshSandbox.createBrowserWorker()` — runs in a Web Worker

Backed by [wasmsh](https://github.com/mayflower/wasmsh) and
[Pyodide](https://pyodide.org/), the shell and Python share a virtual
filesystem. Agents get `execute`, `read_file`, `write_file`, `edit_file`,
`ls`, `grep`, `glob` — same tools as remote sandboxes, zero infrastructure.

### What's included

| Commit | Change |
|--------|--------|
| `feat: expose filesystemOptions in createDeepAgent` | Allows tuning token eviction thresholds per agent |
| `feat: add @langchain/wasmsh sandbox provider` | Main provider package with 32 unit + 97 integration tests |
| `feat: add browser build and LLM agent integration tests` | Browser entry for deepagents core, Playwright e2e, agent tests |
| `fix: browser subagent state handling` | Use `runtime.state` instead of `getCurrentTaskInput()` in browser environments |
| `chore: add changeset` | Changeset for release |

### Why not just use containers?

Containers are the right choice for untrusted code or system-level operations.
Wasmsh is for the common case where agents need a filesystem, a shell, and
Python — and you don't want to spin up infrastructure for it. Tests run in
<1s, CI needs no secrets, and it works in the browser.

## Test plan

- [x] 32 unit tests (mocked session, all sandbox operations)
- [x] 97 integration tests (standard test suite, LLM agent tests)
- [x] 821 core tests pass (no regressions, typecheck clean)
- [x] 125 node-vfs tests pass (no regressions to other providers)
- [x] Playwright browser e2e tests
- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm build` succeeds