### PR TITLE
feat(deepagents): add handleToolErrors option to recover from tool exceptions

### DIFF
--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
 import { createDeepAgent, isAnthropicModel } from "./agent.js";
-import { FakeListChatModel } from "@langchain/core/utils/testing";
 import {
+  FakeListChatModel,
+  FakeStreamingChatModel,
+} from "@langchain/core/utils/testing";
+import {
+  AIMessage,
   HumanMessage,
   SystemMessage,
+  ToolMessage,
   type BaseMessage,
 } from "@langchain/core/messages";
 import { MemorySaver } from "@langchain/langgraph";
+import { tool } from "langchain";
+import { z } from "zod";
 import { createFileData } from "./backends/utils.js";
 import { ConfigurationError } from "./errors.js";
 
@@ -166,5 +173,104 @@ describe("Built-in tool name collision detection", () => {
     expect(() =>
       createDeepAgent({ model, tools: [makeTool("my_custom_tool")] }),
     ).not.toThrow();
+  });
+});
+
+describe("createDeepAgent handleToolErrors", () => {
+  const throwingTool = tool(
+    async () => {
+      throw new Error("connection refused");
+    },
+    {
+      name: "failing_tool",
+      description: "always fails",
+      schema: z.object({}),
+    },
+  );
+
+  it("propagates tool errors by default (handleToolErrors not set)", async () => {
+    // given
+    let callCount = 0;
+    const generateSpy = vi
+      .spyOn(FakeStreamingChatModel.prototype as any, "_generate")
+      .mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            generations: [
+              {
+                text: "",
+                message: new AIMessage({
+                  content: "",
+                  tool_calls: [
+                    { id: "call_test_1", name: "failing_tool", args: {} },
+                  ],
+                }),
+              },
+            ],
+          };
+        }
+        return {
+          generations: [{ text: "done", message: new AIMessage("done") }],
+        };
+      });
+    const fakeModel = new FakeStreamingChatModel({ responses: [] });
+    const agent = createDeepAgent({ model: fakeModel, tools: [throwingTool] });
+
+    // when, then
+    await expect(
+      agent.invoke(
+        { messages: [new HumanMessage("call failing_tool")] },
+        { configurable: { thread_id: "test-handle-errors-default" } },
+      ),
+    ).rejects.toThrow();
+    generateSpy.mockRestore();
+  });
+
+  it("converts tool error to ToolMessage when handleToolErrors is true", async () => {
+    // given
+    let callCount = 0;
+    const generateSpy = vi
+      .spyOn(FakeStreamingChatModel.prototype as any, "_generate")
+      .mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            generations: [
+              {
+                text: "",
+                message: new AIMessage({
+                  content: "",
+                  tool_calls: [
+                    { id: "call_test_1", name: "failing_tool", args: {} },
+                  ],
+                }),
+              },
+            ],
+          };
+        }
+        return {
+          generations: [{ text: "done", message: new AIMessage("done") }],
+        };
+      });
+    const fakeModel = new FakeStreamingChatModel({ responses: [] });
+    const agent = createDeepAgent({
+      model: fakeModel,
+      tools: [throwingTool],
+      handleToolErrors: true,
+    });
+
+    // when
+    const result = await agent.invoke(
+      { messages: [new HumanMessage("call failing_tool")] },
+      { configurable: { thread_id: "test-handle-errors-enabled" } },
+    );
+    generateSpy.mockRestore();
+
+    // then
+    const toolMessages = result.messages.filter(ToolMessage.isInstance);
+    const errorMessage = toolMessages.find((m) => m.status === "error");
+    expect(errorMessage).toBeDefined();
+    expect(errorMessage!.content).toContain("Error: connection refused");
   });
 });

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -20,6 +20,7 @@ import {
   createSummarizationMiddleware,
   createMemoryMiddleware,
   createSkillsMiddleware,
+  createToolErrorHandlerMiddleware,
   FILESYSTEM_TOOL_NAMES,
   ASYNC_TASK_TOOL_NAMES,
   type SubAgent,
@@ -176,6 +177,7 @@ export function createDeepAgent<
     name,
     memory,
     skills,
+    handleToolErrors = false,
   } = params;
 
   const collidingTools = tools
@@ -275,6 +277,10 @@ export function createDeepAgent<
       ? [createSkillsMiddleware({ backend, sources: skills })]
       : [];
 
+  const toolErrorHandlerMiddleware = handleToolErrors
+    ? [createToolErrorHandlerMiddleware()]
+    : [];
+
   // Built-in middleware array - core middleware with known types.
   // This tuple is typed without conditional spreads to preserve tuple inference.
   // Optional middleware (skills, memory, HITL, async) are appended at runtime.
@@ -310,6 +316,8 @@ export function createDeepAgent<
   // Runtime middleware array: combine built-in + optional middleware.
   // Note: The full type is handled separately via AllMiddleware.
   const middleware = [
+    // Optional tool error handler — outermost layer so it catches all tool errors.
+    ...toolErrorHandlerMiddleware,
     // Built-in middleware with deterministic ordering.
     todoMiddleware,
     // Optional root-level skills.

--- a/libs/deepagents/src/middleware/index.ts
+++ b/libs/deepagents/src/middleware/index.ts
@@ -71,3 +71,6 @@ export {
   ASYNC_TASK_SYSTEM_PROMPT,
   ASYNC_TASK_TOOL_NAMES,
 } from "./async_subagents.js";
+
+// Tool error handler middleware
+export { createToolErrorHandlerMiddleware } from "./tool-error-handler.js";

--- a/libs/deepagents/src/middleware/tool-error-handler.test.ts
+++ b/libs/deepagents/src/middleware/tool-error-handler.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { ToolMessage } from "@langchain/core/messages";
+import { NodeInterrupt } from "@langchain/langgraph";
+import { createToolErrorHandlerMiddleware } from "./tool-error-handler.js";
+
+function makeRequest(toolCallId = "call_1", toolName = "my_tool") {
+  return {
+    toolCall: { id: toolCallId, name: toolName, args: {} },
+    tool: undefined,
+    state: { messages: [] },
+    runtime: {},
+  } as any;
+}
+
+describe("createToolErrorHandlerMiddleware", () => {
+  describe("wrapToolCall", () => {
+    it("passes through successful result unchanged", async () => {
+      // given
+      const middleware = createToolErrorHandlerMiddleware();
+      const expected = new ToolMessage({
+        content: "ok",
+        tool_call_id: "call_1",
+        name: "my_tool",
+      });
+      const handler = async () => expected;
+
+      // when
+      const result = await middleware.wrapToolCall!(makeRequest(), handler);
+
+      // then
+      expect(result).toBe(expected);
+    });
+
+    it("converts a thrown Error to a ToolMessage with status error", async () => {
+      // given
+      const middleware = createToolErrorHandlerMiddleware();
+      const handler = async () => {
+        throw new Error("Timeout: browser did not respond");
+      };
+
+      // when
+      const result = await middleware.wrapToolCall!(
+        makeRequest("call_2", "wam_load_chain"),
+        handler,
+      );
+
+      // then
+      expect(ToolMessage.isInstance(result)).toBe(true);
+      const msg = result as ToolMessage;
+      expect(msg.tool_call_id).toBe("call_2");
+      expect(msg.name).toBe("wam_load_chain");
+      expect(msg.status).toBe("error");
+      expect(msg.content).toBe("Error: Timeout: browser did not respond");
+    });
+
+    it("re-throws NodeInterrupt without converting", async () => {
+      // given
+      const middleware = createToolErrorHandlerMiddleware();
+      const interrupt = new NodeInterrupt("human approval needed");
+      const handler = async () => {
+        throw interrupt;
+      };
+
+      // when, then
+      await expect(
+        middleware.wrapToolCall!(makeRequest(), handler),
+      ).rejects.toThrow(interrupt);
+    });
+
+    it("re-throws when AbortSignal is aborted", async () => {
+      // given
+      const middleware = createToolErrorHandlerMiddleware();
+      const controller = new AbortController();
+      controller.abort();
+      const error = new Error("aborted");
+      const requestWithSignal = {
+        ...makeRequest(),
+        runtime: { signal: controller.signal },
+      } as any;
+      const handler = async () => {
+        throw error;
+      };
+
+      // when, then
+      await expect(
+        middleware.wrapToolCall!(requestWithSignal, handler),
+      ).rejects.toThrow(error);
+    });
+
+    it("converts error to ToolMessage when signal is present but not aborted", async () => {
+      // given
+      const middleware = createToolErrorHandlerMiddleware();
+      const controller = new AbortController();
+      const requestWithSignal = {
+        ...makeRequest("call_3", "my_tool"),
+        runtime: { signal: controller.signal },
+      } as any;
+      const handler = async () => {
+        throw new Error("transient failure");
+      };
+
+      // when
+      const result = await middleware.wrapToolCall!(requestWithSignal, handler);
+
+      // then
+      expect(ToolMessage.isInstance(result)).toBe(true);
+      expect((result as ToolMessage).status).toBe("error");
+      expect((result as ToolMessage).content).toBe("Error: transient failure");
+    });
+  });
+});

--- a/libs/deepagents/src/middleware/tool-error-handler.ts
+++ b/libs/deepagents/src/middleware/tool-error-handler.ts
@@ -1,0 +1,32 @@
+import { createMiddleware, ToolMessage } from "langchain";
+import { isGraphInterrupt } from "@langchain/langgraph";
+
+/**
+ * Responsible for catching exceptions thrown inside tool functions and
+ * converting them to a ToolMessage with status "error" instead of crashing
+ * the LangGraph superstep.
+ *
+ * NodeInterrupt and aborted AbortSignal errors are always re-thrown so that
+ * interrupt and cancellation flows continue to work correctly.
+ */
+export function createToolErrorHandlerMiddleware() {
+  return createMiddleware({
+    name: "ToolErrorHandlerMiddleware",
+    wrapToolCall: async (request, handler) => {
+      const signal = request.runtime?.signal;
+      try {
+        return await handler(request);
+      } catch (error) {
+        if (isGraphInterrupt(error)) throw error;
+        if (signal?.aborted) throw error;
+        const message = error instanceof Error ? error.message : String(error);
+        return new ToolMessage({
+          content: `Error: ${message}`,
+          tool_call_id: request.toolCall.id ?? "",
+          name: request.toolCall.name,
+          status: "error",
+        });
+      }
+    },
+  });
+}

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -436,4 +436,9 @@ export interface CreateDeepAgentParams<
    * ```
    */
   skills?: string[];
+  /**
+   * When true, catches exceptions thrown inside tool functions and returns them
+   * as a ToolMessage with status "error" instead of crashing the graph superstep.
+   */
+  handleToolErrors?: boolean;
 }


### PR DESCRIPTION
## Problem

When an tool throws (timeout, connection error, validation error),
LangGraph JS propagates it as a "Multiple errors occurred during superstep N"
crash. The agent never sees the error in a ToolMessage and cannot recover.

## Solution

Adds opt-in `handleToolErrors` to `createDeepAgent`. When enabled, exceptions
thrown inside tool functions are caught and returned as a `ToolMessage` with
`status: "error"` instead of crashing the graph.

## Usage

​```ts
const agent = createDeepAgent({
  tools: [myTool],
  handleToolErrors: true,
})
​```

The LLM sees the error message and can decide whether to retry with different
arguments.

## Implementation

A new `createToolErrorHandlerMiddleware()` is inserted as the outermost
`wrapToolCall` layer in the middleware stack, so it catches any exception
thrown anywhere in the tool execution chain. `NodeInterrupt` (HITL breakpoints)
and aborted `AbortSignal` are always re-thrown. Defaults to `false` to preserve
existing behavior.

Closes #485
