### PR TITLE
fix: follow symlinks in sandbox find commands

### DIFF
--- a/.changeset/fix-follow-symlinks.md
+++ b/.changeset/fix-follow-symlinks.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix: follow symlinks in sandbox find commands by adding -L flag to find invocations in buildLsCommand, buildFindCommand, and buildGrepCommand

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -179,6 +179,8 @@ describe("BaseSandbox", () => {
       expect(sandbox.executedCommands[0]).toContain("-maxdepth 1");
     });
 
+    // Symlinked volumes (e.g. Modal) are invisible without -L.
+    // See: https://github.com/langchain-ai/deepagentsjs/issues/447
     it("should include -L flag to follow symlinks", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/test.txt", "content");
@@ -642,6 +644,8 @@ describe("BaseSandbox", () => {
       expect(result.matches!.length).toBe(0);
     });
 
+    // Symlinked volumes (e.g. Modal) are invisible without -L.
+    // See: https://github.com/langchain-ai/deepagentsjs/issues/447
     it("should include -L flag to follow symlinks when glob pattern is provided", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/test.txt", "hello world");
@@ -712,6 +716,8 @@ describe("BaseSandbox", () => {
       );
     });
 
+    // Symlinked volumes (e.g. Modal) are invisible without -L.
+    // See: https://github.com/langchain-ai/deepagentsjs/issues/447
     it("should include -L flag to follow symlinks", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/test.py", "print('hello')");

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -179,8 +179,6 @@ describe("BaseSandbox", () => {
       expect(sandbox.executedCommands[0]).toContain("-maxdepth 1");
     });
 
-    // Symlinked volumes (e.g. Modal) are invisible without -L.
-    // See: https://github.com/langchain-ai/deepagentsjs/issues/447
     it("should include -L flag to follow symlinks", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/test.txt", "content");
@@ -644,8 +642,6 @@ describe("BaseSandbox", () => {
       expect(result.matches!.length).toBe(0);
     });
 
-    // Symlinked volumes (e.g. Modal) are invisible without -L.
-    // See: https://github.com/langchain-ai/deepagentsjs/issues/447
     it("should include -L flag to follow symlinks when glob pattern is provided", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/test.txt", "hello world");
@@ -716,8 +712,6 @@ describe("BaseSandbox", () => {
       );
     });
 
-    // Symlinked volumes (e.g. Modal) are invisible without -L.
-    // See: https://github.com/langchain-ai/deepagentsjs/issues/447
     it("should include -L flag to follow symlinks", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/test.py", "print('hello')");

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -179,6 +179,14 @@ describe("BaseSandbox", () => {
       expect(sandbox.executedCommands[0]).toContain("-maxdepth 1");
     });
 
+    it("should include -L flag to follow symlinks", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.addFile("/test.txt", "content");
+
+      await sandbox.ls("/");
+      expect(sandbox.executedCommands[0]).toMatch(/find\s+-L\s+/);
+    });
+
     it("should return empty array for non-existent directory", async () => {
       const sandbox = new MockSandbox();
       // Mock execute to return error
@@ -634,6 +642,14 @@ describe("BaseSandbox", () => {
       expect(result.matches!.length).toBe(0);
     });
 
+    it("should include -L flag to follow symlinks when glob pattern is provided", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.addFile("/test.txt", "hello world");
+
+      await sandbox.grep("hello", "/", "*.txt");
+      expect(sandbox.executedCommands[0]).toMatch(/find\s+-L\s+/);
+    });
+
     it("should skip binary files in grep results", async () => {
       const sandbox = new MockSandbox();
       // Mock grep returning matches from both text and binary files
@@ -694,6 +710,14 @@ describe("BaseSandbox", () => {
       expect(result.files!.some((f) => f.path === "src/utils/helper.ts")).toBe(
         true,
       );
+    });
+
+    it("should include -L flag to follow symlinks", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.addFile("/test.py", "print('hello')");
+
+      await sandbox.glob("*.py", "/");
+      expect(sandbox.executedCommands[0]).toMatch(/find\s+-L\s+/);
     });
 
     it("should return empty array for no matches", async () => {

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -175,7 +175,7 @@ const STAT_C_SCRIPT =
  */
 function buildLsCommand(dirPath: string): string {
   const quotedPath = shellQuote(dirPath);
-  const findBase = `find ${quotedPath} -maxdepth 1 -not -path ${quotedPath}`;
+  const findBase = `find -L ${quotedPath} -maxdepth 1 -not -path ${quotedPath}`;
   return (
     `if find /dev/null -maxdepth 0 -printf '' 2>/dev/null; then ` +
     `${findBase} -printf '%s\\t%T@\\t%y\\t%p\\n' 2>/dev/null; ` +
@@ -195,7 +195,7 @@ function buildLsCommand(dirPath: string): string {
  */
 function buildFindCommand(searchPath: string): string {
   const quotedPath = shellQuote(searchPath);
-  const findBase = `find ${quotedPath} -not -path ${quotedPath}`;
+  const findBase = `find -L ${quotedPath} -not -path ${quotedPath}`;
   return (
     `if find /dev/null -maxdepth 0 -printf '' 2>/dev/null; then ` +
     `${findBase} -printf '%s\\t%T@\\t%y\\t%p\\n' 2>/dev/null; ` +
@@ -257,7 +257,7 @@ function buildGrepCommand(
   if (globPattern) {
     // Use find + grep for BusyBox compatibility (BusyBox grep lacks --include)
     const globEscaped = shellQuote(globPattern);
-    return `find ${searchPathQuoted} -type f -name ${globEscaped} -exec grep -HnF -e ${patternEscaped} {} + 2>/dev/null || true`;
+    return `find -L ${searchPathQuoted} -type f -name ${globEscaped} -exec grep -HnF -e ${patternEscaped} {} + 2>/dev/null || true`;
   }
 
   return `grep -rHnF -e ${patternEscaped} ${searchPathQuoted} 2>/dev/null || true`;


### PR DESCRIPTION
## Summary

- Add `-L` flag to `find` in `buildLsCommand`, `buildFindCommand`, and `buildGrepCommand` so that symlinks are followed
- Fixes #447

## Problem

`BaseSandbox` helper functions use `find` without `-L`, which means symbolic links are not dereferenced. On Modal (and potentially other providers), volumes are mounted as symlinks, so the `ls`, `glob`, and `grep` sandbox tools all return empty results when pointed at symlinked paths.

## Fix

The `-L` flag tells `find` to follow symbolic links. This is a one-line change in each of the three helper functions:

```diff
- find ${quotedPath} -maxdepth 1 ...
+ find -L ${quotedPath} -maxdepth 1 ...
```

This matches user expectations — filesystem exploration tools should transparently follow symlinks, just like `ls` and `find -L` do in a normal shell.

## Test plan

- [ ] Verify `ls` tool returns files when the target path is a symlink
- [ ] Verify `glob` tool traverses symlinked directories
- [ ] Verify `grep` tool searches inside symlinked directories
- [ ] Confirm no regression on non-symlinked paths (behavior is identical when no symlinks are present)