### PR TITLE
ci: add PR title lint workflow

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,18 +1,32 @@
-name: PR Title Lint
+# PR title linting.
+#
+# Enforces Conventional Commits format for pull request titles.
+name: "PR Title Lint"
 
 permissions:
-  contents: read
+  pull-requests: read
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize]
 
 jobs:
   lint-pr-title:
+    name: "validate format"
     runs-on: ubuntu-latest
     steps:
-      - name: Validate PR Title
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - name: "Reject empty scope"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ ^[a-z]+\(\)[!]?: ]]; then
+            echo "::error::PR title has empty scope parentheses: '$PR_TITLE'"
+            echo "Either remove the parentheses or provide a scope (e.g., 'fix(core): ...')."
+            exit 1
+          fi
+
+      - name: "Validate Conventional Commits format"
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -29,6 +43,26 @@ jobs:
             chore
             revert
             release
+            hotfix
+          scopes: |
+            deepagents
+            acp
+            standard-tests
+            providers
+            daytona
+            modal
+            quickjs
+            node-vfs
+            deno
+            evals
+            examples
+            docs
+            internal
+            infra
+            deps
           requireScope: false
+          disallowScopes: |
+            release
+            [A-Z]+
           ignoreLabels: |
             ignore-lint-pr-title


### PR DESCRIPTION
## Summary
Adds PR title validation modeled after langchain-ai/langchainjs#10703.

## Changes
- Harden .github/workflows/pr_lint.yml
- Reject empty scopes in PR titles (for example, fix(): ...)
- Enforce Conventional Commit title format with semantic PR checks
- Add repo-relevant scopes and disallow release/uppercase scopes
- Keep ignore-lint-pr-title label override