### PR TITLE
fix(deepagents): align summarization with active request model

### DIFF
--- a/.changeset/mean-rats-shake.md
+++ b/.changeset/mean-rats-shake.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): route summarization through active request model

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -220,7 +220,7 @@ export function createDeepAgent<
       // Automatically summarizes conversation history when token limits are approached.
       // Uses createSummarizationMiddleware (deepagents version) with backend support
       // and auto-computed defaults from model profile.
-      createSummarizationMiddleware({ backend, model }),
+      createSummarizationMiddleware({ backend }),
       // Patches tool calls to ensure compatibility across different model providers.
       createPatchToolCallsMiddleware(),
       // Loads subagent-specific skills when configured.
@@ -294,7 +294,7 @@ export function createDeepAgent<
     // Automatically summarizes conversation history when token limits are approached.
     // Uses createSummarizationMiddleware (deepagents version) with backend support
     // for conversation history offloading and auto-computed defaults from model profile.
-    createSummarizationMiddleware({ model, backend }),
+    createSummarizationMiddleware({ backend }),
     // Patches tool calls to ensure compatibility across different model providers.
     createPatchToolCallsMiddleware(),
   ] as const;

--- a/libs/deepagents/src/middleware/summarization.test.ts
+++ b/libs/deepagents/src/middleware/summarization.test.ts
@@ -67,7 +67,7 @@ async function callWrapModelCall(
   const request: any = {
     messages,
     state,
-    model: {},
+    model: undefined,
     systemPrompt: "",
     systemMessage: {},
     tools: [],
@@ -1231,6 +1231,58 @@ describe("createSummarizationMiddleware", () => {
           expect(msg.content).toContain("...(result truncated)");
         }
       }
+    });
+  });
+
+  describe("runtime model/provider routing", () => {
+    it("should use request.model when creating summaries", async () => {
+      const mockBackend = createMockBackend();
+
+      const invoke = vi.fn(async (_messages: any) => {
+        return { content: "Summary from runtime-selected provider." };
+      });
+
+      const requestModel = {
+        profile: { maxInputTokens: 128000 },
+        invoke,
+      };
+
+      const middleware = createSummarizationMiddleware({
+        model: "gpt-4o-mini",
+        backend: mockBackend,
+        trigger: { type: "messages", value: 3 },
+        keep: { type: "messages", value: 1 },
+      });
+
+      const messages = Array.from(
+        { length: 5 },
+        (_, i) => new HumanMessage({ content: `Message ${i}` }),
+      );
+
+      let capturedRequest: {
+        messages: BaseMessage[];
+        [key: string]: any;
+      } | null = null;
+
+      const request: any = {
+        messages,
+        state: { messages },
+        model: requestModel,
+        systemPrompt: "",
+        systemMessage: {},
+        tools: [],
+        runtime: {},
+      };
+
+      const result = await middleware.wrapModelCall!(request, (req: any) => {
+        capturedRequest = req;
+        return new AIMessage({ content: "Mock response" });
+      });
+
+      expect(isCommand(result)).toBe(true);
+      expect(capturedRequest).not.toBeNull();
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith(expect.any(Array));
     });
   });
 });

--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -123,8 +123,9 @@ export interface SummarizationMiddlewareOptions {
   /**
    * The language model to use for generating summaries.
    * Can be a model string (e.g., "gpt-4o-mini") or a language model instance.
+   * If omitted, middleware will use the active request model.
    */
-  model: string | BaseChatModel | BaseLanguageModel;
+  model?: string | BaseChatModel | BaseLanguageModel;
 
   /**
    * Backend instance or factory for persisting conversation history.
@@ -399,6 +400,12 @@ export function createSummarizationMiddleware(
   async function getChatModel(): Promise<BaseChatModel> {
     if (cachedModel) {
       return cachedModel;
+    }
+
+    if (!model) {
+      throw new Error(
+        "Summarization middleware could not resolve a model. Provide `options.model` or ensure `request.model` is present.",
+      );
     }
 
     if (typeof model === "string") {
@@ -1189,10 +1196,12 @@ export function createSummarizationMiddleware(
         return handler(request);
       }
 
+      const requestModel = request.model as BaseChatModel | undefined;
+
       /**
        * Resolve the chat model and get max input tokens from its profile.
        */
-      const resolvedModel = await getChatModel();
+      const resolvedModel = requestModel ?? (await getChatModel());
       const maxInputTokens = getMaxInputTokens(resolvedModel);
       applyModelDefaults(resolvedModel);
 


### PR DESCRIPTION
## Summary

Fixes #398

Align deepagents summarization with the active request-time model path instead of relying on a separate middleware-specific model resolution path. This keeps summarization behavior consistent with the main agent model selection flow and avoids divergence in provider/model handling during middleware execution. The update also simplifies runtime behavior by removing unnecessary explicit config threading for summary calls.

## Changes

### `deepagents` middleware/model routing

- Updated summarization middleware to prefer `request.model` as the resolved model used for profile-derived limits and summary generation.
- Kept fallback model resolution support for cases where a request model is not present.
- Removed explicit runtime config plumb-through in summary invocation, relying on LangChain runnable context propagation.

### `deepagents` agent wiring

- Updated `createDeepAgent` built-in and subagent middleware wiring to construct summarization middleware without explicitly passing a separate model option, so summarization follows the active request model path.

### `deepagents` tests

- Added/updated summarization tests to cover request-model-based summarization behavior and ensure middleware behavior remains stable with the new routing path.
- Simplified test request construction to keep request-model assumptions explicit.
