### PR TITLE
fix(deepagents): handle Windows absolute paths in tsdown external filter

### DIFF
--- a/internal/eval-harness/tsdown.config.ts
+++ b/internal/eval-harness/tsdown.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "tsdown";
 
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   {

--- a/libs/acp/tsdown.config.ts
+++ b/libs/acp/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
-// Mark all node_modules as external since this is a library
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   // Library builds (ESM + CJS)

--- a/libs/deepagents/tsdown.config.ts
+++ b/libs/deepagents/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
-// Mark all node_modules as external since this is a library
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   {

--- a/libs/providers/daytona/tsdown.config.ts
+++ b/libs/providers/daytona/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
-// Mark all node_modules as external since this is a library
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   {

--- a/libs/providers/deno/tsdown.config.ts
+++ b/libs/providers/deno/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
-// Mark all node_modules as external since this is a library
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   {

--- a/libs/providers/modal/tsdown.config.ts
+++ b/libs/providers/modal/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "tsdown";
 
-// Mark all node_modules as external since this is a library
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   {

--- a/libs/providers/quickjs/tsdown.config.ts
+++ b/libs/providers/quickjs/tsdown.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "tsdown";
 
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   {

--- a/libs/standard-tests/tsdown.config.ts
+++ b/libs/standard-tests/tsdown.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "tsdown";
 
-const external = [/^[^./]/];
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
 
 export default defineConfig([
   {


### PR DESCRIPTION
## Fix: `ERR_MODULE_NOT_FOUND` on Windows when building `deepagents`

### Problem

Building `libs/deepagents` on Windows produces a `dist/index.js` that imports
local modules with `.ts` extensions instead of bundling them:

```js
import { createDeepAgent } from "./agent.ts";
import { ConfigurationError } from "./errors.ts";
```

This causes an immediate crash at runtime for any consumer of the library:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  'C:\...\deepagentsjs\libs\deepagents\dist\agent.ts'
  imported from C:\...\deepagentsjs\libs\deepagents\dist\index.js
  ```

  **Root Cause**
The `external` filter in `libs/deepagents/tsdown.config.ts:` used a regex intended to match
only npm package names (which don't start with `.` or `/`):

```js
const external = [/^[^./]/];
```
On Unix absolute paths start with `/` so the regex correctly excludes them. On Windows absolute paths start with a drive letter (e.g. C:\...), which also doesn't start with `.` or `/` - so rolldown matches them as external, excludes them from the bundle, and leaves raw `.ts` references in the output.

**Fix**
Replace the regex with a function that explicitly excludes Windows-style
absolute paths:
```js
const external = (id: string) =>
  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
```

After this change `pnpm -w run build` in `libs/deepagents` produces a fully
bundled `[dist/index.js]` with no `.ts` imports and examples run correctly on Windows.

Notes

- `deps.neverBundle` (the tsdown-recommended replacement for `[external]` is not yet functional in tsdown 0.21.7 / rolldown 1.0.0-rc.12 and causes a build error. This fix is the correct workaround until that API stabilises.