### PR TITLE
feat(deepagents): add namespace factory support to StoreBackend

### DIFF
--- a/.changeset/namespace-factories.md
+++ b/.changeset/namespace-factories.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+feat(deepagents): add namespace factory support to StoreBackend
+
+`StoreBackendOptions.namespace` now accepts a `NamespaceFactory` function `(runtime: Partial<Runtime>) => string[]` for dynamic, per-invocation namespace resolution (e.g. per-user, per-assistant, per-thread storage isolation).

--- a/libs/deepagents/src/backends/index.ts
+++ b/libs/deepagents/src/backends/index.ts
@@ -51,7 +51,11 @@ export {
 } from "./protocol.js";
 
 export { StateBackend } from "./state.js";
-export { StoreBackend, type StoreBackendOptions } from "./store.js";
+export {
+  StoreBackend,
+  type StoreBackendOptions,
+  type NamespaceFactory,
+} from "./store.js";
 export { FilesystemBackend } from "./filesystem.js";
 export { CompositeBackend } from "./composite.js";
 export {

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { StoreBackend } from "./store.js";
+import { StoreBackend, type NamespaceFactory } from "./store.js";
 import type { BackendRuntime } from "./protocol.js";
 import { InMemoryStore } from "@langchain/langgraph-checkpoint";
-import { getStore as getLangGraphStore } from "@langchain/langgraph";
+import { getStore as getLangGraphStore, getConfig } from "@langchain/langgraph";
+import type { Runtime } from "@langchain/langgraph";
 
 vi.mock("@langchain/langgraph", async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as any),
     getStore: vi.fn(),
+    getConfig: vi.fn(),
+    getWriter: vi.fn(),
   };
 });
 
@@ -817,6 +820,227 @@ describe("StoreBackend", () => {
       expect(new TextDecoder().decode(downloadRes[1].content!)).toBe(
         "content2",
       );
+    });
+  });
+
+  describe("namespace factory", () => {
+    /**
+     * Set up mocks for a zero-arg StoreBackend with namespace factory.
+     * Mocks getStore and getConfig to simulate a LangGraph execution context.
+     */
+    function setupFactory(runtimeOverrides: Partial<Runtime> = {}) {
+      const store = new InMemoryStore();
+      vi.mocked(getLangGraphStore).mockReturnValue(store);
+      vi.mocked(getConfig).mockReturnValue(runtimeOverrides as any);
+      return { store };
+    }
+
+    it("should resolve namespace from serverInfo.assistantId", async () => {
+      const { store } = setupFactory({
+        serverInfo: { assistantId: "asst-abc", graphId: "graph-1" },
+      });
+
+      const backend = new StoreBackend({
+        namespace: (runtime) => [runtime.serverInfo!.assistantId, "filesystem"],
+      });
+
+      await backend.write("/test.txt", "assistant-scoped");
+
+      const items = await store.search(["asst-abc", "filesystem"]);
+      expect(items.some((item) => item.key === "/test.txt")).toBe(true);
+
+      const defaultItems = await store.search(["filesystem"]);
+      expect(defaultItems.some((item) => item.key === "/test.txt")).toBe(false);
+    });
+
+    it("should resolve namespace from serverInfo.user.identity", async () => {
+      const { store } = setupFactory({
+        serverInfo: {
+          assistantId: "asst-abc",
+          graphId: "graph-1",
+          user: { identity: "user-42" },
+        },
+      });
+
+      const backend = new StoreBackend({
+        namespace: (runtime) => [runtime.serverInfo!.user!.identity],
+      });
+
+      await backend.write("/notes.md", "user-scoped");
+
+      const items = await store.search(["user-42"]);
+      expect(items.some((item) => item.key === "/notes.md")).toBe(true);
+    });
+
+    it("should resolve namespace from executionInfo.threadId", async () => {
+      const { store } = setupFactory({
+        executionInfo: {
+          threadId: "thread-xyz",
+          checkpointId: "cp-1",
+          checkpointNs: "",
+          taskId: "task-1",
+          nodeAttempt: 1,
+        },
+      });
+
+      const backend = new StoreBackend({
+        namespace: (runtime) => [
+          runtime.executionInfo!.threadId!,
+          "filesystem",
+        ],
+      });
+
+      await backend.write("/test.txt", "thread-scoped");
+
+      const items = await store.search(["thread-xyz", "filesystem"]);
+      expect(items.some((item) => item.key === "/test.txt")).toBe(true);
+    });
+
+    it("should support composite namespace (assistantId + userId)", async () => {
+      const { store } = setupFactory({
+        serverInfo: {
+          assistantId: "asst-abc",
+          graphId: "graph-1",
+          user: { identity: "user-42" },
+        },
+      });
+
+      const backend = new StoreBackend({
+        namespace: (runtime) => [
+          runtime.serverInfo!.assistantId,
+          runtime.serverInfo!.user!.identity,
+        ],
+      });
+
+      await backend.write("/mem.md", "user-within-assistant");
+
+      const items = await store.search(["asst-abc", "user-42"]);
+      expect(items.some((item) => item.key === "/mem.md")).toBe(true);
+    });
+
+    it("should call factory on every operation", async () => {
+      setupFactory({
+        serverInfo: { assistantId: "asst-1", graphId: "graph-1" },
+      });
+
+      const factory: NamespaceFactory = vi.fn((runtime) => [
+        runtime.serverInfo!.assistantId,
+        "fs",
+      ]);
+
+      const backend = new StoreBackend({ namespace: factory });
+
+      await backend.write("/a.txt", "first");
+      expect(factory).toHaveBeenCalledTimes(1);
+
+      await backend.read("/a.txt");
+      expect(factory).toHaveBeenCalledTimes(2);
+
+      await backend.ls("/");
+      expect(factory).toHaveBeenCalledTimes(3);
+    });
+
+    it("should validate factory-produced namespace", () => {
+      setupFactory();
+
+      const backend = new StoreBackend({
+        namespace: () => ["filesystem", "*"],
+      });
+      expect(() => backend["getNamespace"]()).toThrow("disallowed characters");
+    });
+
+    it("should throw if factory returns empty namespace", () => {
+      setupFactory();
+
+      const backend = new StoreBackend({ namespace: () => [] });
+      expect(() => backend["getNamespace"]()).toThrow("must not be empty");
+    });
+
+    it("should isolate data between users via factory", async () => {
+      const store = new InMemoryStore();
+      vi.mocked(getLangGraphStore).mockReturnValue(store);
+
+      const backend = new StoreBackend({
+        namespace: (runtime) => [
+          runtime.serverInfo!.user!.identity,
+          "filesystem",
+        ],
+      });
+
+      // Simulate user A
+      vi.mocked(getConfig).mockReturnValue({
+        serverInfo: {
+          assistantId: "asst-1",
+          graphId: "g-1",
+          user: { identity: "alice" },
+        },
+      } as any);
+      await backend.write("/notes.txt", "Alice's notes");
+
+      // Simulate user B
+      vi.mocked(getConfig).mockReturnValue({
+        serverInfo: {
+          assistantId: "asst-1",
+          graphId: "g-1",
+          user: { identity: "bob" },
+        },
+      } as any);
+      await backend.write("/notes.txt", "Bob's notes");
+
+      const aliceItems = await store.search(["alice", "filesystem"]);
+      expect(aliceItems).toHaveLength(1);
+      expect((aliceItems[0].value as any).content).toBe("Alice's notes");
+
+      const bobItems = await store.search(["bob", "filesystem"]);
+      expect(bobItems).toHaveLength(1);
+      expect((bobItems[0].value as any).content).toBe("Bob's notes");
+    });
+
+    it("should gracefully degrade outside execution context", async () => {
+      const store = new InMemoryStore();
+      vi.mocked(getLangGraphStore).mockReturnValue(store);
+      vi.mocked(getConfig).mockImplementation(() => {
+        throw new Error("No execution context");
+      });
+
+      const backend = new StoreBackend({
+        namespace: () => ["fallback", "filesystem"],
+      });
+
+      await backend.write("/test.txt", "works outside context");
+
+      const items = await store.search(["fallback", "filesystem"]);
+      expect(items.some((item) => item.key === "/test.txt")).toBe(true);
+    });
+
+    it("should receive the runtime from getConfig()", async () => {
+      const mockRuntime = {
+        serverInfo: { assistantId: "asst-1", graphId: "g-1" },
+        executionInfo: {
+          threadId: "t-1",
+          checkpointId: "cp-1",
+          checkpointNs: "",
+          taskId: "task-1",
+          nodeAttempt: 1,
+        },
+        context: { userId: "u-1" },
+      };
+      setupFactory(mockRuntime);
+
+      let captured: Partial<Runtime> | undefined;
+      const backend = new StoreBackend({
+        namespace: (runtime) => {
+          captured = runtime;
+          return ["test"];
+        },
+      });
+
+      await backend.write("/x.txt", "test");
+
+      expect(captured).toBeDefined();
+      expect(captured!.serverInfo!.assistantId).toBe("asst-1");
+      expect(captured!.executionInfo!.threadId).toBe("t-1");
+      expect(captured!.context).toEqual({ userId: "u-1" });
     });
   });
 });

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -2,7 +2,13 @@
  * StoreBackend: Adapter for LangGraph's BaseStore (persistent, cross-thread).
  */
 
-import { Item, getStore as getLangGraphStore } from "@langchain/langgraph";
+import {
+  Item,
+  getStore as getLangGraphStore,
+  getConfig,
+  getWriter,
+} from "@langchain/langgraph";
+import type { Runtime } from "@langchain/langgraph";
 import type {
   BackendOptions,
   BackendProtocolV2,
@@ -70,31 +76,68 @@ function validateNamespace(namespace: string[]): string[] {
 }
 
 /**
+ * Factory function that computes a store namespace from the LangGraph
+ * {@link Runtime} at invocation time.
+ *
+ * Called on every backend operation so the namespace can vary per-user,
+ * per-thread, per-assistant, etc.  Must return a non-empty `string[]`
+ * whose components contain only safe characters (alphanumeric, `-`, `_`,
+ * `.`, `@`, `+`, `:`, `~`).
+ *
+ * @example
+ * ```typescript
+ * import { StoreBackend } from "deepagents";
+ *
+ * // Per-user
+ * new StoreBackend({
+ *   namespace: (runtime) => [runtime.serverInfo!.user!.identity],
+ * });
+ *
+ * // Per-assistant
+ * new StoreBackend({
+ *   namespace: (runtime) => [runtime.serverInfo!.assistantId],
+ * });
+ *
+ * // Per-thread
+ * new StoreBackend({
+ *   namespace: (runtime) => [runtime.executionInfo!.threadId!],
+ * });
+ * ```
+ */
+export type NamespaceFactory = (runtime: Partial<Runtime>) => string[];
+
+/**
  * Options for StoreBackend constructor.
  */
 export interface StoreBackendOptions extends BackendOptions {
   /**
-   * Custom namespace for store operations.
+   * Namespace for store operations — either a static `string[]` or a
+   * {@link NamespaceFactory} that derives the namespace from the LangGraph
+   * {@link Runtime} at invocation time.
    *
    * Determines where files are stored in the LangGraph store, enabling
-   * user-scoped, org-scoped, or any custom isolation pattern.
+   * user-scoped, per-thread, per-assistant, or any custom isolation pattern.
    *
-   * If not provided, falls back to legacy behavior using assistantId from {@link BackendRuntime}.
+   * If not provided, falls back to legacy `assistantId`-based isolation or
+   * `["filesystem"]` as a last resort.
    *
    * @example
    * ```typescript
-   * // User-scoped storage
-   * new StoreBackend(runtime, {
-   *   namespace: ["memories", orgId, userId, "filesystem"],
+   * // Static namespace
+   * new StoreBackend({ namespace: ["org-123", "user-456", "filesystem"] });
+   *
+   * // Per-user (dynamic)
+   * new StoreBackend({
+   *   namespace: (runtime) => [runtime.serverInfo!.user!.identity],
    * });
    *
-   * // Org-scoped storage
-   * new StoreBackend(runtime, {
-   *   namespace: ["memories", orgId, "filesystem"],
+   * // Per-thread (dynamic)
+   * new StoreBackend({
+   *   namespace: (runtime) => [runtime.executionInfo!.threadId!],
    * });
    * ```
    */
-  namespace?: string[];
+  namespace?: string[] | NamespaceFactory;
 }
 
 /**
@@ -109,7 +152,7 @@ export interface StoreBackendOptions extends BackendOptions {
  */
 export class StoreBackend implements BackendProtocolV2 {
   private stateAndStore: StateAndStore | undefined;
-  private _namespace: string[] | undefined;
+  private _namespace: string[] | NamespaceFactory | undefined;
   private fileFormat: "v1" | "v2";
 
   constructor(options?: StoreBackendOptions);
@@ -136,7 +179,11 @@ export class StoreBackend implements BackendProtocolV2 {
     }
 
     if (opts?.namespace) {
-      this._namespace = validateNamespace(opts.namespace);
+      if (typeof opts.namespace === "function") {
+        this._namespace = opts.namespace;
+      } else {
+        this._namespace = validateNamespace(opts.namespace);
+      }
     }
     this.fileFormat = opts?.fileFormat ?? "v2";
   }
@@ -172,16 +219,40 @@ export class StoreBackend implements BackendProtocolV2 {
   }
 
   /**
+   * Assemble a {@link Runtime} from the LangGraph execution-context accessors
+   * ({@link getConfig}, {@link getLangGraphStore}, {@link getWriter}).
+   *
+   * Returns `Partial<Runtime>` because `interrupt` and `signal` have no
+   * standalone accessors.  Falls back to `{}` outside an execution context.
+   */
+  private static getRuntime(): Partial<Runtime> {
+    try {
+      const config = getConfig();
+      return {
+        ...config,
+        store: getLangGraphStore() ?? config.store,
+        writer: getWriter() ?? config.writer,
+      };
+    } catch {
+      return {};
+    }
+  }
+
+  /**
    * Get the namespace for store operations.
    *
    * Resolution order:
-   * 1. Explicit namespace from constructor options (both modes)
-   * 2. Legacy mode: `[assistantId, "filesystem"]` fallback from {@link StateAndStore}
-   * 3. Zero-arg mode without namespace: `["filesystem"]` with a deprecation warning
-   *    nudging callers to pass an explicit namespace
-   * 4. Legacy mode without assistantId: `["filesystem"]`
+   * 1. Namespace factory — called with a {@link Runtime} assembled from the
+   *    current LangGraph execution context. Result is validated.
+   * 2. Explicit static namespace from constructor options
+   * 3. Legacy mode: `[assistantId, "filesystem"]` fallback from {@link StateAndStore}
+   * 4. Default: `["filesystem"]`
    */
   protected getNamespace(): string[] {
+    if (typeof this._namespace === "function") {
+      return validateNamespace(this._namespace(StoreBackend.getRuntime()));
+    }
+
     if (this._namespace) {
       return this._namespace;
     }

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -97,6 +97,7 @@ export {
   StateBackend,
   StoreBackend,
   type StoreBackendOptions,
+  type NamespaceFactory,
   FilesystemBackend,
   CompositeBackend,
   BaseSandbox,


### PR DESCRIPTION
## Summary

`StoreBackend.namespace` now accepts a `NamespaceFactory` function in addition to a static `string[]`, enabling dynamic per-invocation namespace resolution. This lets users scope storage by user, assistant, thread, or any combination derived from the LangGraph `Runtime` — without the deprecated `BackendFactory` pattern.

## Changes

### `deepagents` — `store.ts`

- New `NamespaceFactory` type: `(runtime: Partial<Runtime>) => string[]`. The factory receives a `Partial<Runtime>` assembled from LangGraph's execution-context accessors (`getConfig`, `getStore`, `getWriter`) — no wrapper types, just the LangGraph `Runtime` directly.
- `StoreBackendOptions.namespace` widened to `string[] | NamespaceFactory`. Static arrays are validated eagerly at construction; factories are validated at call time.
- New `StoreBackend.getRuntime()` static method assembles a `Partial<Runtime>` from the execution context. Falls back to `{}` outside a graph execution (e.g. tests).
- `getNamespace()` updated to call the factory on every operation when present, then validate the result through the existing namespace component rules.

### `deepagents` — exports

- `NamespaceFactory` exported from `backends/index.ts` and `src/index.ts`.

### `deepagents` — `store.test.ts`

- 10 new tests: resolution from `serverInfo.assistantId`, `serverInfo.user.identity`, `executionInfo.threadId`; composite namespaces; per-invocation calling semantics; validation of factory output; multi-user isolation; graceful degradation outside execution context; runtime passthrough verification.
