### PR TITLE
feat(deepagents): implement functional skills for quickjs middleware

### DIFF
--- a/.changeset/eager-oranges-help.md
+++ b/.changeset/eager-oranges-help.md
@@ -1,0 +1,6 @@
+---
+"@langchain/quickjs": patch
+"deepagents": patch
+---
+
+feat(deepagents): implement functional skills for quickjs middleware

--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -1596,6 +1596,111 @@ describe("formatSkillsList with annotations", () => {
   });
 });
 
+describe("formatSkillsList module import hint", () => {
+  it("includes the import hint for a skill with module set", () => {
+    const skills: SkillMetadata[] = [
+      {
+        name: "pdf-extract",
+        description: "Extracts text from PDFs",
+        path: "/skills/pdf-extract/SKILL.md",
+        license: null,
+        compatibility: null,
+        metadata: {},
+        module: "index.ts",
+      },
+    ];
+
+    const result = formatSkillsList(skills, ["/skills/"]);
+    expect(result).toContain(
+      '  → Import: `await import("@/skills/pdf-extract")`',
+    );
+  });
+
+  it("omits the import hint for a skill without module", () => {
+    const skills: SkillMetadata[] = [
+      {
+        name: "prose-skill",
+        description: "Prose only",
+        path: "/skills/prose-skill/SKILL.md",
+        license: null,
+        compatibility: null,
+        metadata: {},
+      },
+    ];
+
+    const result = formatSkillsList(skills, ["/skills/"]);
+    expect(result).not.toContain("Import:");
+    expect(result).not.toContain("@/skills/");
+  });
+
+  it("import hint appears after the read line", () => {
+    const skills: SkillMetadata[] = [
+      {
+        name: "my-skill",
+        description: "Does things",
+        path: "/skills/my-skill/SKILL.md",
+        license: null,
+        compatibility: null,
+        metadata: {},
+        module: "index.ts",
+      },
+    ];
+
+    const result = formatSkillsList(skills, ["/skills/"]);
+    const readIdx = result.indexOf("→ Read");
+    const importIdx = result.indexOf("→ Import:");
+    expect(readIdx).toBeGreaterThan(-1);
+    expect(importIdx).toBeGreaterThan(readIdx);
+  });
+
+  it("import hint appears after allowed tools line when both are present", () => {
+    const skills: SkillMetadata[] = [
+      {
+        name: "rich-skill",
+        description: "Has tools and a module",
+        path: "/skills/rich-skill/SKILL.md",
+        license: null,
+        compatibility: null,
+        metadata: {},
+        allowedTools: ["read_file"],
+        module: "index.ts",
+      },
+    ];
+
+    const result = formatSkillsList(skills, ["/skills/"]);
+    const toolsIdx = result.indexOf("→ Allowed tools:");
+    const importIdx = result.indexOf("→ Import:");
+    expect(toolsIdx).toBeGreaterThan(-1);
+    expect(importIdx).toBeGreaterThan(toolsIdx);
+  });
+
+  it("only the skill with module gets the import hint when mixed", () => {
+    const skills: SkillMetadata[] = [
+      {
+        name: "with-module",
+        description: "Has a module",
+        path: "/skills/with-module/SKILL.md",
+        license: null,
+        compatibility: null,
+        metadata: {},
+        module: "index.ts",
+      },
+      {
+        name: "prose-only",
+        description: "No module",
+        path: "/skills/prose-only/SKILL.md",
+        license: null,
+        compatibility: null,
+        metadata: {},
+      },
+    ];
+
+    const result = formatSkillsList(skills, ["/skills/"]);
+    expect(result).toContain('`await import("@/skills/with-module")`');
+    expect(result).not.toContain("@/skills/prose-only");
+  });
+});
+
 describe("validateModulePath", () => {
   describe("absent / empty values", () => {
     it("returns undefined for null", () => {

--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -12,6 +12,7 @@ import {
   skillsMetadataReducer,
   MAX_SKILL_COMPATIBILITY_LENGTH,
   validateSkillName,
+  validateModulePath,
   parseSkillMetadataFromContent,
   validateMetadata,
   formatSkillAnnotations,
@@ -1592,6 +1593,221 @@ describe("formatSkillsList with annotations", () => {
     expect(result).toContain("- **plain-skill**: A plain skill\n");
     expect(result).not.toContain("License");
     expect(result).not.toContain("Compatibility");
+  });
+});
+
+describe("validateModulePath", () => {
+  describe("absent / empty values", () => {
+    it("returns undefined for null", () => {
+      expect(validateModulePath(null)).toBeUndefined();
+    });
+
+    it("returns undefined for undefined", () => {
+      expect(validateModulePath(undefined)).toBeUndefined();
+    });
+
+    it("returns undefined for empty string", () => {
+      expect(validateModulePath("")).toBeUndefined();
+    });
+
+    it("returns undefined for whitespace-only string", () => {
+      expect(validateModulePath("   ")).toBeUndefined();
+    });
+  });
+
+  describe("non-string values", () => {
+    it("returns undefined for number", () => {
+      expect(validateModulePath(42)).toBeUndefined();
+    });
+
+    it("returns undefined for boolean", () => {
+      expect(validateModulePath(true)).toBeUndefined();
+    });
+
+    it("returns undefined for object", () => {
+      expect(validateModulePath({ path: "index.ts" })).toBeUndefined();
+    });
+
+    it("returns undefined for array", () => {
+      expect(validateModulePath(["index.ts"])).toBeUndefined();
+    });
+  });
+
+  describe("valid paths", () => {
+    it("returns 'index.ts' for 'index.ts'", () => {
+      expect(validateModulePath("index.ts")).toBe("index.ts");
+    });
+
+    it("strips leading ./ from './entry.ts'", () => {
+      expect(validateModulePath("./entry.ts")).toBe("entry.ts");
+    });
+
+    it("strips leading ./ from './lib/util.js'", () => {
+      expect(validateModulePath("./lib/util.js")).toBe("lib/util.js");
+    });
+
+    it("passes through a path without ./ prefix", () => {
+      expect(validateModulePath("lib/entry.js")).toBe("lib/entry.js");
+    });
+
+    it("accepts .mjs extension", () => {
+      expect(validateModulePath("index.mjs")).toBe("index.mjs");
+    });
+
+    it("accepts .cjs extension", () => {
+      expect(validateModulePath("index.cjs")).toBe("index.cjs");
+    });
+
+    it("accepts .jsx extension", () => {
+      expect(validateModulePath("ui.jsx")).toBe("ui.jsx");
+    });
+
+    it("accepts .tsx extension", () => {
+      expect(validateModulePath("component.tsx")).toBe("component.tsx");
+    });
+
+    it("accepts .mts extension", () => {
+      expect(validateModulePath("index.mts")).toBe("index.mts");
+    });
+
+    it("accepts .cts extension", () => {
+      expect(validateModulePath("index.cts")).toBe("index.cts");
+    });
+
+    it("trims surrounding whitespace before validating", () => {
+      expect(validateModulePath("  index.ts  ")).toBe("index.ts");
+    });
+  });
+
+  describe("absolute paths", () => {
+    it("returns undefined for '/foo.ts'", () => {
+      expect(validateModulePath("/foo.ts")).toBeUndefined();
+    });
+
+    it("returns undefined for '/absolute/path/index.ts'", () => {
+      expect(validateModulePath("/absolute/path/index.ts")).toBeUndefined();
+    });
+
+    it("returns undefined for './' that normalizes to an absolute after stripping", () => {
+      expect(validateModulePath("/./index.ts")).toBeUndefined();
+    });
+  });
+
+  describe("path traversal", () => {
+    it("returns undefined for '..'", () => {
+      expect(validateModulePath("..")).toBeUndefined();
+    });
+
+    it("returns undefined for '../foo.ts'", () => {
+      expect(validateModulePath("../foo.ts")).toBeUndefined();
+    });
+
+    it("returns undefined for 'lib/../foo.ts'", () => {
+      expect(validateModulePath("lib/../foo.ts")).toBeUndefined();
+    });
+
+    it("returns undefined for 'a/b/../../foo.ts'", () => {
+      expect(validateModulePath("a/b/../../foo.ts")).toBeUndefined();
+    });
+
+    it("returns undefined for 'foo/..' (trailing traversal without extension)", () => {
+      expect(validateModulePath("foo/..")).toBeUndefined();
+    });
+
+    it("returns undefined for './../../escape.ts'", () => {
+      expect(validateModulePath("./../../escape.ts")).toBeUndefined();
+    });
+  });
+
+  describe("bad extensions", () => {
+    it("returns undefined for '.json'", () => {
+      expect(validateModulePath("data.json")).toBeUndefined();
+    });
+
+    it("returns undefined for '.md'", () => {
+      expect(validateModulePath("README.md")).toBeUndefined();
+    });
+
+    it("returns undefined for no extension", () => {
+      expect(validateModulePath("index")).toBeUndefined();
+    });
+
+    it("returns undefined for '.py'", () => {
+      expect(validateModulePath("script.py")).toBeUndefined();
+    });
+
+    it("returns undefined for '.d.ts' (type declaration only)", () => {
+      expect(validateModulePath("index.d.ts")).toBeUndefined();
+    });
+  });
+});
+
+describe("parseSkillMetadataFromContent module field", () => {
+  function makeContent(extra = ""): string {
+    return `---\nname: my-skill\ndescription: A skill\n${extra}---\n\nContent\n`;
+  }
+
+  it("sets module when a valid path is provided", () => {
+    const result = parseSkillMetadataFromContent(
+      makeContent("module: index.ts\n"),
+      "/skills/my-skill/SKILL.md",
+      "my-skill",
+    );
+    expect(result?.module).toBe("index.ts");
+  });
+
+  it("strips leading ./ from module path", () => {
+    const result = parseSkillMetadataFromContent(
+      makeContent("module: ./src/entry.ts\n"),
+      "/skills/my-skill/SKILL.md",
+      "my-skill",
+    );
+    expect(result?.module).toBe("src/entry.ts");
+  });
+
+  it("sets module to undefined when module key is absent", () => {
+    const result = parseSkillMetadataFromContent(
+      makeContent(),
+      "/skills/my-skill/SKILL.md",
+      "my-skill",
+    );
+    expect(result?.module).toBeUndefined();
+  });
+
+  it("sets module to undefined for a non-string value", () => {
+    const result = parseSkillMetadataFromContent(
+      makeContent("module: 42\n"),
+      "/skills/my-skill/SKILL.md",
+      "my-skill",
+    );
+    expect(result?.module).toBeUndefined();
+  });
+
+  it("sets module to undefined for an unsupported extension", () => {
+    const result = parseSkillMetadataFromContent(
+      makeContent("module: index.py\n"),
+      "/skills/my-skill/SKILL.md",
+      "my-skill",
+    );
+    expect(result?.module).toBeUndefined();
+  });
+
+  it("sets module to undefined for a traversal path", () => {
+    const result = parseSkillMetadataFromContent(
+      makeContent("module: ../escape.ts\n"),
+      "/skills/my-skill/SKILL.md",
+      "my-skill",
+    );
+    expect(result?.module).toBeUndefined();
+  });
+
+  it("sets module to undefined for an empty string", () => {
+    const result = parseSkillMetadataFromContent(
+      makeContent('module: ""\n'),
+      "/skills/my-skill/SKILL.md",
+      "my-skill",
+    );
+    expect(result?.module).toBeUndefined();
   });
 });
 

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -658,6 +658,9 @@ export function formatSkillsList(
       lines.push(`  → Allowed tools: ${skill.allowedTools.join(", ")}`);
     }
     lines.push(`  → Read \`${skill.path}\` for full instructions`);
+    if (skill.module !== undefined) {
+      lines.push(`  → Import: \`await import("@/skills/${skill.name}")\``);
+    }
   }
 
   return lines.join("\n");

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -73,6 +73,20 @@ export const MAX_SKILL_DESCRIPTION_LENGTH = 1024;
 export const MAX_SKILL_COMPATIBILITY_LENGTH = 500;
 
 /**
+ * File extensions a skill module entrypoint may use.
+ */
+export const SKILL_MODULE_EXTENSIONS = [
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".mts",
+  ".cts",
+  ".jsx",
+  ".tsx",
+];
+
+/**
  * Metadata for a skill per Agent Skills specification.
  */
 export interface SkillMetadata {
@@ -136,6 +150,12 @@ export interface SkillMetadata {
    * - Space-delimited list of tool names
    */
   allowedTools?: string[];
+
+  /**
+   * Path to a JS/TS entrypoint file for a QuickJS REPL module, relative to the skill
+   * directory.
+   */
+  module?: string;
 }
 
 /**
@@ -170,6 +190,7 @@ export const SkillMetadataEntrySchema = z.object({
   compatibility: z.string().nullable().optional(),
   metadata: z.record(z.string(), z.string()).optional(),
   allowedTools: z.array(z.string()).optional(),
+  module: z.string().optional(),
 });
 
 /**
@@ -489,6 +510,7 @@ export function parseSkillMetadataFromContent(
     license: String(frontmatterData.license ?? "").trim() || null,
     compatibility: compatibilityStr,
     allowedTools,
+    module: validateModulePath(frontmatterData.module),
   };
 }
 
@@ -639,6 +661,73 @@ export function formatSkillsList(
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Returns true when `value` ends with a recognized skill module extension.
+ */
+function endsWithModuleExtension(value: string): boolean {
+  for (const ext of SKILL_MODULE_EXTENSIONS) {
+    if (value.endsWith(ext)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Validate and normalize the `module` frontmatter key from a `SKILL.md`.
+ *
+ * Returns the normalized path (e.g. `"index.ts"`, `"lib/entry.js"`) or
+ * `undefined` when the key is absent, empty, non-string, absolute, contains
+ * path traversal, or uses an unsupported extension. Invalid values silently
+ * degrade the skill to prose-only.
+ */
+export function validateModulePath(raw: unknown): string | undefined {
+  if (raw === null || raw === undefined) {
+    return;
+  }
+
+  if (typeof raw !== "string") {
+    return;
+  }
+
+  const stripped = raw.trim();
+  if (stripped === "") {
+    return;
+  }
+
+  // Normalize "./x" → "x" so the value lines up with the keys the loader
+  // uses inside the installed module scope. Leaves "lib/util.js" untouched.
+  const normalized = stripped.startsWith("./") ? stripped.slice(2) : stripped;
+
+  if (normalized.startsWith("/")) {
+    return;
+  }
+
+  if (
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../") ||
+    normalized.endsWith("/..")
+  ) {
+    return;
+  }
+
+  // Declaration files are type-only stubs with no runtime exports.
+  if (
+    normalized.endsWith(".d.ts") ||
+    normalized.endsWith(".d.mts") ||
+    normalized.endsWith(".d.cts")
+  ) {
+    return;
+  }
+
+  if (!endsWithModuleExtension(normalized)) {
+    return;
+  }
+
+  return normalized;
 }
 
 /**

--- a/libs/providers/quickjs/src/index.ts
+++ b/libs/providers/quickjs/src/index.ts
@@ -31,7 +31,11 @@ export {
   DEFAULT_EXECUTION_TIMEOUT,
 } from "./session.js";
 
-export { formatReplResult, toCamelCase } from "./utils.js";
+export {
+  formatReplResult,
+  toCamelCase,
+  formatSkillNotAvailable,
+} from "./utils.js";
 
 export { transformForEval, stripTypeSyntax } from "./transform.js";
 

--- a/libs/providers/quickjs/src/index.ts
+++ b/libs/providers/quickjs/src/index.ts
@@ -34,3 +34,11 @@ export {
 export { formatReplResult, toCamelCase } from "./utils.js";
 
 export { transformForEval, stripTypeSyntax } from "./transform.js";
+
+export {
+  loadSkill,
+  scanSkillReferences,
+  SKILL_MODULE_EXTENSIONS,
+  MAX_SKILL_BUNDLE_BYTES,
+  type LoadedSkill,
+} from "./skills.js";

--- a/libs/providers/quickjs/src/index.ts
+++ b/libs/providers/quickjs/src/index.ts
@@ -33,4 +33,4 @@ export {
 
 export { formatReplResult, toCamelCase } from "./utils.js";
 
-export { transformForEval } from "./transform.js";
+export { transformForEval, stripTypeSyntax } from "./transform.js";

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -16,6 +16,13 @@ import { z } from "zod/v4";
 import type { StructuredToolInterface } from "@langchain/core/tools";
 
 import dedent from "dedent";
+import { getCurrentTaskInput } from "@langchain/langgraph";
+import {
+  resolveBackend,
+  type AnyBackendProtocol,
+  type BackendFactory,
+  type SkillMetadata,
+} from "deepagents";
 import type { QuickJSMiddlewareOptions } from "./types.js";
 import {
   ReplSession,
@@ -26,10 +33,12 @@ import {
 } from "./session.js";
 import {
   formatReplResult,
+  formatSkillNotAvailable,
   toCamelCase,
   toolToTypeSignature,
   safeToJsonSchema,
 } from "./utils.js";
+import { scanSkillReferences } from "./skills.js";
 
 /**
  * These type-only imports are required for TypeScript's type inference to work
@@ -131,6 +140,39 @@ export function resolveToolList(
 }
 
 /**
+ * Pull `skillsMetadata` from the task input, resolve the backend, and push
+ * both into the session. Short-circuits with a `SkillNotAvailable` error if
+ * the source references skills the agent doesn't have.
+ */
+async function prepareSkillsForEval(
+  session: ReplSession,
+  skillsBackend: AnyBackendProtocol | BackendFactory,
+  code: string,
+): Promise<string | undefined> {
+  const taskInput = getCurrentTaskInput<{ skillsMetadata?: SkillMetadata[] }>();
+  const metadata: SkillMetadata[] = taskInput?.skillsMetadata ?? [];
+
+  const referenced = scanSkillReferences(code);
+  if (referenced.size > 0) {
+    const known = new Set(metadata.map((m) => m.name));
+    const missing: string[] = [];
+    for (const name of referenced) {
+      if (!known.has(name)) {
+        missing.push(name);
+      }
+    }
+    if (missing.length > 0) {
+      session.setSkillsContext(undefined);
+      return formatSkillNotAvailable(missing);
+    }
+  }
+
+  const resolved = await resolveBackend(skillsBackend, { state: taskInput });
+  session.setSkillsContext({ metadata, backend: resolved });
+  return undefined;
+}
+
+/**
  * Create the QuickJS REPL middleware.
  */
 export function createQuickJSMiddleware(
@@ -142,6 +184,7 @@ export function createQuickJSMiddleware(
     maxStackSizeBytes = DEFAULT_MAX_STACK_SIZE,
     executionTimeoutMs = DEFAULT_EXECUTION_TIMEOUT,
     systemPrompt: customSystemPrompt = null,
+    skillsBackend,
   } = options;
 
   const baseSystemPrompt = customSystemPrompt || REPL_SYSTEM_PROMPT;
@@ -171,7 +214,19 @@ export function createQuickJSMiddleware(
         memoryLimitBytes,
         maxStackSizeBytes,
         tools: ptcTools,
+        skillsEnabled: skillsBackend !== undefined,
       });
+
+      if (skillsBackend !== undefined) {
+        const setupError = await prepareSkillsForEval(
+          session,
+          skillsBackend,
+          input.code,
+        );
+        if (setupError !== undefined) {
+          return setupError;
+        }
+      }
 
       const result = await session.eval(input.code, executionTimeoutMs);
       return formatReplResult(result);
@@ -182,6 +237,7 @@ export function createQuickJSMiddleware(
         Evaluate TypeScript/JavaScript code in a sandboxed REPL. State persists across calls.
         Use console.log() for output. Returns the result of the last expression.
         If file or other tools are available, call them via the tools namespace: await tools.readFile({ path }).
+        If skills are configured, dynamically import them: await import("@/skills/<name>").
       `,
       schema: z.object({
         code: z

--- a/libs/providers/quickjs/src/session.test.ts
+++ b/libs/providers/quickjs/src/session.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { tool } from "langchain";
 import { z } from "zod/v4";
+import type {
+  AnyBackendProtocol,
+  FileDownloadResponse,
+  SkillMetadata,
+} from "deepagents";
 import { ReplSession } from "./session.js";
+import type { SkillsContext } from "./types.js";
 
 const TIMEOUT = 5000;
 let nextId = 0;
@@ -574,5 +580,190 @@ describe("REPL Engine", () => {
     it("should no-op for a key that does not exist", () => {
       expect(() => ReplSession.deleteSession("nonexistent")).not.toThrow();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skills module loader
+// ---------------------------------------------------------------------------
+
+const enc = new TextEncoder();
+
+function makeSkillsBackend(files: Record<string, string>): AnyBackendProtocol {
+  return {
+    glob: async (pattern: string, basePath?: string) => {
+      const ext = pattern.replace("**/*", "");
+      const matches = Object.keys(files)
+        .filter((p) => p.startsWith(basePath ?? "") && p.endsWith(ext))
+        .map((p) => ({ path: p }));
+      return { files: matches };
+    },
+    downloadFiles: async (paths: string[]) => {
+      return paths.map((p): FileDownloadResponse => {
+        const content = files[p];
+        if (content === undefined) {
+          return { path: p, content: null, error: "file_not_found" };
+        }
+        return { path: p, content: enc.encode(content), error: null };
+      });
+    },
+  } as unknown as AnyBackendProtocol;
+}
+
+function makeSkillsMeta(
+  name: string,
+  module: string,
+  skillDir?: string,
+): SkillMetadata {
+  const dir = skillDir ?? `/skills/${name}`;
+  return {
+    name,
+    description: `Test skill ${name}`,
+    path: `${dir}/SKILL.md`,
+    module,
+  };
+}
+
+function makeSkillsContext(
+  metadata: SkillMetadata[],
+  files: Record<string, string>,
+): SkillsContext {
+  return { metadata, backend: makeSkillsBackend(files) };
+}
+
+describe("skills module loader", () => {
+  let session: ReplSession;
+
+  beforeEach(() => {
+    ReplSession.clearCache();
+  });
+
+  afterEach(() => {
+    if (session) session.dispose();
+  });
+
+  it("resolves a single-file skill and exposes its exports", async () => {
+    session = ReplSession.getOrCreate(uniqueThreadId(), {
+      skillsEnabled: true,
+    });
+    session.setSkillsContext(
+      makeSkillsContext([makeSkillsMeta("my-skill", "index.js")], {
+        "/skills/my-skill/index.js": "export const VALUE = 42;",
+      }),
+    );
+
+    const result = await session.eval(
+      `const mod = await import("@/skills/my-skill"); mod.VALUE`,
+      TIMEOUT,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe(42);
+  });
+
+  it("resolves relative imports inside a multi-file skill", async () => {
+    session = ReplSession.getOrCreate(uniqueThreadId(), {
+      skillsEnabled: true,
+    });
+    session.setSkillsContext(
+      makeSkillsContext([makeSkillsMeta("my-skill", "index.js")], {
+        "/skills/my-skill/index.js":
+          "import { add } from './lib/math.js'; export function compute() { return add(1, 2); }",
+        "/skills/my-skill/lib/math.js":
+          "export function add(a, b) { return a + b; }",
+      }),
+    );
+
+    const result = await session.eval(
+      `const { compute } = await import("@/skills/my-skill"); compute()`,
+      TIMEOUT,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe(3);
+  });
+
+  it("rejects import of an unknown skill with a recognizable message", async () => {
+    session = ReplSession.getOrCreate(uniqueThreadId(), {
+      skillsEnabled: true,
+    });
+    session.setSkillsContext(makeSkillsContext([], {}));
+
+    const result = await session.eval(
+      `await import("@/skills/unknown")`,
+      TIMEOUT,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("not available on this agent");
+  });
+
+  it("rejects import when skills context is cleared", async () => {
+    session = ReplSession.getOrCreate(uniqueThreadId(), {
+      skillsEnabled: true,
+    });
+    session.setSkillsContext(undefined);
+
+    const result = await session.eval(
+      `await import("@/skills/my-skill")`,
+      TIMEOUT,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("not configured");
+  });
+
+  it("rejects traversal escape from inside a skill", async () => {
+    session = ReplSession.getOrCreate(uniqueThreadId(), {
+      skillsEnabled: true,
+    });
+    session.setSkillsContext(
+      makeSkillsContext([makeSkillsMeta("my-skill", "index.js")], {
+        "/skills/my-skill/index.js":
+          "export { escape } from '../../other-skill/index.js';",
+      }),
+    );
+
+    const result = await session.eval(
+      `await import("@/skills/my-skill")`,
+      TIMEOUT,
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("caches a load failure and does not re-fetch from the backend", async () => {
+    let downloadCount = 0;
+    const meta = makeSkillsMeta("my-skill", "index.js");
+    const backend = {
+      glob: async (pattern: string) => {
+        const ext = pattern.replace("**/*", "");
+        if (ext === ".js") {
+          return { files: [{ path: "/skills/my-skill/index.js" }] };
+        }
+        return { files: [] };
+      },
+      downloadFiles: async (paths: string[]) => {
+        downloadCount++;
+        return paths.map(
+          (p): FileDownloadResponse => ({
+            path: p,
+            content: null,
+            error: "file_not_found",
+          }),
+        );
+      },
+    } as unknown as AnyBackendProtocol;
+
+    session = ReplSession.getOrCreate(uniqueThreadId(), {
+      skillsEnabled: true,
+    });
+    session.setSkillsContext({ metadata: [meta], backend });
+
+    await session.eval(
+      `await import("@/skills/my-skill").catch(() => null)`,
+      TIMEOUT,
+    );
+    await session.eval(
+      `await import("@/skills/my-skill").catch(() => null)`,
+      TIMEOUT,
+    );
+
+    expect(downloadCount).toBe(1);
   });
 });

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -36,19 +36,20 @@ export const DEFAULT_MAX_STACK_SIZE = 320 * 1024;
 export const DEFAULT_EXECUTION_TIMEOUT = 30_000;
 export const DEFAULT_SESSION_ID = "__default__";
 
-let asyncModulePromise: Promise<any> | undefined;
+// The variant descriptor (WASM binary + glue) is safe to share across sessions;
+// only the instantiated module carries asyncify state. Import once, instantiate per session.
+const variantImport = import("@jitl/quickjs-ng-wasmfile-release-asyncify");
 
-async function getAsyncModule() {
-  if (!asyncModulePromise) {
-    asyncModulePromise = (async () => {
-      const variant =
-        await import("@jitl/quickjs-ng-wasmfile-release-asyncify");
-      return newQuickJSAsyncWASMModuleFromVariant(
-        (variant.default ?? variant) as any,
-      );
-    })();
-  }
-  return asyncModulePromise;
+// Each ReplSession needs its own WASM module. The asyncify WASM variant allows only one
+// concurrent async call per module instance, and multi-file skill imports (2+ unwind/rewind
+// cycles inside a single evalCodeAsync) leave the module's asyncify state corrupted after
+// the owning runtime is disposed — new runtimes on the same module silently skip module
+// loader callbacks. A fresh instantiation per session gives each session clean asyncify state.
+async function newAsyncModule() {
+  const variant = await variantImport;
+  return newQuickJSAsyncWASMModuleFromVariant(
+    (variant.default ?? variant) as any,
+  );
 }
 
 // After a successful asyncify unwind/rewind cycle, a rejected module loader
@@ -167,7 +168,7 @@ export class ReplSession {
   }
 
   private async ensureStarted(): Promise<void> {
-    if (this.runtime !== null) return;
+    if (this.runtime) return;
 
     const {
       memoryLimitBytes = DEFAULT_MEMORY_LIMIT,
@@ -176,7 +177,7 @@ export class ReplSession {
       skillsEnabled = false,
     } = this.options;
 
-    const asyncModule = await getAsyncModule();
+    const asyncModule = await newAsyncModule();
     const runtime: QuickJSAsyncRuntime = asyncModule.newRuntime();
     runtime.setMemoryLimit(memoryLimitBytes);
     runtime.setMaxStackSize(maxStackSizeBytes);
@@ -474,12 +475,6 @@ export class ReplSession {
     this.runtime = null;
     this.context = null;
     ReplSession.sessions.delete(this.id);
-    // Multi-file skill imports (2+ asyncify unwind/rewind cycles in one
-    // evalCodeAsync) leave the shared WASM module's asyncify state corrupted
-    // after the owning runtime is disposed. New runtimes on the same module
-    // silently fail to invoke module loader callbacks. Reset the singleton so
-    // the next session gets a fresh WASM module (~14ms lazy cost on next eval).
-    asyncModulePromise = undefined;
   }
 
   toJSON(): { id: string } {

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -474,6 +474,12 @@ export class ReplSession {
     this.runtime = null;
     this.context = null;
     ReplSession.sessions.delete(this.id);
+    // Multi-file skill imports (2+ asyncify unwind/rewind cycles in one
+    // evalCodeAsync) leave the shared WASM module's asyncify state corrupted
+    // after the owning runtime is disposed. New runtimes on the same module
+    // silently fail to invoke module loader callbacks. Reset the singleton so
+    // the next session gets a fresh WASM module (~14ms lazy cost on next eval).
+    asyncModulePromise = undefined;
   }
 
   toJSON(): { id: string } {
@@ -493,12 +499,6 @@ export class ReplSession {
       session.dispose();
     }
     ReplSession.sessions.clear();
-    // Multi-file skill imports (2+ asyncify unwind/rewind cycles in one
-    // evalCodeAsync) leave the shared WASM module's asyncify state corrupted
-    // after the runtime that performed them is disposed. New runtimes on the
-    // same module will silently fail to invoke module loader callbacks. Force
-    // a fresh WASM module so the next session starts clean.
-    asyncModulePromise = undefined;
   }
 
   private setupConsole(): void {

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -26,7 +26,8 @@ import type {
 } from "quickjs-emscripten-core";
 import type { StructuredToolInterface } from "@langchain/core/tools";
 
-import type { ReplSessionOptions, ReplResult } from "./types.js";
+import { loadSkill, type LoadedSkill } from "./skills.js";
+import type { ReplSessionOptions, ReplResult, SkillsContext } from "./types.js";
 import { toCamelCase } from "./utils.js";
 import { transformForEval } from "./transform.js";
 
@@ -50,6 +51,95 @@ async function getAsyncModule() {
   return asyncModulePromise;
 }
 
+// After a successful asyncify unwind/rewind cycle, a rejected module loader
+// Promise causes a WASM crash ("memory access out of bounds"). The rejection
+// path in quickjs-emscripten's `maybeAsyncFn` catch block calls
+// `context.throw(error)` — a WASM FFI call while the asyncify stack is still
+// unwound — which corrupts memory. To avoid this, the module loader must never
+// reject. This helper returns source code that throws at evaluation time inside
+// the VM instead.
+//
+// The thrown value is a plain object (not `new Error()`) because QuickJS stores
+// Error's `name` and `message` as non-enumerable properties (per spec), which
+// causes `context.dump()` (JSON.stringify) to return `{}`.
+function makeErrorSource(message: string): string {
+  return `throw { name: "Error", message: ${JSON.stringify(message)} };`;
+}
+
+/**
+ * Parse a canonicalized skill specifier into `{ name, rel }`.
+ * Returns `undefined` for anything that isn't a valid `@/skills/<name>` or
+ * `@/skills/<name>/<rel>` shape. `rel` is absent for the bare form.
+ */
+function parseSkillSpecifier(
+  specifier: string,
+): { name: string; rel?: string } | undefined {
+  const prefix = "@/skills/";
+  if (!specifier.startsWith(prefix)) {
+    return;
+  }
+
+  const tail = specifier.slice(prefix.length);
+  const slashIdx = tail.indexOf("/");
+  const name = slashIdx === -1 ? tail : tail.slice(0, slashIdx);
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
+    return;
+  }
+
+  const rel = slashIdx === -1 ? undefined : tail.slice(slashIdx + 1);
+  if (rel !== undefined && rel === "") {
+    return;
+  }
+
+  return { name, rel };
+}
+
+/**
+ * Return the `@/skills/<name>` prefix for the skill that owns `base`, or `undefined`.
+ */
+function matchSkillPrefix(base: string): string | undefined {
+  const parsed = parseSkillSpecifier(base);
+  if (parsed === undefined) {
+    return;
+  }
+  return `@/skills/${parsed.name}`;
+}
+
+/**
+ * Return the directory portion of a slash-separated specifier path.
+ */
+function posixDirname(p: string): string {
+  const idx = p.lastIndexOf("/");
+  if (idx === -1) {
+    return "";
+  }
+  return p.slice(0, idx);
+}
+
+/**
+ * POSIX join for slash-separated specifiers. Avoids `node:path/posix`
+ * since session.ts is consumed in browser bundles.
+ */
+function posixJoin(base: string, rel: string): string {
+  const out: string[] = [];
+
+  const segments = `${base}/${rel}`.split("/");
+  for (const segment of segments) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+
+    if (segment === "..") {
+      out.pop();
+      continue;
+    }
+
+    out.push(segment);
+  }
+
+  return out.join("/");
+}
+
 /**
  * Sandboxed JavaScript REPL session backed by QuickJS WASM.
  *
@@ -66,20 +156,25 @@ export class ReplSession {
   private runtime: QuickJSAsyncRuntime | null = null;
   private context: QuickJSAsyncContext | null = null;
   private logs: string[] = [];
-  private _options: ReplSessionOptions;
+  private options: ReplSessionOptions;
+  private skillsContext: SkillsContext | undefined;
+  private skillsLoaded: Map<string, LoadedSkill> = new Map();
+  private skillsFailed: Map<string, Error> = new Map();
+
   constructor(id: string, options: ReplSessionOptions = {}) {
     this.id = id;
-    this._options = options;
+    this.options = options;
   }
 
   private async ensureStarted(): Promise<void> {
-    if (this.runtime) return;
+    if (this.runtime !== null) return;
 
     const {
       memoryLimitBytes = DEFAULT_MEMORY_LIMIT,
       maxStackSizeBytes = DEFAULT_MAX_STACK_SIZE,
       tools,
-    } = this._options;
+      skillsEnabled = false,
+    } = this.options;
 
     const asyncModule = await getAsyncModule();
     const runtime: QuickJSAsyncRuntime = asyncModule.newRuntime();
@@ -92,9 +187,133 @@ export class ReplSession {
 
     this.setupConsole();
 
-    if (tools && tools.length > 0) {
+    if (tools !== undefined && tools.length > 0) {
       this.injectTools(tools);
     }
+
+    if (skillsEnabled) {
+      this.installModuleLoader();
+    }
+  }
+
+  /**
+   * Load the skill into cache on first access and replay cached errors.
+   */
+  private async ensureSkillLoaded(name: string): Promise<LoadedSkill> {
+    const cached = this.skillsLoaded.get(name);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const cachedError = this.skillsFailed.get(name);
+    if (cachedError !== undefined) {
+      throw cachedError;
+    }
+
+    const ctx = this.skillsContext;
+    if (ctx === undefined) {
+      throw new Error(
+        `Skill '${name}' referenced but skills are not configured for this session`,
+      );
+    }
+
+    const metadata = ctx.metadata.find((m) => m.name === name);
+    if (metadata === undefined) {
+      throw new Error(
+        `Skill '${name}' referenced but not available on this agent`,
+      );
+    }
+
+    try {
+      const loaded = await loadSkill(metadata, ctx.backend);
+      this.skillsLoaded.set(name, loaded);
+      return loaded;
+    } catch (err) {
+      this.skillsFailed.set(name, err as Error);
+      throw err;
+    }
+  }
+
+  private async resolveSpecifier(specifier: string): Promise<string> {
+    const parsed = parseSkillSpecifier(specifier);
+    if (parsed === undefined) {
+      return makeErrorSource(`Module not found: ${specifier}`);
+    }
+
+    let loaded: LoadedSkill;
+    try {
+      loaded = await this.ensureSkillLoaded(parsed.name);
+    } catch (err) {
+      return makeErrorSource((err as Error).message ?? String(err));
+    }
+
+    if (parsed.rel === undefined) {
+      const source = loaded.files.get(loaded.entryRel);
+      if (source === undefined) {
+        return makeErrorSource(
+          `Skill '${parsed.name}': entrypoint '${loaded.entryRel}' missing from bundle`,
+        );
+      }
+      return source;
+    }
+
+    const source = loaded.files.get(parsed.rel);
+    if (source === undefined) {
+      return makeErrorSource(
+        `Skill '${parsed.name}': '${parsed.rel}' not found in bundle`,
+      );
+    }
+
+    return source;
+  }
+
+  /**
+   * Canonicalize an `import` specifier. Bare specifiers pass through;
+   * relative specifiers are resolved against the importing module's path.
+   * Traversal out of a skill's `@/skills/<name>/` namespace is rejected.
+   */
+  private normalizeSpecifier(base: string, requested: string): string {
+    const isRelative =
+      requested.startsWith("./") || requested.startsWith("../");
+    if (!isRelative) {
+      return requested;
+    }
+
+    // A bare skill specifier like "@/skills/my-skill" has no file component, so
+    // posixDirname would return "@/skills". Treat the bare specifier itself as
+    // the directory so that "./lib/math.js" resolves to "@/skills/my-skill/lib/math.js".
+    const parsed = parseSkillSpecifier(base);
+    const baseDir =
+      parsed !== undefined && parsed.rel === undefined
+        ? base
+        : posixDirname(base);
+    const resolved = posixJoin(baseDir, requested);
+
+    const skillPrefix = matchSkillPrefix(base);
+    if (skillPrefix === undefined) {
+      return resolved;
+    }
+
+    if (!resolved.startsWith(`${skillPrefix}/`)) {
+      return `__resolve_error__:${requested} escapes ${skillPrefix}`;
+    }
+
+    return resolved;
+  }
+
+  /**
+   * Wire the QuickJS module loader and normalizer on this session's runtime.
+   */
+  private installModuleLoader(): void {
+    if (this.runtime === null) {
+      return;
+    }
+
+    this.runtime.setModuleLoader(
+      async (specifier: string) => this.resolveSpecifier(specifier),
+      (base: string, requested: string) =>
+        this.normalizeSpecifier(base, requested),
+    );
   }
 
   /**
@@ -148,6 +367,15 @@ export class ReplSession {
     if (session) {
       session.dispose();
     }
+  }
+
+  /**
+   * Push the current skills metadata + backend into the session.
+   * Called by the middleware once per `js_eval` invocation, before eval runs.
+   * Pass `undefined` to clear the context (no skill imports will resolve).
+   */
+  setSkillsContext(ctx?: SkillsContext): void {
+    this.skillsContext = ctx;
   }
 
   /**
@@ -265,6 +493,12 @@ export class ReplSession {
       session.dispose();
     }
     ReplSession.sessions.clear();
+    // Multi-file skill imports (2+ asyncify unwind/rewind cycles in one
+    // evalCodeAsync) leave the shared WASM module's asyncify state corrupted
+    // after the runtime that performed them is disposed. New runtimes on the
+    // same module will silently fail to invoke module loader callbacks. Force
+    // a fresh WASM module so the next session starts clean.
+    asyncModulePromise = undefined;
   }
 
   private setupConsole(): void {

--- a/libs/providers/quickjs/src/skills.test.ts
+++ b/libs/providers/quickjs/src/skills.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from "vitest";
+import type {
+  AnyBackendProtocol,
+  FileDownloadResponse,
+  SkillMetadata,
+} from "deepagents";
+
+import {
+  loadSkill,
+  scanSkillReferences,
+  MAX_SKILL_BUNDLE_BYTES,
+} from "./skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SKILL_DIR = "/skills/my-skill";
+const ENTRY_ABS = `${SKILL_DIR}/index.ts`;
+
+function makeSkillMeta(overrides?: Partial<SkillMetadata>): SkillMetadata {
+  return {
+    name: "my-skill",
+    description: "A test skill",
+    path: `${SKILL_DIR}/SKILL.md`,
+    module: "index.ts",
+    ...overrides,
+  };
+}
+
+type GlobFn = (
+  pattern: string,
+  path?: string,
+) => Promise<{ files?: { path: string }[]; error?: string }>;
+type DownloadFn = (paths: string[]) => Promise<FileDownloadResponse[]>;
+
+function makeBackend(overrides: {
+  glob?: GlobFn;
+  downloadFiles?: DownloadFn;
+}): AnyBackendProtocol {
+  return {
+    glob: overrides.glob ?? (() => Promise.resolve({ files: [] })),
+    downloadFiles: overrides.downloadFiles,
+  } as unknown as AnyBackendProtocol;
+}
+
+const enc = new TextEncoder();
+
+function src(code: string): Uint8Array {
+  return enc.encode(code);
+}
+
+/** Returns a file at `absPath` for the matching extension, empty for all others. */
+function globFor(absPath: string): GlobFn {
+  return async (pattern) => {
+    const ext = pattern.replace("**/*", "");
+    if (absPath.endsWith(ext)) {
+      return { files: [{ path: absPath }] };
+    }
+    return { files: [] };
+  };
+}
+
+function downloadWith(responses: FileDownloadResponse[]): DownloadFn {
+  return async () => responses;
+}
+
+function okResponse(path: string, code: string): FileDownloadResponse {
+  return { path, content: src(code), error: null };
+}
+
+// ---------------------------------------------------------------------------
+// loadSkill
+// ---------------------------------------------------------------------------
+
+describe("loadSkill", () => {
+  describe("validation", () => {
+    it("throws on a non-kebab-case skill name", async () => {
+      const meta = makeSkillMeta({ name: "MySkill" });
+      await expect(loadSkill(meta, makeBackend({}))).rejects.toThrow(
+        "not a valid kebab-case",
+      );
+    });
+
+    it("throws when module is undefined", async () => {
+      const meta = makeSkillMeta({ module: undefined });
+      await expect(loadSkill(meta, makeBackend({}))).rejects.toThrow(
+        "no 'module' frontmatter key",
+      );
+    });
+
+    it("throws when backend has no downloadFiles", async () => {
+      const meta = makeSkillMeta();
+      const backend = makeBackend({ downloadFiles: undefined });
+      await expect(loadSkill(meta, backend)).rejects.toThrow(
+        "backend does not implement downloadFiles",
+      );
+    });
+  });
+
+  describe("glob failures", () => {
+    it("throws when glob returns an error", async () => {
+      const backend = makeBackend({
+        glob: async () => ({ error: "permission denied" }),
+        downloadFiles: downloadWith([]),
+      });
+      await expect(loadSkill(makeSkillMeta(), backend)).rejects.toThrow(
+        "failed to list",
+      );
+    });
+
+    it("throws when no JS/TS files are found under the skill directory", async () => {
+      const backend = makeBackend({
+        glob: async () => ({ files: [] }),
+        downloadFiles: downloadWith([]),
+      });
+      await expect(loadSkill(makeSkillMeta(), backend)).rejects.toThrow(
+        "no JS/TS files",
+      );
+    });
+  });
+
+  describe("download failures", () => {
+    it("throws when a file download returns an error", async () => {
+      const backend = makeBackend({
+        glob: globFor(ENTRY_ABS),
+        downloadFiles: downloadWith([
+          { path: ENTRY_ABS, content: null, error: "file_not_found" },
+        ]),
+      });
+      await expect(loadSkill(makeSkillMeta(), backend)).rejects.toThrow(
+        "failed to download",
+      );
+    });
+
+    it("throws when file content is not valid UTF-8", async () => {
+      const backend = makeBackend({
+        glob: globFor(ENTRY_ABS),
+        downloadFiles: downloadWith([
+          {
+            path: ENTRY_ABS,
+            content: new Uint8Array([0xff, 0xfe, 0x00]),
+            error: null,
+          },
+        ]),
+      });
+      await expect(loadSkill(makeSkillMeta(), backend)).rejects.toThrow(
+        "not valid UTF-8",
+      );
+    });
+
+    it("throws when the total bundle size exceeds the limit", async () => {
+      const bigCode = "x".repeat(MAX_SKILL_BUNDLE_BYTES + 1);
+      const backend = makeBackend({
+        glob: globFor(ENTRY_ABS),
+        downloadFiles: downloadWith([okResponse(ENTRY_ABS, bigCode)]),
+      });
+      await expect(loadSkill(makeSkillMeta(), backend)).rejects.toThrow(
+        "bundle exceeds",
+      );
+    });
+  });
+
+  describe("file map failures", () => {
+    it("throws when the declared entrypoint is not in the enumerated files", async () => {
+      const meta = makeSkillMeta({ module: "missing.ts" });
+      const backend = makeBackend({
+        glob: globFor(ENTRY_ABS), // returns index.ts, not missing.ts
+        downloadFiles: downloadWith([
+          okResponse(ENTRY_ABS, "export const x = 1;"),
+        ]),
+      });
+      await expect(loadSkill(meta, backend)).rejects.toThrow(
+        "did not match any file",
+      );
+    });
+
+    it("throws when a file path escapes the skill directory", async () => {
+      const escapePath = "/other-skills/sneaky.ts";
+      const backend = makeBackend({
+        glob: async (pattern) => {
+          if (pattern.endsWith(".ts")) {
+            return { files: [{ path: escapePath }] };
+          }
+          return { files: [] };
+        },
+        downloadFiles: downloadWith([
+          okResponse(escapePath, "export const x = 1;"),
+        ]),
+      });
+      await expect(loadSkill(makeSkillMeta(), backend)).rejects.toThrow(
+        "is not under",
+      );
+    });
+  });
+
+  describe("happy path", () => {
+    it("returns a LoadedSkill with the correct shape", async () => {
+      const backend = makeBackend({
+        glob: globFor(ENTRY_ABS),
+        downloadFiles: downloadWith([
+          okResponse(ENTRY_ABS, "export const x = 1;"),
+        ]),
+      });
+
+      const loaded = await loadSkill(makeSkillMeta(), backend);
+
+      expect(loaded.name).toBe("my-skill");
+      expect(loaded.specifier).toBe("@/skills/my-skill");
+      expect(loaded.entryRel).toBe("index.ts");
+    });
+
+    it("keys files by relative POSIX path, not absolute path", async () => {
+      const backend = makeBackend({
+        glob: globFor(ENTRY_ABS),
+        downloadFiles: downloadWith([
+          okResponse(ENTRY_ABS, "export const x = 1;"),
+        ]),
+      });
+
+      const loaded = await loadSkill(makeSkillMeta(), backend);
+
+      expect(loaded.files.has("index.ts")).toBe(true);
+      expect(loaded.files.has(ENTRY_ABS)).toBe(false);
+    });
+
+    it("strips TypeScript syntax from file sources", async () => {
+      const tsCode =
+        "export function greet(name: string): string { return name; }";
+      const backend = makeBackend({
+        glob: globFor(ENTRY_ABS),
+        downloadFiles: downloadWith([okResponse(ENTRY_ABS, tsCode)]),
+      });
+
+      const loaded = await loadSkill(makeSkillMeta(), backend);
+
+      const stripped = loaded.files.get("index.ts")!;
+      expect(stripped).toContain("function greet");
+      expect(stripped).not.toContain(": string");
+    });
+
+    it("handles a skill with multiple files", async () => {
+      const helperAbs = `${SKILL_DIR}/lib/helper.ts`;
+      const backend = makeBackend({
+        glob: async (pattern) => {
+          if (pattern.endsWith(".ts")) {
+            return { files: [{ path: ENTRY_ABS }, { path: helperAbs }] };
+          }
+          return { files: [] };
+        },
+        downloadFiles: downloadWith([
+          okResponse(ENTRY_ABS, "export { greet } from './lib/helper.js';"),
+          okResponse(helperAbs, "export function greet() { return 'hi'; }"),
+        ]),
+      });
+
+      const loaded = await loadSkill(makeSkillMeta(), backend);
+
+      expect(loaded.files.size).toBe(2);
+      expect(loaded.files.has("index.ts")).toBe(true);
+      expect(loaded.files.has("lib/helper.ts")).toBe(true);
+    });
+
+    it("accepts a multi-segment kebab-case skill name", async () => {
+      const dir = "/skills/pdf-extract";
+      const entry = `${dir}/index.ts`;
+      const meta = makeSkillMeta({
+        name: "pdf-extract",
+        path: `${dir}/SKILL.md`,
+        module: "index.ts",
+      });
+      const backend = makeBackend({
+        glob: globFor(entry),
+        downloadFiles: downloadWith([okResponse(entry, "export const x = 1;")]),
+      });
+
+      const loaded = await loadSkill(meta, backend);
+
+      expect(loaded.specifier).toBe("@/skills/pdf-extract");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanSkillReferences
+// ---------------------------------------------------------------------------
+
+describe("scanSkillReferences", () => {
+  it("returns an empty set for empty source", () => {
+    expect(scanSkillReferences("")).toEqual(new Set());
+  });
+
+  it("returns an empty set when no skill references are present", () => {
+    expect(scanSkillReferences("const x = 1;")).toEqual(new Set());
+  });
+
+  it("detects a double-quoted skill reference", () => {
+    expect(scanSkillReferences(`import("@/skills/foo")`)).toEqual(
+      new Set(["foo"]),
+    );
+  });
+
+  it("detects a single-quoted skill reference", () => {
+    expect(scanSkillReferences(`import('@/skills/bar')`)).toEqual(
+      new Set(["bar"]),
+    );
+  });
+
+  it("detects multiple distinct skill references", () => {
+    const code = `
+      const a = await import("@/skills/pdf-extract");
+      const b = await import("@/skills/csv-parser");
+    `;
+    expect(scanSkillReferences(code)).toEqual(
+      new Set(["pdf-extract", "csv-parser"]),
+    );
+  });
+
+  it("deduplicates repeated references to the same skill", () => {
+    const code = `import("@/skills/foo"); import("@/skills/foo");`;
+    expect(scanSkillReferences(code)).toEqual(new Set(["foo"]));
+  });
+
+  it("does not detect template literal specifiers", () => {
+    expect(scanSkillReferences("import(`@/skills/foo`)")).toEqual(new Set());
+  });
+
+  it("does not match a bare @/skills/ prefix with no name", () => {
+    expect(scanSkillReferences(`"@/skills/"`)).toEqual(new Set());
+  });
+});

--- a/libs/providers/quickjs/src/skills.ts
+++ b/libs/providers/quickjs/src/skills.ts
@@ -1,0 +1,263 @@
+import * as posix from "node:path/posix";
+
+import {
+  adaptBackendProtocol,
+  BackendProtocolV2,
+  type AnyBackendProtocol,
+  type FileDownloadResponse,
+  type FileInfo,
+  type SkillMetadata,
+} from "deepagents";
+
+import { stripTypeSyntax } from "./transform.js";
+
+/**
+ * File extensions the loader will enumerate from a skill directory.
+ */
+export const SKILL_MODULE_EXTENSIONS = [
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".mts",
+  ".cts",
+  ".jsx",
+  ".tsx",
+];
+
+/**
+ * Hard cap on total bytes pulled for one skill's bundle (1 MiB).
+ */
+export const MAX_SKILL_BUNDLE_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Validates a skill name against the spec's kebab-case rule.
+ */
+const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Matches `"@/skills/<name>"` or `'@/skills/<name>'` references in source.
+ * Template literals and computed specifiers are not caught.
+ */
+const SKILL_SPECIFIER_RE = /["']@\/skills\/([a-z0-9]+(?:-[a-z0-9]+)*)["']/g;
+
+/**
+ * Install-ready state for a single skill, produced by `loadSkill`.
+ */
+export interface LoadedSkill {
+  /**
+   * Spec-validated kebab-case skill name.
+   */
+  name: string;
+
+  /**
+   * Bare specifier the skill installs under: `"@/skills/<name>"`.
+   */
+  specifier: string;
+
+  /**
+   * Relative POSIX path of the entrypoint file (e.g. `"index.ts"`).
+   */
+  entryRel: string;
+
+  /**
+   * File contents keyed by relative POSIX path, with TS syntax stripped.
+   */
+  files: Map<string, string>;
+}
+
+/**
+ * List every code-extension file under `skillDir` (recursive).
+ */
+async function enumerateCodeFiles(
+  backend: BackendProtocolV2,
+  skillDir: string,
+  skillName: string,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  for (const ext of SKILL_MODULE_EXTENSIONS) {
+    const result = await backend.glob(`**/*${ext}`, skillDir);
+    if (result.error !== undefined) {
+      throw new Error(
+        `Skill '${skillName}': failed to list '${skillDir}': ${result.error}`,
+      );
+    }
+
+    const matches: FileInfo[] = result.files ?? [];
+    for (const match of matches) {
+      seen.add(match.path);
+    }
+  }
+
+  return [...seen].sort();
+}
+
+/**
+ * Decode download responses into [path, source] pairs.
+ */
+function decodeFiles(
+  responses: FileDownloadResponse[],
+  skillName: string,
+): Array<[string, string]> {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+
+  const pairs: Array<[string, string]> = [];
+  for (const response of responses) {
+    if (response.error !== null || response.content === null) {
+      throw new Error(
+        `Skill '${skillName}': failed to download '${response.path}': ${response.error ?? "no content"}`,
+      );
+    }
+
+    let source: string;
+    try {
+      source = decoder.decode(response.content);
+    } catch {
+      throw new Error(
+        `Skill '${skillName}': file '${response.path}' is not valid UTF-8`,
+      );
+    }
+
+    pairs.push([response.path, source]);
+  }
+
+  return pairs;
+}
+
+/**
+ * Throws an Error when the total decoded size of all files exceeds
+ * `MAX_SKILL_BUNDLE_BYTES`. Counts characters rather than bytes, which
+ * over-counts multi-byte UTF-8. Intentionally errs toward rejection.
+ */
+function validateBundleSize(
+  pairs: Array<[string, string]>,
+  skillName: string,
+): void {
+  let total = 0;
+  for (const [, source] of pairs) {
+    total += source.length;
+  }
+
+  if (total > MAX_SKILL_BUNDLE_BYTES) {
+    throw new Error(
+      `Skill '${skillName}': bundle exceeds ${MAX_SKILL_BUNDLE_BYTES} bytes (total ${total})`,
+    );
+  }
+}
+
+/**
+ * Express `absolutePath` as a POSIX-relative path under `skillDir`.
+ * Throws an Error if the path escapes the skill directory which indicates
+ * a backend bug, not a user error.
+ */
+function relativeUnder(
+  skillDir: string,
+  absolutePath: string,
+  skillName: string,
+): string {
+  const rel = posix.relative(skillDir, absolutePath);
+  if (rel === "" || rel.startsWith("..")) {
+    throw new Error(
+      `Skill '${skillName}': file ${absolutePath} is not under '${skillDir}'`,
+    );
+  }
+  return rel;
+}
+
+/**
+ * Build the relative-path → source map, applying `stripTypeSyntax` to each file.
+ */
+function buildFilesMap(
+  skillDir: string,
+  entryRel: string,
+  pairs: Array<[string, string]>,
+  skillName: string,
+): Map<string, string> {
+  const files = new Map<string, string>();
+  let entryPresent = false;
+
+  for (const [absPath, source] of pairs) {
+    const rel = relativeUnder(skillDir, absPath, skillName);
+    files.set(rel, stripTypeSyntax(source));
+    if (rel === entryRel) {
+      entryPresent = true;
+    }
+  }
+
+  if (!entryPresent) {
+    throw new Error(
+      `Skill '${skillName}': module path '${entryRel}' did not match any file in the skill directory`,
+    );
+  }
+
+  return files;
+}
+
+/**
+ * Build a `LoadedSkill` from a skill's metadata and a backend handle.
+ *
+ * Enumerates code files under the skill directory, downloads them,
+ * strips TypeScript syntax, and validates the entrypoint is present.
+ */
+export async function loadSkill(
+  metadata: SkillMetadata,
+  backend: AnyBackendProtocol,
+): Promise<LoadedSkill> {
+  const name = metadata.name;
+
+  if (!SKILL_NAME_RE.test(name)) {
+    throw new Error(
+      `Skill name '${name}' is not a valid kebab-case identifier`,
+    );
+  }
+
+  const entryRel = metadata.module;
+  if (entryRel === undefined || entryRel === "") {
+    throw new Error(
+      `Skill '${name}' has no 'module' frontmatter key - only skills with a declared entrypoint are installable`,
+    );
+  }
+
+  const adapted = adaptBackendProtocol(backend);
+  if (adapted.downloadFiles === undefined) {
+    throw new Error(
+      `Skill '${name}': backend does not implement downloadFiles`,
+    );
+  }
+
+  const skillDir = posix.dirname(metadata.path);
+  const codeFiles = await enumerateCodeFiles(adapted, skillDir, name);
+  if (codeFiles.length === 0) {
+    throw new Error(`Skill '${name}': no JS/TS files under '${skillDir}'`);
+  }
+
+  const responses = await adapted.downloadFiles(codeFiles);
+  const filePairs = decodeFiles(responses, name);
+  validateBundleSize(filePairs, name);
+
+  const files = buildFilesMap(skillDir, entryRel, filePairs, name);
+  return {
+    name,
+    specifier: `@/skills/${name}`,
+    entryRel,
+    files,
+  };
+}
+
+/**
+ * Extract skill names referenced by `"@/skills/<name>"` literals in source.
+ *
+ * Used as a pre-eval scan so the middleware can surface `SkillNotAvailable`
+ * before evaluation starts. Dynamic imports with computed specifiers are
+ * not detected.
+ */
+export function scanSkillReferences(source: string): Set<string> {
+  const names = new Set<string>();
+
+  const matches = source.matchAll(SKILL_SPECIFIER_RE);
+  for (const match of matches) {
+    names.add(match[1]);
+  }
+
+  return names;
+}

--- a/libs/providers/quickjs/src/transform.test.ts
+++ b/libs/providers/quickjs/src/transform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { transformForEval } from "./transform.js";
+import { transformForEval, stripTypeSyntax } from "./transform.js";
 
 describe("transformForEval", () => {
   describe("basic wrapping", () => {
@@ -159,6 +159,162 @@ describe("transformForEval", () => {
       const result = transformForEval("{{{{invalid syntax");
       expect(result).toContain("(async () => {");
       expect(result).toContain("{{{{invalid syntax");
+    });
+  });
+});
+
+describe("stripTypeSyntax", () => {
+  describe("plain JS passthrough", () => {
+    it("returns an empty string unchanged", () => {
+      expect(stripTypeSyntax("")).toBe("");
+    });
+
+    it("returns plain JS module unchanged", () => {
+      const code = `export function add(a, b) { return a + b; }`;
+      expect(stripTypeSyntax(code)).toBe(code);
+    });
+  });
+
+  describe("TS-only top-level forms are removed", () => {
+    it("removes interface declarations", () => {
+      const result = stripTypeSyntax("interface Foo { x: number }");
+      expect(result).not.toContain("interface");
+      expect(result.trim()).toBe("");
+    });
+
+    it("removes type aliases", () => {
+      const result = stripTypeSyntax("type ID = string;");
+      expect(result).not.toContain("type ID");
+      expect(result.trim()).toBe("");
+    });
+
+    it("removes enum declarations", () => {
+      const result = stripTypeSyntax("enum Direction { Up, Down }");
+      expect(result).not.toContain("enum");
+      expect(result.trim()).toBe("");
+    });
+
+    it("removes declare function", () => {
+      const result = stripTypeSyntax("declare function foo(x: number): void;");
+      expect(result).not.toContain("declare");
+      expect(result.trim()).toBe("");
+    });
+
+    it("removes mixed TS-only and JS nodes, keeping JS", () => {
+      const code = [
+        "interface Foo { x: number }",
+        "export function bar() { return 1; }",
+      ].join("\n");
+      const result = stripTypeSyntax(code);
+      expect(result).not.toContain("interface");
+      expect(result).toContain("export function bar");
+    });
+  });
+
+  describe("type annotations stripped from expressions", () => {
+    it("strips parameter types", () => {
+      const result = stripTypeSyntax(
+        "export function add(a: number, b: number) { return a + b; }",
+      );
+      expect(result).toContain("function add(a, b)");
+      expect(result).not.toContain(": number");
+    });
+
+    it("strips return types", () => {
+      const result = stripTypeSyntax(
+        "export function id(x: string): string { return x; }",
+      );
+      expect(result).not.toContain("): string");
+      expect(result).toContain("function id");
+    });
+
+    it("strips generics from function declarations", () => {
+      const result = stripTypeSyntax(
+        "export function wrap<T>(x: T): T { return x; }",
+      );
+      expect(result).not.toContain("<T>");
+      expect(result).toContain("function wrap");
+    });
+
+    it("strips `as` type casts", () => {
+      const result = stripTypeSyntax(
+        "export const x = JSON.parse(raw) as { n: number };",
+      );
+      expect(result).toContain("JSON.parse(raw)");
+      expect(result).not.toContain("as {");
+    });
+
+    it("strips non-null assertions", () => {
+      const result = stripTypeSyntax(
+        "export const el = document.getElementById('x')!;",
+      );
+      expect(result).toContain("document.getElementById('x')");
+      expect(result).not.toMatch(/getElementById\('x'\)!/);
+    });
+
+    it("strips satisfies expressions", () => {
+      const result = stripTypeSyntax(
+        "export const cfg = { port: 8080 } satisfies Config;",
+      );
+      expect(result).toContain("{ port: 8080 }");
+      expect(result).not.toContain("satisfies");
+    });
+
+    it("strips type annotations from variable declarations", () => {
+      const result = stripTypeSyntax("const x: number = 42;");
+      expect(result).toContain("const x");
+      expect(result).not.toContain(": number");
+    });
+  });
+
+  describe("import and export declarations survive", () => {
+    it("preserves named import declarations", () => {
+      const result = stripTypeSyntax(`import { foo } from "./foo.js";`);
+      expect(result).toContain(`import { foo } from "./foo.js"`);
+    });
+
+    it("preserves default import declarations", () => {
+      const result = stripTypeSyntax(`import bar from "./bar.js";`);
+      expect(result).toContain(`import bar from "./bar.js"`);
+    });
+
+    it("preserves named export declarations", () => {
+      const result = stripTypeSyntax(
+        "export function greet() { return 'hi'; }",
+      );
+      expect(result).toContain("export function greet");
+    });
+
+    it("preserves export default", () => {
+      const result = stripTypeSyntax(
+        "export default function () { return 1; }",
+      );
+      expect(result).toContain("export default function");
+    });
+
+    it("preserves re-export declarations", () => {
+      const result = stripTypeSyntax(`export { foo } from "./foo.js";`);
+      expect(result).toContain(`export { foo } from "./foo.js"`);
+    });
+
+    it("strips type-only imports without leaving behind empty lines that break syntax", () => {
+      const code = [
+        `import type { Foo } from "./types.js";`,
+        `export function bar() { return 1; }`,
+      ].join("\n");
+      const result = stripTypeSyntax(code);
+      expect(result).toContain("export function bar");
+    });
+  });
+
+  describe("parse failure fallback", () => {
+    it("returns original source on invalid syntax", () => {
+      const code = "{{{{invalid syntax";
+      expect(stripTypeSyntax(code)).toBe(code);
+    });
+
+    it("does not throw on parse failure", () => {
+      expect(() => stripTypeSyntax("}{")).not.toThrow();
     });
   });
 });

--- a/libs/providers/quickjs/src/transform.ts
+++ b/libs/providers/quickjs/src/transform.ts
@@ -293,3 +293,47 @@ function findLastNonEmptyNode(
 function isExpression(node: AcornNode): boolean {
   return node.type === "ExpressionStatement";
 }
+
+/**
+ * Strip TypeScript type syntax from an ES-module source so QuickJS can
+ * evaluate it as a standard JS module.
+ *
+ * Unlike `transformForEval`, this keeps `import`/`export` declarations,
+ * does not hoist to `globalThis`, and does not wrap in an IIFE.
+ * On parse failure the original source is returned unchanged.
+ */
+export function stripTypeSyntax(code: string): string {
+  let ast: AcornNode;
+  try {
+    ast = TSParser.parse(code, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      locations: true,
+    }) as unknown as AcornNode;
+  } catch {
+    // Return the original source unchanged rather than throwing or returning an empty string.
+    // We don't know why the parse failed - it could be a valid plain-JS file that hit an
+    // acorn-typescript incompatibility, in which case returning it unchanged lets QuickJS
+    // evaluate it correctly. If it's genuinely broken TS, QuickJS will surface the parse error
+    // at evaluation time with a useful line/column.
+    return code;
+  }
+
+  const magicString = new MagicString(code);
+  const program = ast as unknown as { body: AcornNode[] };
+
+  for (const node of program.body) {
+    if (isTSOnlyNode(node)) {
+      magicString.remove(node.start, node.end);
+      continue;
+    }
+
+    walk(node as any, {
+      enter(n: any) {
+        stripTypeAnnotationFromNode(magicString, n);
+      },
+    });
+  }
+
+  return magicString.toString();
+}

--- a/libs/providers/quickjs/src/types.ts
+++ b/libs/providers/quickjs/src/types.ts
@@ -1,6 +1,10 @@
 import type { StructuredToolInterface } from "@langchain/core/tools";
 
-import type { AnyBackendProtocol, SkillMetadata } from "deepagents";
+import type {
+  AnyBackendProtocol,
+  BackendFactory,
+  SkillMetadata,
+} from "deepagents";
 
 /**
  * Configuration options for the QuickJS REPL middleware.
@@ -42,10 +46,10 @@ export interface QuickJSMiddlewareOptions {
   systemPrompt?: string | null;
 
   /**
-   * Enables the `@/skills/<name>` module loader on the QuickJS runtime.
-   * @default false
+   * Backend the REPL reads skill module sources from. When provided alongside
+   * `SkillsMiddleware`, skills with a `module:` key become dynamic-importable.
    */
-  skillsEnabled?: boolean;
+  skillsBackend?: AnyBackendProtocol | BackendFactory;
 }
 
 /**

--- a/libs/providers/quickjs/src/types.ts
+++ b/libs/providers/quickjs/src/types.ts
@@ -1,5 +1,7 @@
 import type { StructuredToolInterface } from "@langchain/core/tools";
 
+import type { AnyBackendProtocol, SkillMetadata } from "deepagents";
+
 /**
  * Configuration options for the QuickJS REPL middleware.
  */
@@ -38,6 +40,12 @@ export interface QuickJSMiddlewareOptions {
    * @default null (uses built-in prompt)
    */
   systemPrompt?: string | null;
+
+  /**
+   * Enables the `@/skills/<name>` module loader on the QuickJS runtime.
+   * @default false
+   */
+  skillsEnabled?: boolean;
 }
 
 /**
@@ -47,6 +55,7 @@ export interface ReplSessionOptions {
   memoryLimitBytes?: number;
   maxStackSizeBytes?: number;
   tools?: StructuredToolInterface[];
+  skillsEnabled?: boolean;
 }
 
 /**
@@ -57,4 +66,19 @@ export interface ReplResult {
   value?: unknown;
   error?: { name?: string; message?: string; stack?: string };
   logs: string[];
+}
+
+/**
+ * Metadata + backend pair the session needs to resolve skill imports.
+ */
+export interface SkillsContext {
+  /**
+   * Per-eval snapshot of `state.skillsMetadata`.
+   */
+  metadata: SkillMetadata[];
+
+  /**
+   * Backend the session fetches skill source files from.
+   */
+  backend: AnyBackendProtocol;
 }

--- a/libs/providers/quickjs/src/utils.ts
+++ b/libs/providers/quickjs/src/utils.ts
@@ -115,9 +115,9 @@ export async function toolToTypeSignature(
 }
 
 /**
- * Render a pre-eval skill-availability failure matching the Python error shape.
+ * Render a pre-eval error when referenced skills are not available on the agent.
  */
 export function formatSkillNotAvailable(missing: readonly string[]): string {
   const list = [...missing].sort().join(", ");
-  return `<error type="SkillNotAvailable">${list}</error>`;
+  return `Skills unavailable: ${list}`;
 }

--- a/libs/providers/quickjs/src/utils.ts
+++ b/libs/providers/quickjs/src/utils.ts
@@ -113,3 +113,11 @@ export async function toolToTypeSignature(
     async tools.${name}(input: ${inputType}): Promise<string>
   `;
 }
+
+/**
+ * Render a pre-eval skill-availability failure matching the Python error shape.
+ */
+export function formatSkillNotAvailable(missing: readonly string[]): string {
+  const list = [...missing].sort().join(", ");
+  return `<error type="SkillNotAvailable">${list}</error>`;
+}


### PR DESCRIPTION
### Summary

Adds functional skill modules to the QuickJS REPL. Skills can now ship JS/TS entrypoints via a module: frontmatter key on SKILL.md, which the model dynamically imports at eval time with await import("@/skills/<name>").

When skillsBackend is passed to createQuickJSMiddleware, the middleware reads skillsMetadata from the current task state before each eval, scans the source for skill references, and pushes the metadata + backend into the session. The session wires a QuickJS module loader that lazily fetches skill files from the backend, strips TypeScript syntax, and caches the result for the lifetime of the session. Skills that are referenced but not available on the agent short-circuit with a clear error before evaluation starts.

On the deepagents side, SkillMetadata gains an optional module field (validated and normalized from frontmatter), and formatSkillsList now advertises importable skills in the system prompt with an await import(...) hint.

```ts
const backend = new FilesystemBackend({ rootDir: "/project", virtualMode: true });

const agent = createDeepAgent({
  model: "claude-sonnet-4-6",
  backend,
  skills: ["/skills/"],
  middleware: [
    createQuickJSMiddleware({ skillsBackend: backend }),
  ],
});
```

### Tests

- Unit tests cover module path validation, TS syntax stripping, skill loading (single/multi-file, error cases, bundle size cap), skill reference scanning, module loader resolution and caching, and system prompt formatting
- Ran an E2E eval that exercised the full pipeline from SKILL.md parse through dynamic import and function call in the REPL, with a LangSmith trace

### Benchmarks

#### memory: console_log concurrent
- Total time: 15820ms

| name                     | hz      | min    | max    | mean   | p75    | p99    | p995   | p999   | rme    | samples |
|--------------------------|---------|--------|--------|--------|--------|--------|--------|--------|--------|---------|
| 1 concurrent sessions    | 145.91  | 1.8263 | 27.7702| 6.8536 | 9.1753 | 21.1492| 25.0420| 27.7702| ±5.30% | 730     |
| 8 concurrent sessions    | 39.1773 | 15.5854| 61.5015| 25.5250| 27.8461| 49.0536| 61.5015| 61.5015| ±3.58% | 196     |
| 32 concurrent sessions   | 13.9753 | 48.5504| 110.40 | 71.5547| 76.6394| 110.40 | 110.40 | 110.40 | ±3.72% | 70      |

---

#### memory: ptc_tools concurrent
- Total time: 16755ms

| name                     | hz      | min    | max    | mean   | p75    | p99    | p995   | p999   | rme    | samples |
|--------------------------|---------|--------|--------|--------|--------|--------|--------|--------|--------|---------|
| 1 concurrent sessions    | 86.9205 | 4.1809 | 32.1833| 11.5048| 15.3222| 25.2676| 28.2697| 32.1833| ±4.76% | 435     |
| 8 concurrent sessions    | 21.8310 | 33.5598| 69.0041| 45.8065| 50.8740| 60.2001| 69.0041| 69.0041| ±2.77% | 110     |
| 32 concurrent sessions   | 7.0269  | 137.88 | 148.90 | 142.31 | 144.05 | 148.90 | 148.90 | 148.90 | ±0.70% | 36      |

---

#### throughput: single thread many iterations
- Total time: 31656ms

| name                                      | hz     | min    | max    | mean   | p75    | p99    | p995   | p999   | rme    | samples |
|-------------------------------------------|--------|--------|--------|--------|--------|--------|--------|--------|--------|---------|
| 200 sequential evals (ptc + console.log)  | 3.5897 | 240.92 | 347.19 | 278.58 | 289.81 | 341.02 | 347.19 | 347.19 | ±1.44% | 108     |