### PR TITLE
fix(deepagents): follow symlinks in sandbox find commands

### DIFF
--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -175,6 +175,7 @@ describe("BaseSandbox", () => {
       await sandbox.ls("/");
       expect(sandbox.executedCommands.length).toBeGreaterThan(0);
       expect(sandbox.executedCommands[0]).toContain("find");
+      expect(sandbox.executedCommands[0]).toContain("find -L");
       expect(sandbox.executedCommands[0]).toContain("stat");
       expect(sandbox.executedCommands[0]).toContain("-maxdepth 1");
     });
@@ -620,6 +621,16 @@ describe("BaseSandbox", () => {
       expect(sandbox.executedCommands[0]).toContain("grep");
     });
 
+    it("should follow symlinks for grep when glob is provided", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.addFile("/test.txt", "hello");
+
+      await sandbox.grep("hello", "/", "*.txt");
+      expect(sandbox.executedCommands.length).toBe(1);
+      expect(sandbox.executedCommands[0]).toContain("find -L");
+      expect(sandbox.executedCommands[0]).toContain("-name '*.txt'");
+    });
+
     it("should return empty matches array for no matches", async () => {
       const sandbox = new MockSandbox();
       sandbox.execute = vi.fn().mockResolvedValue({
@@ -654,7 +665,7 @@ describe("BaseSandbox", () => {
     it("should find matching files via execute with find + stat", async () => {
       const sandbox = new MockSandbox();
       const now = Math.floor(Date.now() / 1000);
-      sandbox.execute = vi.fn().mockResolvedValue({
+      const executeMock = vi.fn().mockResolvedValue({
         output: [
           `100\t${now}\tregular file\t/test.py`,
           `200\t${now}\tregular file\t/main.py`,
@@ -663,6 +674,7 @@ describe("BaseSandbox", () => {
         exitCode: 0,
         truncated: false,
       });
+      sandbox.execute = executeMock;
 
       const result = await sandbox.glob("*.py", "/");
       expect(result.error).toBeUndefined();
@@ -671,6 +683,7 @@ describe("BaseSandbox", () => {
       expect(result.files!.some((f) => f.path === "test.py")).toBe(true);
       expect(result.files!.some((f) => f.path === "main.py")).toBe(true);
       expect(result.files!.some((f) => f.path === "readme.md")).toBe(false);
+      expect(executeMock.mock.calls[0][0]).toContain("find -L");
     });
 
     it("should support recursive ** glob patterns", async () => {

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -175,7 +175,7 @@ const STAT_C_SCRIPT =
  */
 function buildLsCommand(dirPath: string): string {
   const quotedPath = shellQuote(dirPath);
-  const findBase = `find ${quotedPath} -maxdepth 1 -not -path ${quotedPath}`;
+  const findBase = `find -L ${quotedPath} -maxdepth 1 -not -path ${quotedPath}`;
   return (
     `if find /dev/null -maxdepth 0 -printf '' 2>/dev/null; then ` +
     `${findBase} -printf '%s\\t%T@\\t%y\\t%p\\n' 2>/dev/null; ` +
@@ -195,7 +195,7 @@ function buildLsCommand(dirPath: string): string {
  */
 function buildFindCommand(searchPath: string): string {
   const quotedPath = shellQuote(searchPath);
-  const findBase = `find ${quotedPath} -not -path ${quotedPath}`;
+  const findBase = `find -L ${quotedPath} -not -path ${quotedPath}`;
   return (
     `if find /dev/null -maxdepth 0 -printf '' 2>/dev/null; then ` +
     `${findBase} -printf '%s\\t%T@\\t%y\\t%p\\n' 2>/dev/null; ` +
@@ -257,7 +257,7 @@ function buildGrepCommand(
   if (globPattern) {
     // Use find + grep for BusyBox compatibility (BusyBox grep lacks --include)
     const globEscaped = shellQuote(globPattern);
-    return `find ${searchPathQuoted} -type f -name ${globEscaped} -exec grep -HnF -e ${patternEscaped} {} + 2>/dev/null || true`;
+    return `find -L ${searchPathQuoted} -type f -name ${globEscaped} -exec grep -HnF -e ${patternEscaped} {} + 2>/dev/null || true`;
   }
 
   return `grep -rHnF -e ${patternEscaped} ${searchPathQuoted} 2>/dev/null || true`;


### PR DESCRIPTION
## Summary

Fixes #447.

Sandbox filesystem discovery commands were not following symlinks, causing `ls`, `glob`, and `grep` (with `glob`) to return empty results for symlinked directories (for example, provider mounts exposed via symlinks). This change updates the `BaseSandbox` command builders to use `find -L` so symlink targets are traversed consistently.

## Changes

### `deepagents` (`libs/deepagents/src/backends/sandbox.ts`)

- Updated `buildLsCommand` to use `find -L`.
- Updated `buildFindCommand` (used by `glob`) to use `find -L`.
- Updated glob-filtered `buildGrepCommand` path to use `find -L` before `grep`.

### Tests (`libs/deepagents/src/backends/sandbox.test.ts`)

- Added assertions that generated `ls` and `glob` commands include `find -L`.
- Added coverage for `grep(..., glob=...)` to verify symlink-following command generation.
