### PR TITLE
feat(deepagents): expose summarization options on createDeepAgent

### DIFF
--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -115,7 +115,8 @@ export function isAnthropicModel(model: BaseLanguageModel | string): boolean {
  *
  * This is the main entry point for building a production-style agent with
  * deepagents. It gives you a strong default runtime (filesystem, tasks,
- * subagents, summarization) and lets you opt into skills, memory,
+ * subagents, summarization) and lets you configure summarization via `summarization`,
+ * plus opt into skills, memory,
  * human-in-the-loop interrupts, async subagents, and custom middleware.
  *
  * The runtime is intentionally opinionated: defaults work out of the box, and
@@ -172,6 +173,7 @@ export function createDeepAgent<
     checkpointer,
     store,
     backend = (config) => new StateBackend(config),
+    summarization,
     interruptOn,
     name,
     memory,
@@ -220,7 +222,7 @@ export function createDeepAgent<
       // Automatically summarizes conversation history when token limits are approached.
       // Uses createSummarizationMiddleware (deepagents version) with backend support
       // and auto-computed defaults from model profile.
-      createSummarizationMiddleware({ backend }),
+      createSummarizationMiddleware({ backend, ...summarization }),
       // Patches tool calls to ensure compatibility across different model providers.
       createPatchToolCallsMiddleware(),
       // Loads subagent-specific skills when configured.
@@ -294,7 +296,7 @@ export function createDeepAgent<
     // Automatically summarizes conversation history when token limits are approached.
     // Uses createSummarizationMiddleware (deepagents version) with backend support
     // for conversation history offloading and auto-computed defaults from model profile.
-    createSummarizationMiddleware({ backend }),
+    createSummarizationMiddleware({ backend, ...summarization }),
     // Patches tool calls to ensure compatibility across different model providers.
     createPatchToolCallsMiddleware(),
   ] as const;

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -10,6 +10,7 @@ export { ConfigurationError, type ConfigurationErrorCode } from "./errors.js";
 export type {
   AnySubAgent,
   CreateDeepAgentParams,
+  DeepAgentSummarizationOptions,
   MergedDeepAgentState,
   // DeepAgent type bag and helper types
   DeepAgent,

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -23,7 +23,11 @@ import type {
 } from "@langchain/langgraph-checkpoint";
 
 import type { AnyBackendProtocol } from "./backends/index.js";
-import type { AsyncSubAgent, SubAgent } from "./middleware/index.js";
+import type {
+  AsyncSubAgent,
+  SubAgent,
+  SummarizationMiddlewareOptions,
+} from "./middleware/index.js";
 import type { InteropZodObject } from "@langchain/core/utils/types";
 import type { AnnotationRoot } from "@langchain/langgraph";
 import type { CompiledSubAgent } from "./middleware/subagents.js";
@@ -34,6 +38,16 @@ type AnyAnnotationRoot = AnnotationRoot<any>;
 
 /** Any subagent specification — sync, compiled, or async. */
 export type AnySubAgent = SubAgent | CompiledSubAgent | AsyncSubAgent;
+
+/**
+ * Summarization settings for {@link createDeepAgent}.
+ * Same options as {@link SummarizationMiddlewareOptions} except `backend`,
+ * which always comes from the agent's `backend` parameter.
+ */
+export type DeepAgentSummarizationOptions = Omit<
+  SummarizationMiddlewareOptions,
+  "backend"
+>;
 
 // TODO: import TypedToolStrategy from "langchain" once exported from the top-level entry point
 // (currently only available via "langchain/dist/agents/responses.js")
@@ -394,6 +408,11 @@ export interface CreateDeepAgentParams<
   backend?:
     | AnyBackendProtocol
     | ((config: { state: unknown; store?: BaseStore }) => AnyBackendProtocol);
+  /**
+   * Options for the built-in summarization middleware (thresholds, summary model, prompt, etc.).
+   * The agent `backend` is always used for conversation history offloading.
+   */
+  summarization?: DeepAgentSummarizationOptions;
   /** Optional interrupt configuration mapping tool names to interrupt configs */
   interruptOn?: Record<string, boolean | InterruptOnConfig>;
   /** The name of the agent */


### PR DESCRIPTION
Add optional `summarization` parameter (DeepAgentSummarizationOptions) so callers can pass trigger, keep, trimTokensToSummarize, and other SummarizationMiddleware settings without duplicating middleware wiring. Options are forwarded to createSummarizationMiddleware for the root agent and all built-in subagent stacks; backend always comes from the agent.