### PR TITLE
feat(deepagents): add snapshot/start/stop lifecycle to LangSmithSandbox

### DIFF
--- a/.changeset/heavy-horses-wait.md
+++ b/.changeset/heavy-horses-wait.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+feat(deepagents): add snapshot/start/stop lifecycle to LangSmithSandbox

--- a/examples/sandbox/langsmith-sandbox.ts
+++ b/examples/sandbox/langsmith-sandbox.ts
@@ -7,20 +7,18 @@
  * in the `deepagents` package.
  *
  * It shows how to:
- * 1. Create a LangSmith Sandbox via `LangSmithSandbox.create()`
+ * 1. Create a LangSmith Sandbox from a snapshot via `LangSmithSandbox.create()`
  * 2. Use the `execute` tool to run shell commands in the cloud sandbox
  * 3. Clean up the sandbox when finished
  *
  * ## Prerequisites
  *
- * Set your LangSmith API key:
+ * Set your LangSmith API key and snapshot ID:
  *
  * ```bash
  * export LANGSMITH_API_KEY=your_api_key_here
+ * export LANGSMITH_SANDBOX_SNAPSHOT_ID=your_snapshot_id
  * ```
- *
- * You also need a sandbox template created in your LangSmith workspace.
- * The default template name used here is `"deepagents"`.
  *
  * ## Running the Example
  *
@@ -65,11 +63,17 @@ You can execute shell commands to:
 You're working in an isolated sandbox powered by LangSmith — feel free to experiment!`;
 
 async function main() {
+  const snapshotId = process.env.LANGSMITH_SANDBOX_SNAPSHOT_ID;
+  if (!snapshotId) {
+    console.error(
+      "Set LANGSMITH_SANDBOX_SNAPSHOT_ID to the snapshot you want to boot from.",
+    );
+    process.exit(1);
+  }
+
   console.log("Creating LangSmith Sandbox...\n");
 
-  const backend = await LangSmithSandbox.create({
-    templateName: "deepagents",
-  });
+  const backend = await LangSmithSandbox.create({ snapshotId });
 
   console.log(`Sandbox created with ID: ${backend.id}\n`);
 

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -78,7 +78,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "langsmith": ">=0.5.19 <1.0.0"
+    "langsmith": ">=0.5.20 <1.0.0"
   },
   "files": [
     "dist/**/*"

--- a/libs/deepagents/src/backends/index.ts
+++ b/libs/deepagents/src/backends/index.ts
@@ -74,5 +74,12 @@ export {
   type LangSmithSandboxCreateOptions,
 } from "./langsmith.js";
 
+// Re-export upstream sandbox types used by LangSmithSandbox public API
+export type {
+  Snapshot as LangSmithSnapshot,
+  CaptureSnapshotOptions as LangSmithCaptureSnapshotOptions,
+  StartSandboxOptions as LangSmithStartSandboxOptions,
+} from "langsmith/experimental/sandbox";
+
 // Re-export utils for convenience
 export * from "./utils.js";

--- a/libs/deepagents/src/backends/langsmith.test.ts
+++ b/libs/deepagents/src/backends/langsmith.test.ts
@@ -5,6 +5,9 @@ let mockRun: ReturnType<typeof vi.fn>;
 let mockRead: ReturnType<typeof vi.fn>;
 let mockWrite: ReturnType<typeof vi.fn>;
 let mockDelete: ReturnType<typeof vi.fn>;
+let mockStart: ReturnType<typeof vi.fn>;
+let mockStop: ReturnType<typeof vi.fn>;
+let mockCaptureSnapshot: ReturnType<typeof vi.fn>;
 let MockLangSmithResourceNotFoundError: new (message?: string) => Error;
 let MockLangSmithSandboxError: new (message?: string) => Error;
 
@@ -43,6 +46,14 @@ function makeMockSandbox(name: string = "test-sandbox") {
   mockRead = vi.fn();
   mockWrite = vi.fn();
   mockDelete = vi.fn().mockResolvedValue(undefined);
+  mockStart = vi.fn().mockResolvedValue(undefined);
+  mockStop = vi.fn().mockResolvedValue(undefined);
+  mockCaptureSnapshot = vi.fn().mockResolvedValue({
+    id: "snap-123",
+    name: "my-snapshot",
+    status: "ready",
+    fs_capacity_bytes: 1073741824,
+  });
   MockLangSmithResourceNotFoundError = LangSmithResourceNotFoundError;
   MockLangSmithSandboxError = LangSmithSandboxError;
 
@@ -53,6 +64,9 @@ function makeMockSandbox(name: string = "test-sandbox") {
     read: mockRead,
     write: mockWrite,
     delete: mockDelete,
+    start: mockStart,
+    stop: mockStop,
+    captureSnapshot: mockCaptureSnapshot,
   };
 }
 
@@ -95,6 +109,69 @@ describe("LangSmithSandbox", () => {
       const sandbox = makeSandbox();
       await sandbox.close();
       expect(mockDelete).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("start()", () => {
+    it("calls sandbox.start() and sets isRunning to true", async () => {
+      const sandbox = makeSandbox();
+      // First stop it
+      await sandbox.stop();
+      expect(sandbox.isRunning).toBe(false);
+
+      await sandbox.start();
+
+      expect(mockStart).toHaveBeenCalledOnce();
+      expect(mockStart).toHaveBeenCalledWith({});
+      expect(sandbox.isRunning).toBe(true);
+    });
+
+    it("passes options through to sandbox.start()", async () => {
+      const sandbox = makeSandbox();
+      await sandbox.stop();
+
+      await sandbox.start({ timeout: 60 });
+
+      expect(mockStart).toHaveBeenCalledWith({ timeout: 60 });
+    });
+  });
+
+  describe("stop()", () => {
+    it("calls sandbox.stop() and sets isRunning to false", async () => {
+      const sandbox = makeSandbox();
+      expect(sandbox.isRunning).toBe(true);
+
+      await sandbox.stop();
+
+      expect(mockStop).toHaveBeenCalledOnce();
+      expect(sandbox.isRunning).toBe(false);
+    });
+  });
+
+  describe("captureSnapshot()", () => {
+    it("delegates to sandbox.captureSnapshot() and returns result", async () => {
+      const sandbox = makeSandbox();
+
+      const snapshot = await sandbox.captureSnapshot("my-snapshot");
+
+      expect(mockCaptureSnapshot).toHaveBeenCalledOnce();
+      expect(mockCaptureSnapshot).toHaveBeenCalledWith("my-snapshot", {});
+      expect(snapshot).toEqual({
+        id: "snap-123",
+        name: "my-snapshot",
+        status: "ready",
+        fs_capacity_bytes: 1073741824,
+      });
+    });
+
+    it("passes options through to sandbox.captureSnapshot()", async () => {
+      const sandbox = makeSandbox();
+
+      await sandbox.captureSnapshot("my-snapshot", { timeout: 120 });
+
+      expect(mockCaptureSnapshot).toHaveBeenCalledWith("my-snapshot", {
+        timeout: 120,
+      });
     });
   });
 

--- a/libs/deepagents/src/backends/langsmith.ts
+++ b/libs/deepagents/src/backends/langsmith.ts
@@ -5,7 +5,7 @@
  * ```typescript
  * import { LangSmithSandbox, createDeepAgent } from "deepagents";
  *
- * const sandbox = await LangSmithSandbox.create({ templateName: "deepagents-cli" });
+ * const sandbox = await LangSmithSandbox.create({ snapshotId: "your-snapshot-id" });
  *
  * const agent = createDeepAgent({ model, backend: sandbox });
  *
@@ -21,7 +21,10 @@
 
 import {
   type Sandbox,
+  type Snapshot,
   type CreateSandboxOptions,
+  type CaptureSnapshotOptions,
+  type StartSandboxOptions,
   LangSmithResourceNotFoundError,
   LangSmithSandboxError,
   SandboxClient,
@@ -52,7 +55,9 @@ export interface LangSmithSandboxCreateOptions extends Omit<
 > {
   /**
    * Name of the LangSmith sandbox template to use.
-   * @default "deepagents"
+   * Mutually exclusive with `snapshotId`.
+   * @deprecated Use `snapshotId` instead. Template-based creation will be
+   * removed in a future release.
    */
   templateName?: string;
   /**
@@ -195,6 +200,47 @@ export class LangSmithSandbox extends BaseSandbox {
   }
 
   /**
+   * Start a stopped sandbox and wait until it is ready.
+   *
+   * After calling this, `isRunning` will be `true` and the sandbox
+   * can be used for command execution and file operations again.
+   *
+   * @param options - Start options (timeout, signal).
+   */
+  async start(options: StartSandboxOptions = {}): Promise<void> {
+    await this.#sandbox.start(options);
+    this.#isRunning = true;
+  }
+
+  /**
+   * Stop the sandbox without deleting it.
+   *
+   * Sandbox files are preserved and the sandbox can be restarted later
+   * with `start()`. After calling this, `isRunning` will be `false`.
+   */
+  async stop(): Promise<void> {
+    await this.#sandbox.stop();
+    this.#isRunning = false;
+  }
+
+  /**
+   * Capture a snapshot from this running sandbox.
+   *
+   * Snapshots can be used to create new sandboxes via
+   * `LangSmithSandbox.create({ snapshotId })`.
+   *
+   * @param name - Name for the snapshot.
+   * @param options - Capture options (checkpoint, timeout).
+   * @returns The created Snapshot in "ready" status.
+   */
+  async captureSnapshot(
+    name: string,
+    options: CaptureSnapshotOptions = {},
+  ): Promise<Snapshot> {
+    return this.#sandbox.captureSnapshot(name, options);
+  }
+
+  /**
    * Create and return a new LangSmithSandbox in one step.
    *
    * This is the recommended way to create a sandbox — no need to import
@@ -202,7 +248,10 @@ export class LangSmithSandbox extends BaseSandbox {
    *
    * @example
    * ```typescript
-   * const sandbox = await LangSmithSandbox.create({ templateName: "deepagents" });
+   * const sandbox = await LangSmithSandbox.create({
+   *   snapshotId: "abc-123",
+   * });
+   *
    * try {
    *   const agent = createDeepAgent({ model, backend: sandbox });
    *   await agent.invoke({ messages: [...] });
@@ -212,19 +261,27 @@ export class LangSmithSandbox extends BaseSandbox {
    * ```
    */
   static async create(
-    options: LangSmithSandboxCreateOptions = {},
+    options: LangSmithSandboxCreateOptions,
   ): Promise<LangSmithSandbox> {
     const {
-      templateName = "deepagents",
+      templateName,
       apiKey = process.env.LANGSMITH_API_KEY,
       defaultTimeout,
+      snapshotId,
       ...createSandboxOptions
     } = options;
+
+    if (!snapshotId && !templateName) {
+      throw new Error(
+        "Either snapshotId or templateName is required. " +
+          "snapshotId is recommended — template-based creation is deprecated.",
+      );
+    }
 
     const client = new SandboxClient({ apiKey });
     const sandbox = await client.createSandbox(
       templateName,
-      createSandboxOptions,
+      { ...createSandboxOptions, snapshotId },
     );
     return new LangSmithSandbox({ sandbox, defaultTimeout });
   }

--- a/libs/deepagents/src/backends/langsmith.ts
+++ b/libs/deepagents/src/backends/langsmith.ts
@@ -279,10 +279,10 @@ export class LangSmithSandbox extends BaseSandbox {
     }
 
     const client = new SandboxClient({ apiKey });
-    const sandbox = await client.createSandbox(
-      templateName,
-      { ...createSandboxOptions, snapshotId },
-    );
+    const sandbox = await client.createSandbox(templateName, {
+      ...createSandboxOptions,
+      snapshotId,
+    });
     return new LangSmithSandbox({ sandbox, defaultTimeout });
   }
 }

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -151,6 +151,10 @@ export {
   // LangSmith sandbox backend
   LangSmithSandbox,
   type LangSmithSandboxOptions,
+  type LangSmithSandboxCreateOptions,
+  type LangSmithSnapshot,
+  type LangSmithCaptureSnapshotOptions,
+  type LangSmithStartSandboxOptions,
   // Sandbox error types
   type SandboxErrorCode,
   // Local shell backend

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,7 +621,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       langsmith:
-        specifier: '>=0.5.19 <1.0.0'
+        specifier: '>=0.5.20 <1.0.0'
         version: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0)
       micromatch:
         specifier: ^4.0.8


### PR DESCRIPTION
## Summary

Expose the new LangSmith sandbox snapshot and lifecycle APIs (landed in `langsmith@0.5.20`) through the `LangSmithSandbox` wrapper.

- New methods on `LangSmithSandbox`: `start()`, `stop()`, `captureSnapshot()`
- `LangSmithSandbox.create()` now accepts `snapshotId` (preferred) or `templateName` (deprecated); throws if neither is provided
- Re-export upstream types as `LangSmithSnapshot`, `LangSmithCaptureSnapshotOptions`, `LangSmithStartSandboxOptions`
- Bump `langsmith` peer dep to `>=0.5.20`
- Update the example to boot from `LANGSMITH_SANDBOX_SNAPSHOT_ID`

## Test plan

- [x] Unit tests: added coverage for `start()`, `stop()`, `captureSnapshot()`; 41/41 pass
- [x] Type-check clean
- [x] Dev smoke test against `dev.api.smith.langchain.com` — create from snapshot, execute, stop, start, execute after restart all working