### PR TITLE
fix(quickjs): read pending writes in same eval

### DIFF
--- a/.changeset/quickjs-pending-write-reads.md
+++ b/.changeset/quickjs-pending-write-reads.md
@@ -1,0 +1,9 @@
+---
+"@langchain/quickjs": patch
+---
+
+fix(quickjs): make readFile reflect pending writes in the same eval
+
+Ensure `readFile` checks buffered `pendingWrites` first (latest write wins)
+before falling back to backend `readRaw`, and add regression coverage for
+`writeFile` then `readFile` in a single `js_eval` call.

--- a/libs/providers/quickjs/src/session.test.ts
+++ b/libs/providers/quickjs/src/session.test.ts
@@ -339,6 +339,22 @@ describe("REPL Engine", () => {
       const result = await session.eval('await readFile("/f.txt")', TIMEOUT);
       expect(result.value).toBe("content");
     });
+
+    it("should read pending writes within the same eval call", async () => {
+      const backend = createMockBackend({ "/f.txt": "stale" });
+      session = ReplSession.getOrCreate(uniqueThreadId(), { backend });
+
+      const result = await session.eval(
+        'await writeFile("/f.txt", "fresh"); await readFile("/f.txt")',
+        TIMEOUT,
+      );
+      expect(result.ok).toBe(true);
+      expect(result.value).toBe("fresh");
+      expect(backend.written["/f.txt"]).toBeUndefined();
+
+      await session.flushWrites(backend);
+      expect(backend.written["/f.txt"]).toBe("fresh");
+    });
   });
 
   describe("PTC (programmatic tool calling)", () => {

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -322,19 +322,28 @@ export class ReplSession {
     const readFileHandle = context.newFunction(
       "readFile",
       (pathHandle: QuickJSHandle) => {
-        const backend = getBackend();
-        if (!backend) {
-          const promise = context.newPromise();
-          const err = context.newError("Backend not available");
-          promise.reject(err);
-          err.dispose();
-          promise.settled.then(context.runtime.executePendingJobs);
-          return promise.handle;
-        }
         const path = context.getString(pathHandle);
         const promise = context.newPromise();
         (async () => {
           try {
+            for (let i = pendingWrites.length - 1; i >= 0; i -= 1) {
+              const pending = pendingWrites[i];
+              if (pending.path === path) {
+                const val = context.newString(pending.content);
+                promise.resolve(val);
+                val.dispose();
+                return;
+              }
+            }
+
+            const backend = getBackend();
+            if (!backend) {
+              const err = context.newError("Backend not available");
+              promise.reject(err);
+              err.dispose();
+              return;
+            }
+
             const result = await backend.readRaw(path);
             if (result.error || !result.data) {
               const err = context.newError(


### PR DESCRIPTION
## Summary

This change fixes QuickJS REPL VFS consistency so `readFile` reflects prior `writeFile` calls made within the same `js_eval` execution. Previously, reads always hit backend storage and could return stale content until writes were flushed after eval.

The update makes in-eval file operations behave transactionally from the REPL user's perspective while preserving deferred backend flush behavior.

## Changes

### @langchain/quickjs

- Updated [`ReplSession.injectVfs` read bridge](libs/providers/quickjs/src/session.ts) to check `pendingWrites` first (reverse scan so latest write wins) before falling back to backend `readRaw`.
- Kept backend writes buffered and flushed after eval, but made reads consistent with buffered state in the same eval call.
- Added regression coverage in [`session.test.ts`](libs/providers/quickjs/src/session.test.ts) for `writeFile` then `readFile` within one eval call:
  - verifies immediate read returns fresh content,
  - verifies backend is unchanged before flush,
  - verifies flush persists the new value.
