### PR TITLE
fix: skills middleware discovery for scoped directories - Fixes #387

### DIFF
--- a/.changeset/clean-onions-reply.md
+++ b/.changeset/clean-onions-reply.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Fix skills middleware discovery for scoped directories (#387)

--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -769,9 +769,7 @@ description: [invalid yaml syntax: unclosed bracket
       // explicitly scoped source directory.
       expect(result?.skillsMetadata).toHaveLength(1);
       expect(result?.skillsMetadata[0].name).toBe("web-research");
-      expect(result?.skillsMetadata[0].path).toBe(
-        "/skills/domainA/SKILL.md",
-      );
+      expect(result?.skillsMetadata[0].path).toBe("/skills/domainA/SKILL.md");
     });
   });
 

--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -737,6 +737,42 @@ description: [invalid yaml syntax: unclosed bracket
         "C:\\skills\\user\\web-research\\SKILL.md",
       );
     });
+    it("should discover skill.md when source is an explicit skill directory (bug #387)", async () => {
+      // Reproduces: skillsMiddleware skips skill.md discovery for explicitly
+      // scoped skill directories. When `sources` points directly at a skill
+      // directory (e.g. "skills/domainA/") rather than a parent directory
+      // (e.g. "skills/"), listSkillsFromBackend calls ls("skills/domainA/")
+      // and gets back the *contents* of that directory (files like SKILL.md).
+      // Because those entries are files, not subdirectories, the loop skips
+      // them and no skill metadata is ever extracted.
+      const mockBackend = createMockBackend({
+        files: {
+          "/skills/domainA/SKILL.md": VALID_SKILL_CONTENT,
+        },
+        directories: {
+          // ls("/skills/domainA/") returns the contents of the directory,
+          // not the directory itself — this is the exact shape that triggers
+          // the bug.
+          "/skills/domainA/": [{ name: "SKILL.md", type: "file" }],
+        },
+      });
+
+      const middleware = createSkillsMiddleware({
+        backend: mockBackend,
+        sources: ["/skills/domainA/"],
+      });
+
+      // @ts-expect-error - typing issue in LangChain
+      const result = await middleware.beforeAgent?.({});
+
+      // Should have found the skill whose SKILL.md lives directly inside the
+      // explicitly scoped source directory.
+      expect(result?.skillsMetadata).toHaveLength(1);
+      expect(result?.skillsMetadata[0].name).toBe("web-research");
+      expect(result?.skillsMetadata[0].path).toBe(
+        "/skills/domainA/SKILL.md",
+      );
+    });
   });
 
   describe("wrapModelCall", () => {

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -541,7 +541,10 @@ async function listSkillsFromBackend(
   if (hasDirectSkillMd) {
     const directSkillMdPath = `${normalizedPath}SKILL.md`;
     const dirName =
-      normalizedPath.replace(/[/\\]$/, "").split(/[/\\]/).pop() || "";
+      normalizedPath
+        .replace(/[/\\]$/, "")
+        .split(/[/\\]/)
+        .pop() || "";
     let content: string | null = null;
 
     if (adaptedBackend.downloadFiles) {

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -531,6 +531,49 @@ async function listSkillsFromBackend(
     type: (info.is_dir ? "directory" : "file") as "file" | "directory",
   }));
 
+  // Check if the source path itself is a skill directory (has SKILL.md directly inside it).
+  // This handles the case where `sources` contains an explicitly scoped skill directory
+  // like "skills/domainA/" rather than a parent directory like "skills/".
+  const hasDirectSkillMd = entries.some(
+    (e) => e.type === "file" && e.name === "SKILL.md",
+  );
+
+  if (hasDirectSkillMd) {
+    const directSkillMdPath = `${normalizedPath}SKILL.md`;
+    const dirName =
+      normalizedPath.replace(/[/\\]$/, "").split(/[/\\]/).pop() || "";
+    let content: string | null = null;
+
+    if (adaptedBackend.downloadFiles) {
+      const results = await adaptedBackend.downloadFiles([directSkillMdPath]);
+      if (
+        results.length === 1 &&
+        results[0].error == null &&
+        results[0].content != null
+      ) {
+        content = new TextDecoder().decode(results[0].content);
+      }
+    } else {
+      const readResult = await adaptedBackend.read(directSkillMdPath);
+      if (!readResult.error && typeof readResult.content === "string") {
+        content = readResult.content;
+      }
+    }
+
+    if (content !== null) {
+      const metadata = parseSkillMetadataFromContent(
+        content,
+        directSkillMdPath,
+        dirName,
+      );
+      if (metadata) {
+        skills.push(metadata);
+      }
+    }
+
+    return skills;
+  }
+
   // Look for subdirectories containing SKILL.md
   for (const entry of entries) {
     if (entry.type !== "directory") {


### PR DESCRIPTION
## Description

Fixes skills middleware skipping `SKILL.md` discovery when explicitly scoped skill directories are provided.

## Issue

Closes #387

## Problem

When `skills` is configured with a specific skill directory path like `"skills/domainA/"`, the `listSkillsFromBackend` function fails to discover `SKILL.md` at that location.

**Root cause:**  
The function calls `ls("skills/domainA/")`, which returns the **contents** of that directory (files like `SKILL.md`). The existing loop only processes subdirectories and skips files, so `SKILL.md` is never discovered.

**Result:**
- `skills_locations` shows `"skills/domainA/"` in the system prompt
- `skills_list` shows `"none"`
- Internally inconsistent state (noted at line 715)

## Solution

Before the subdirectory iteration loop, check if `SKILL.md` exists as a direct child of the source directory. If found:
1. Parse the skill metadata directly
2. Add to skills list
3. Return early

This enables scoped skill directories while maintaining backward compatibility with the existing parent directory behavior.

## Changes

**Modified:** `libs/deepagents/src/middleware/skills.ts`
- Added check for `SKILL.md` as direct child before subdirectory loop
- Reads and parses skill if found at source path
- Returns early to avoid unnecessary processing

**Modified:** `libs/deepagents/src/middleware/skills.test.ts`
- Added regression test reproducing the bug scenario
- Verifies `SKILL.md` is discovered when source is explicit skill directory

## Testing

**New test case:**
```javascript
sources: ["/skills/domainA/"]
// With SKILL.md at /skills/domainA/SKILL.md
```

**Before fix:** `skillsMetadata` was empty ❌  
**After fix:** `skillsMetadata` contains the discovered skill ✅

**Backward compatibility verified:**
- ✅ Parent directories still work: `sources: ["skills/"]`
- ✅ Multiple scoped directories: `sources: ["skills/domainA/", "skills/domainB/"]`
- ✅ All existing tests pass

## Checklist

- [x] Code follows project style guidelines
- [x] Added test coverage for the fix
- [x] All tests pass locally
- [x] Backward compatible - no breaking changes