### PR TITLE
fix(quickjs): add ls_code_input_language metadata to js_eval tool

### DIFF
--- a/.changeset/ten-eyes-develop.md
+++ b/.changeset/ten-eyes-develop.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+fix(quickjs): add ls_code_input_language metadata to js_eval tool

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -20,11 +20,21 @@ describe("createQuickJSMiddleware", () => {
       expect(middleware.tools).toBeDefined();
       const names = middleware.tools!.map((t: { name: string }) => t.name);
       expect(names).toContain("js_eval");
+      const jsEval = middleware.tools!.find(
+        (t: { name: string }) => t.name === "js_eval",
+      ) as {
+        metadata?: Record<string, unknown>;
+      };
+      expect(jsEval.metadata?.ls_code_input_language).toBe("javascript");
     });
 
     it("should register exactly one tool", () => {
       const middleware = createQuickJSMiddleware();
       expect(middleware.tools!.length).toBe(1);
+      expect(
+        (middleware.tools![0] as { metadata?: Record<string, unknown> })
+          .metadata,
+      ).toMatchObject({ ls_code_input_language: "javascript" });
     });
   });
 

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -183,6 +183,7 @@ export function createQuickJSMiddleware(
         Use console.log() for output. Returns the result of the last expression.
         If file or other tools are available, call them via the tools namespace: await tools.readFile({ path }).
       `,
+      metadata: { ls_code_input_language: "javascript" },
       schema: z.object({
         code: z
           .string()


### PR DESCRIPTION
## Summary

Adds LangSmith code-language metadata to the QuickJS REPL evaluation tool so tool inputs are correctly interpreted as JavaScript in traces.

## Changes

### @langchain/quickjs

- Added `metadata: { ls_code_input_language: "javascript" }` to the `js_eval` tool definition in `createQuickJSMiddleware`.
- Extended middleware tool-registration tests to assert that `js_eval` exposes `ls_code_input_language` metadata.
- Verified behavior with quickjs unit tests (`src/middleware.test.ts`).
