### PR TITLE
fix(deepagents): remove unconditional @langchain/anthropic import

### DIFF
--- a/.changeset/hot-berries-arrive.md
+++ b/.changeset/hot-berries-arrive.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+remove unconditional @langchain/anthropic import

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -162,7 +162,7 @@ export function createDeepAgent<
   >,
 ) {
   const {
-    model = "claude-sonnet-4-6",
+    model = "anthropic:claude-sonnet-4-6",
     tools = [],
     systemPrompt,
     middleware: customMiddleware = [],

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -7,7 +7,6 @@ import {
   type AgentMiddleware,
   context,
 } from "langchain";
-import { ChatAnthropic } from "@langchain/anthropic";
 import type {
   ClientTool,
   ServerTool,
@@ -163,7 +162,7 @@ export function createDeepAgent<
   >,
 ) {
   const {
-    model = new ChatAnthropic("claude-sonnet-4-6"),
+    model = "claude-sonnet-4-6",
     tools = [],
     systemPrompt,
     middleware: customMiddleware = [],


### PR DESCRIPTION
## Summary

Fixes #443

- Removed static `import { ChatAnthropic } from "@langchain/anthropic"` at module level
- Changed default `model` parameter from `new ChatAnthropic("claude-sonnet-4-6")` to the string `"claude-sonnet-4-6"`

## Problem

`deepagents@1.9.0` unconditionally imported `@langchain/anthropic` at the top of `agent.ts`. Bundlers follow static imports regardless of which model the user actually uses, causing builds to fail for users who only use other providers (e.g. `ChatOpenAI`) and don't have `@langchain/anthropic` installed.

## Solution

`createAgent` from `langchain` natively accepts a model name string (`string | AgentLanguageModelLike`), so no `ChatAnthropic` instantiation is needed at the library level. With a string default, bundlers have no static reference to `@langchain/anthropic` and can tree-shake it entirely.

Users who want Anthropic models can either:
- Pass `new ChatAnthropic(...)` explicitly (requires `@langchain/anthropic` in their own `package.json`)
- Rely on the `"claude-sonnet-4-6"` string default (also requires `@langchain/anthropic` at runtime, but no longer breaks builds for non-Anthropic users)