### PR TITLE
feat(quickjs): implement delete session in after agent hook to clean up completed repl sessions

### DIFF
--- a/.changeset/some-beds-serve.md
+++ b/.changeset/some-beds-serve.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+feat(quickjs): implement delete session in after agent hook to clean up completed repl sessions

--- a/libs/providers/quickjs/src/middleware.int.test.ts
+++ b/libs/providers/quickjs/src/middleware.int.test.ts
@@ -51,8 +51,6 @@ describe("QuickJS REPL integration", () => {
 
       const secondToolContent = toolMessages[1].content as string;
       expect(secondToolContent).toContain("99");
-
-      expect(ReplSession.hasAnyForThread(threadId)).toBe(true);
     },
   );
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -237,4 +237,63 @@ describe("createQuickJSMiddleware", () => {
       expect(await generatePtcPrompt([])).toBe("");
     });
   });
+
+  describe("afterAgent call", () => {
+    it("should dispose of the session for the current thread", async () => {
+      const middleware = createQuickJSMiddleware();
+
+      // Trigger session creation via js_eval
+      const jsTool = middleware.tools!.find(
+        (t: any) => t.name === "js_eval",
+      ) as any;
+      await jsTool.invoke(
+        { code: "1 + 1" },
+        { configurable: { thread_id: "cleanup-test" } },
+      );
+
+      expect(ReplSession.hasAnyForThread("cleanup-test")).toBe(true);
+
+      // Fire afterAgent
+      await (middleware as any).afterAgent(
+        {},
+        { configurable: { thread_id: "cleanup-test" } },
+      );
+
+      expect(ReplSession.hasAnyForThread("cleanup-test")).toBe(false);
+    });
+
+    it("should no-op for afterAgent on a thread with no session", async () => {
+      const middleware = createQuickJSMiddleware();
+      await expect(
+        (middleware as any).afterAgent(
+          {},
+          { configurable: { thread_id: "no-session-thread" } },
+        ),
+      ).resolves.not.toThrow();
+    });
+
+    it("shoudl only remove the session for the finished thread, not others", async () => {
+      const middleware = createQuickJSMiddleware();
+      const jsTool = middleware.tools!.find(
+        (t: any) => t.name === "js_eval",
+      ) as any;
+
+      await jsTool.invoke(
+        { code: "1" },
+        { configurable: { thread_id: "thread-a" } },
+      );
+      await jsTool.invoke(
+        { code: "1" },
+        { configurable: { thread_id: "thread-b" } },
+      );
+
+      await (middleware as any).afterAgent(
+        {},
+        { configurable: { thread_id: "thread-a" } },
+      );
+
+      expect(ReplSession.hasAnyForThread("thread-a")).toBe(false);
+      expect(ReplSession.hasAnyForThread("thread-b")).toBe(true);
+    });
+  });
 });

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -272,7 +272,7 @@ describe("createQuickJSMiddleware", () => {
       ).resolves.not.toThrow();
     });
 
-    it("shoudl only remove the session for the finished thread, not others", async () => {
+    it("should only remove the session for the finished thread, not others", async () => {
       const middleware = createQuickJSMiddleware();
       const jsTool = middleware.tools!.find(
         (t: any) => t.name === "js_eval",

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -209,5 +209,10 @@ export function createQuickJSMiddleware(
         .concat(cachedPtcPrompt || "");
       return handler({ ...request, systemMessage });
     },
+    afterAgent: async (_state, runtime) => {
+      const threadId = runtime.configurable?.thread_id ?? DEFAULT_SESSION_ID;
+      const sessionKey = `${threadId}:${middlewareId}`;
+      ReplSession.deleteSession(sessionKey);
+    },
   });
 }

--- a/libs/providers/quickjs/src/session.test.ts
+++ b/libs/providers/quickjs/src/session.test.ts
@@ -562,4 +562,17 @@ describe("REPL Engine", () => {
       expect(result.value).toBe("hello");
     });
   });
+
+  describe("session deletion", () => {
+    it("should dispose and remove an existing session", () => {
+      const session = ReplSession.getOrCreate("test-key");
+      expect(ReplSession.get("test-key")).toBe(session);
+      ReplSession.deleteSession("test-key");
+      expect(ReplSession.get("test-key")).toBeNull();
+    });
+
+    it("should no-op for a key that does not exist", () => {
+      expect(() => ReplSession.deleteSession("nonexistent")).not.toThrow();
+    });
+  });
 });

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -141,6 +141,16 @@ export class ReplSession {
   }
 
   /**
+   * Dispose and remove the session with the given key, if it exists.
+   */
+  static deleteSession(key: string): void {
+    const session = ReplSession.sessions.get(key);
+    if (session) {
+      session.dispose();
+    }
+  }
+
+  /**
    * Evaluate code in this session.
    *
    * Lazily starts the QuickJS runtime on the first call. Code is


### PR DESCRIPTION
### Summary

ReplSession uses a static map to preserve QuickJS WASM runtime state across js_eval calls within a run. Previously sessions were never cleaned up, causing unbounded memory growth as each thread_id accumulated a live WASM runtime for the lifetime of the process.

- Added ReplSession.deleteSession(key) to dispose of the QuickJS runtime and removes the entry from the session map
- Added an afterAgent hook in createQuickJSMiddleware that calls deleteSession for the current thread's session key at the end of each agent run

Sessions still persist across all js_eval calls within a single run. The map remains for correct concurrent thread isolation. Without it, simultaneous runs from different threads would share a runtime.

### Tests

Unit tests covering the following scenarios:
- ReplSession.deleteSession disposes and removes an existing session
- ReplSession.deleteSession is a no-op for a key that does not exist
- afterAgent disposes the session for the finished thread
- afterAgent on a thread with no session does not throw
- afterAgent only removes the session for the finished thread, leaving other active threads intact