### PR TITLE
chore(quickjs): rename to REPLMiddleware and adjust defaults

### DIFF
--- a/.changeset/slick-moose-serve.md
+++ b/.changeset/slick-moose-serve.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+chore(quickjs): rename to REPLMiddleware and adjust defaults

--- a/.changeset/slick-moose-serve.md
+++ b/.changeset/slick-moose-serve.md
@@ -1,5 +1,5 @@
 ---
-"@langchain/quickjs": patch
+"@langchain/quickjs": minor
 ---
 
 chore(quickjs): rename to REPLMiddleware and adjust defaults

--- a/examples/repl/data-analysis-agent.ts
+++ b/examples/repl/data-analysis-agent.ts
@@ -16,7 +16,7 @@ import dedent from "dedent";
 import { HumanMessage } from "@langchain/core/messages";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { createDeepAgent } from "deepagents";
-import { createQuickJSMiddleware } from "@langchain/quickjs";
+import { createREPLMiddleware } from "@langchain/quickjs";
 
 const model = new ChatAnthropic({
   model: "claude-sonnet-4-5",
@@ -26,11 +26,11 @@ const model = new ChatAnthropic({
 const agent = createDeepAgent({
   model,
   systemPrompt: dedent`
-    You are a data analyst. Use the js_eval REPL to perform calculations
+    You are a data analyst. Use the eval REPL to perform calculations
     and data transformations. Always show your work in code — never guess
     at arithmetic or statistics.
   `,
-  middleware: [createQuickJSMiddleware()],
+  middleware: [createREPLMiddleware()],
 });
 
 const result = await agent.invoke({

--- a/examples/repl/rlm-agent.ts
+++ b/examples/repl/rlm-agent.ts
@@ -12,7 +12,7 @@
  *
  * Architecture:
  * ```
- * Agent (with js_eval + PTC)
+ * Agent (with eval + PTC)
  *   └── REPL code
  *       ├── tools.task({ description: "analyze chunk 1", ... })
  *       ├── tools.task({ description: "analyze chunk 2", ... })
@@ -25,7 +25,7 @@ import "dotenv/config";
 import dedent from "dedent";
 import { HumanMessage } from "@langchain/core/messages";
 import { createDeepAgent, type SubAgent } from "deepagents";
-import { createQuickJSMiddleware } from "@langchain/quickjs";
+import { createREPLMiddleware } from "@langchain/quickjs";
 import { ChatOpenAI } from "@langchain/openai";
 
 const generalPurpose: SubAgent = {
@@ -53,7 +53,7 @@ const agent = createDeepAgent({
 
     When given a complex research task:
     1. Break it into independent sub-tasks
-    2. Write a single js_eval call that spawns ALL sub-agents in parallel
+    2. Write a single eval call that spawns ALL sub-agents in parallel
     3. Aggregate and analyze the results programmatically in the same code block
     4. Write your final synthesis to a file
 
@@ -76,12 +76,12 @@ const agent = createDeepAgent({
     \`\`\`
 
     Do all sub-agent spawning, result processing, and file writing in a
-    single js_eval call. Do not use multiple sequential js_eval calls
+    single eval call. Do not use multiple sequential eval calls
     when the work can be parallelized.
   `,
   subagents: [generalPurpose],
   middleware: [
-    createQuickJSMiddleware({
+    createREPLMiddleware({
       ptc: ["task"],
     }),
   ],

--- a/libs/providers/quickjs/src/index.ts
+++ b/libs/providers/quickjs/src/index.ts
@@ -3,7 +3,7 @@
  *
  * Sandboxed JavaScript REPL for deepagents using QuickJS (WASM).
  *
- * Provides a middleware that adds a `js_eval` tool to any deepagent,
+ * Provides a middleware that adds an `eval` tool to any deepagent,
  * enabling code execution in a fully isolated QuickJS WASM sandbox.
  *
  * Features:
@@ -16,12 +16,12 @@
  * @packageDocumentation
  */
 
-export { createQuickJSMiddleware } from "./middleware.js";
+export { createREPLMiddleware } from "./middleware.js";
 
 export { PTCCallBudgetExceededError } from "./errors.js";
 
 export type {
-  QuickJSMiddlewareOptions,
+  REPLMiddlewareOptions,
   ReplSessionOptions,
   ReplResult,
 } from "./types.js";

--- a/libs/providers/quickjs/src/middleware.int.test.ts
+++ b/libs/providers/quickjs/src/middleware.int.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createAgent } from "langchain";
 import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { MemorySaver } from "@langchain/langgraph";
-import { createQuickJSMiddleware } from "./middleware.js";
+import { createREPLMiddleware } from "./middleware.js";
 import { ReplSession } from "./session.js";
 
 import type * as _zodTypes from "@langchain/core/utils/types";
@@ -11,22 +11,22 @@ import type * as _messages from "@langchain/core/messages";
 
 const MODEL = "claude-sonnet-4-5-20250929";
 
-describe("QuickJS REPL integration", () => {
+describe("REPL middleware integration", () => {
   beforeEach(() => {
     ReplSession.clearCache();
   });
 
   it(
-    "should persist REPL state across multiple js_eval calls within the same thread",
+    "should persist REPL state across multiple eval calls within the same thread",
     { timeout: 90_000 },
     async () => {
-      const quickjsMiddleware = createQuickJSMiddleware();
+      const replMiddleware = createREPLMiddleware();
       const checkpointer = new MemorySaver();
       const threadId = `int-repl-persist-${Date.now()}`;
 
       const agent = createAgent({
         model: MODEL,
-        middleware: [quickjsMiddleware],
+        middleware: [replMiddleware],
         checkpointer,
       });
 
@@ -39,7 +39,7 @@ describe("QuickJS REPL integration", () => {
         {
           messages: [
             new HumanMessage(
-              "Use js_eval twice: first call `var x = 99`, then in a separate second call log `x` with console.log. Report the value you see.",
+              "Use eval twice: first call `var x = 99`, then in a separate second call log `x` with console.log. Report the value you see.",
             ),
           ],
         },
@@ -58,13 +58,13 @@ describe("QuickJS REPL integration", () => {
     "should reference variables from prior cells instead of re-embedding data",
     { timeout: 90_000 },
     async () => {
-      const quickjsMiddleware = createQuickJSMiddleware();
+      const replMiddleware = createREPLMiddleware();
       const checkpointer = new MemorySaver();
       const threadId = `int-repl-reuse-${Date.now()}`;
 
       const agent = createAgent({
         model: MODEL,
-        middleware: [quickjsMiddleware],
+        middleware: [replMiddleware],
         checkpointer,
       });
 
@@ -79,9 +79,9 @@ describe("QuickJS REPL integration", () => {
         {
           messages: [
             new HumanMessage(
-              "Using js_eval, first store this data: " +
+              "Using eval, first store this data: " +
                 '[{name: "a", value: 10}, {name: "b", value: 20}, {name: "c", value: 30}]. ' +
-                "Then in a separate js_eval call, compute the sum of all the values.",
+                "Then in a separate eval call, compute the sum of all the values.",
             ),
           ],
         },
@@ -91,14 +91,14 @@ describe("QuickJS REPL integration", () => {
       const toolMessages = result.messages.filter(ToolMessage.isInstance);
       expect(toolMessages.length).toBeGreaterThanOrEqual(2);
 
-      // Verify the second js_eval call does not re-embed the array literal
+      // Verify the second eval call does not re-embed the array literal
       const aiMessages = result.messages.filter(AIMessage.isInstance);
-      const jsEvalCalls = aiMessages.flatMap((msg) =>
-        (msg.tool_calls || []).filter((tc) => tc.name === "js_eval"),
+      const evalCalls = aiMessages.flatMap((msg) =>
+        (msg.tool_calls || []).filter((tc) => tc.name === "eval"),
       );
-      expect(jsEvalCalls.length).toBeGreaterThanOrEqual(2);
+      expect(evalCalls.length).toBeGreaterThanOrEqual(2);
 
-      const secondCallCode = jsEvalCalls[1].args?.code as string;
+      const secondCallCode = evalCalls[1].args?.code as string;
       expect(secondCallCode).not.toContain('"name": "a"');
       expect(secondCallCode).not.toContain('"name": "b"');
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -56,12 +56,12 @@ describe("createREPLMiddleware", () => {
       const req = mockHandler.mock.calls[0][0];
       const text = req.systemMessage.text;
       expect(text).toContain("Base");
-      expect(text).toContain("eval");
-      expect(text).toContain("### Hard rules");
-      expect(text).toContain("### Limitations");
+      expect(text).toContain("### Interpreter");
+      expect(text).toContain("`eval`");
+      expect(text).toContain("5s per call");
+      expect(text).toContain("64 MB total");
       expect(text).not.toContain("async readFile");
       expect(text).not.toContain("async writeFile");
-      expect(text).not.toContain("### First-time usage");
     });
 
     it("should use custom system prompt when provided", async () => {
@@ -82,7 +82,7 @@ describe("createREPLMiddleware", () => {
 
       const req = mockHandler.mock.calls[0][0];
       expect(req.systemMessage.text).toContain("Custom REPL prompt");
-      expect(req.systemMessage.text).not.toContain("Hard rules");
+      expect(req.systemMessage.text).not.toContain("### Interpreter");
     });
   });
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -3,25 +3,25 @@ import { tool } from "langchain";
 import * as z from "zod";
 import { SystemMessage } from "@langchain/core/messages";
 import {
-  createQuickJSMiddleware,
+  createREPLMiddleware,
   generatePtcPrompt,
   resolveToolList,
 } from "./middleware.js";
 import { ReplSession } from "./session.js";
 
-describe("createQuickJSMiddleware", () => {
+describe("createREPLMiddleware", () => {
   beforeEach(() => {
     ReplSession.clearCache();
   });
 
   describe("tool registration", () => {
-    it("should register js_eval tool", () => {
-      const middleware = createQuickJSMiddleware();
+    it("should register eval tool", () => {
+      const middleware = createREPLMiddleware();
       expect(middleware.tools).toBeDefined();
       const names = middleware.tools!.map((t: { name: string }) => t.name);
-      expect(names).toContain("js_eval");
+      expect(names).toContain("eval");
       const jsEval = middleware.tools!.find(
-        (t: { name: string }) => t.name === "js_eval",
+        (t: { name: string }) => t.name === "eval",
       ) as {
         metadata?: Record<string, unknown>;
       };
@@ -29,7 +29,7 @@ describe("createQuickJSMiddleware", () => {
     });
 
     it("should register exactly one tool", () => {
-      const middleware = createQuickJSMiddleware();
+      const middleware = createREPLMiddleware();
       expect(middleware.tools!.length).toBe(1);
       expect(
         (middleware.tools![0] as { metadata?: Record<string, unknown> })
@@ -40,7 +40,7 @@ describe("createQuickJSMiddleware", () => {
 
   describe("wrapModelCall", () => {
     it("should add REPL system prompt with API Reference structure", async () => {
-      const middleware = createQuickJSMiddleware();
+      const middleware = createREPLMiddleware();
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
 
       await middleware.wrapModelCall!(
@@ -56,7 +56,7 @@ describe("createQuickJSMiddleware", () => {
       const req = mockHandler.mock.calls[0][0];
       const text = req.systemMessage.text;
       expect(text).toContain("Base");
-      expect(text).toContain("js_eval");
+      expect(text).toContain("eval");
       expect(text).toContain("### Hard rules");
       expect(text).toContain("### Limitations");
       expect(text).not.toContain("async readFile");
@@ -65,7 +65,7 @@ describe("createQuickJSMiddleware", () => {
     });
 
     it("should use custom system prompt when provided", async () => {
-      const middleware = createQuickJSMiddleware({
+      const middleware = createREPLMiddleware({
         systemPrompt: "Custom REPL prompt",
       });
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
@@ -160,7 +160,7 @@ describe("createQuickJSMiddleware", () => {
     });
 
     it("should include directly injected instances in PTC prompt", async () => {
-      const middleware = createQuickJSMiddleware({ ptc: [extraTool] });
+      const middleware = createREPLMiddleware({ ptc: [extraTool] });
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
 
       await middleware.wrapModelCall!(
@@ -178,7 +178,7 @@ describe("createQuickJSMiddleware", () => {
     });
 
     it("should include both named agent tools and injected instances in mixed ptc array", async () => {
-      const middleware = createQuickJSMiddleware({
+      const middleware = createREPLMiddleware({
         ptc: ["agent_tool", extraTool],
       });
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
@@ -250,11 +250,11 @@ describe("createQuickJSMiddleware", () => {
 
   describe("afterAgent call", () => {
     it("should dispose of the session for the current thread", async () => {
-      const middleware = createQuickJSMiddleware();
+      const middleware = createREPLMiddleware();
 
-      // Trigger session creation via js_eval
+      // Trigger session creation via eval
       const jsTool = middleware.tools!.find(
-        (t: any) => t.name === "js_eval",
+        (t: any) => t.name === "eval",
       ) as any;
       await jsTool.invoke(
         { code: "1 + 1" },
@@ -273,7 +273,7 @@ describe("createQuickJSMiddleware", () => {
     });
 
     it("should no-op for afterAgent on a thread with no session", async () => {
-      const middleware = createQuickJSMiddleware();
+      const middleware = createREPLMiddleware();
       await expect(
         (middleware as any).afterAgent(
           {},
@@ -283,9 +283,9 @@ describe("createQuickJSMiddleware", () => {
     });
 
     it("should only remove the session for the finished thread, not others", async () => {
-      const middleware = createQuickJSMiddleware();
+      const middleware = createREPLMiddleware();
       const jsTool = middleware.tools!.find(
-        (t: any) => t.name === "js_eval",
+        (t: any) => t.name === "eval",
       ) as any;
 
       await jsTool.invoke(

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -57,17 +57,17 @@ const DEFAULT_TOOL_NAME = "eval";
 
 function renderReplSystemPrompt(opts: {
   toolName: string;
-  timeoutS: number;
+  timeout: number;
   memoryLimitMb: number;
 }): string {
   return dedent`
     ### Interpreter
 
     An \`${opts.toolName}\` tool is available. It runs JavaScript in a persistent REPL.
-    - State (variables, functions) persists across tool calls within a single turn of conversation.
+    - State (variables, functions) persists across tool calls within a single turn of conversation. They DO NOT persist across multiple turns.
     - Top-level \`await\` works; Promises resolve before the call returns.
     - Sandboxed: no filesystem, no stdlib, no network, no real clock, no \`fetch\`, no \`require\`.
-    - Timeout: ${opts.timeoutS}s per call. Memory: ${opts.memoryLimitMb} MB total.
+    - Timeout: ${opts.timeout}s per call. Memory: ${opts.memoryLimitMb} MB total.
     - \`console.log\` output is captured and returned alongside the result.
   `;
 }
@@ -197,7 +197,7 @@ export function createREPLMiddleware(options: REPLMiddlewareOptions = {}) {
     customSystemPrompt ||
     renderReplSystemPrompt({
       toolName,
-      timeoutS: executionTimeoutMs / 1000,
+      timeout: executionTimeoutMs / 1000,
       memoryLimitMb: Math.floor(memoryLimitBytes / (1024 * 1024)),
     });
 

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -55,26 +55,22 @@ import { LangGraphRunnableConfig } from "@langchain/langgraph";
 
 const DEFAULT_TOOL_NAME = "eval";
 
-const REPL_SYSTEM_PROMPT = dedent`
-  ## TypeScript/JavaScript REPL (\`js_eval\`)
+function renderReplSystemPrompt(opts: {
+  toolName: string;
+  timeoutS: number;
+  memoryLimitMb: number;
+}): string {
+  return dedent`
+    ### Interpreter
 
-  You have access to a sandboxed TypeScript/JavaScript REPL running in an isolated interpreter.
-  TypeScript syntax (type annotations, interfaces, generics, \`as\` casts) is supported and stripped at evaluation time.
-  Variables, functions, and closures persist across calls within the same session.
-
-  ### Hard rules
-
-  - **No network, no direct filesystem** — only through tools provided in the \`tools\` namespace below.
-  - **Cite your sources** — when reporting values from files, include the path and key/index so the user can verify.
-  - **Use console.log()** for output — it is captured and returned. \`console.warn()\` and \`console.error()\` are also available.
-  - **Reuse state from previous cells** — variables, functions, and results from earlier \`js_eval\` calls persist across calls. Reference them by name in follow-up cells instead of re-embedding data as inline JSON literals.
-
-  ### Limitations
-
-  - ES2023+ syntax with TypeScript support. No Node.js APIs, no \`require\`, no \`import\`.
-  - Output is truncated beyond a fixed character limit — be selective about what you log.
-  - Execution timeout per call (default 30 s).
-`;
+    An \`${opts.toolName}\` tool is available. It runs JavaScript in a persistent REPL.
+    - State (variables, functions) persists across tool calls within a single turn of conversation.
+    - Top-level \`await\` works; Promises resolve before the call returns.
+    - Sandboxed: no filesystem, no stdlib, no network, no real clock, no \`fetch\`, no \`require\`.
+    - Timeout: ${opts.timeoutS}s per call. Memory: ${opts.memoryLimitMb} MB total.
+    - \`console.log\` output is captured and returned alongside the result.
+  `;
+}
 
 /**
  * Generate the PTC API Reference section for the system prompt.
@@ -197,7 +193,13 @@ export function createREPLMiddleware(options: REPLMiddlewareOptions = {}) {
     throw new Error("`maxPtcCalls` must be >= 1 or null");
   }
 
-  const baseSystemPrompt = customSystemPrompt || REPL_SYSTEM_PROMPT;
+  const baseSystemPrompt =
+    customSystemPrompt ||
+    renderReplSystemPrompt({
+      toolName,
+      timeoutS: executionTimeoutMs / 1000,
+      memoryLimitMb: Math.floor(memoryLimitBytes / (1024 * 1024)),
+    });
 
   const middlewareId = crypto.randomUUID();
 

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -1,7 +1,7 @@
 /**
- * QuickJS REPL middleware for deepagents.
+ * REPL middleware for deepagents.
  *
- * Provides a `js_eval` tool that runs JavaScript in a WASM-sandboxed QuickJS
+ * Provides an `eval` tool that runs JavaScript in a WASM-sandboxed QuickJS
  * interpreter. Supports:
  * - Persistent state across evaluations (true REPL)
  * - Programmatic tool calling (PTC) — expose agent or custom tools inside the REPL
@@ -23,7 +23,7 @@ import {
   type BackendFactory,
   type SkillMetadata,
 } from "deepagents";
-import type { QuickJSMiddlewareOptions } from "./types.js";
+import type { REPLMiddlewareOptions } from "./types.js";
 import {
   ReplSession,
   DEFAULT_EXECUTION_TIMEOUT,
@@ -52,6 +52,8 @@ import type * as _zodTypes from "@langchain/core/utils/types";
 import type * as _zodMeta from "@langchain/langgraph/zod";
 import type * as _messages from "@langchain/core/messages";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
+
+const DEFAULT_TOOL_NAME = "eval";
 
 const REPL_SYSTEM_PROMPT = dedent`
   ## TypeScript/JavaScript REPL (\`js_eval\`)
@@ -175,11 +177,9 @@ async function prepareSkillsForEval(
 }
 
 /**
- * Create the QuickJS REPL middleware.
+ * Create the REPL middleware.
  */
-export function createQuickJSMiddleware(
-  options: QuickJSMiddlewareOptions = {},
-) {
+export function createREPLMiddleware(options: REPLMiddlewareOptions = {}) {
   const {
     ptc,
     memoryLimitBytes = DEFAULT_MEMORY_LIMIT,
@@ -189,6 +189,8 @@ export function createQuickJSMiddleware(
     skillsBackend,
     maxPtcCalls = DEFAULT_MAX_PTC_CALLS,
     maxResultChars = DEFAULT_MAX_RESULTS_CHARS,
+    toolName = DEFAULT_TOOL_NAME,
+    captureConsole = true,
   } = options;
 
   if (maxPtcCalls !== null && maxPtcCalls !== undefined && maxPtcCalls < 1) {
@@ -208,12 +210,12 @@ export function createQuickJSMiddleware(
   ): StructuredToolInterface[] {
     if (!ptc) return [];
 
-    const candidates = allTools.filter((t) => t.name !== "js_eval");
+    const candidates = allTools.filter((t) => t.name !== toolName);
 
     return resolveToolList(ptc, candidates);
   }
 
-  const jsEvalTool = tool(
+  const evalTool = tool(
     async (input, config: LangGraphRunnableConfig) => {
       const threadId = config.configurable?.thread_id || DEFAULT_SESSION_ID;
       const sessionKey = `${threadId}:${middlewareId}`;
@@ -225,6 +227,7 @@ export function createQuickJSMiddleware(
         tools: ptcTools,
         skillsEnabled: skillsBackend !== undefined,
         maxResultChars,
+        captureConsole,
       });
 
       if (skillsBackend !== undefined) {
@@ -242,7 +245,7 @@ export function createQuickJSMiddleware(
       return formatReplResult(result);
     },
     {
-      name: "js_eval",
+      name: toolName,
       description: dedent`
         Evaluate TypeScript/JavaScript code in a sandboxed REPL. State persists across calls.
         Use console.log() for output. Returns the result of the last expression.
@@ -261,8 +264,8 @@ export function createQuickJSMiddleware(
   );
 
   return createMiddleware({
-    name: "QuickJSMiddleware",
-    tools: [jsEvalTool],
+    name: "REPLMiddleware",
+    tools: [evalTool],
     wrapModelCall: async (request, handler) => {
       const agentTools = (request.tools || []) as StructuredToolInterface[];
       ptcTools = filterToolsForPtc(agentTools);

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -32,9 +32,9 @@ import type { ReplSessionOptions, ReplResult, SkillsContext } from "./types.js";
 import { toCamelCase } from "./utils.js";
 import { transformForEval } from "./transform.js";
 
-export const DEFAULT_MEMORY_LIMIT = 50 * 1024 * 1024;
+export const DEFAULT_MEMORY_LIMIT = 64 * 1024 * 1024;
 export const DEFAULT_MAX_STACK_SIZE = 320 * 1024;
-export const DEFAULT_EXECUTION_TIMEOUT = 30_000;
+export const DEFAULT_EXECUTION_TIMEOUT = 5_000;
 export const DEFAULT_SESSION_ID = "__default__";
 export const DEFAULT_MAX_PTC_CALLS = 256;
 export const DEFAULT_MAX_RESULTS_CHARS = 4000;
@@ -240,6 +240,7 @@ export class ReplSession {
       tools,
       skillsEnabled = false,
       maxResultChars = DEFAULT_MAX_RESULTS_CHARS,
+      captureConsole = true,
     } = this.options;
 
     const asyncModule = await newAsyncModule();
@@ -252,7 +253,9 @@ export class ReplSession {
     this.context = context;
 
     this.consoleBuffer = new ConsoleBuffer(maxResultChars);
-    this.setupConsole();
+    if (captureConsole) {
+      this.setupConsole();
+    }
 
     if (tools !== undefined && tools.length > 0) {
       this.injectTools(tools);
@@ -468,7 +471,7 @@ export class ReplSession {
 
   /**
    * Push the current skills metadata + backend into the session.
-   * Called by the middleware once per `js_eval` invocation, before eval runs.
+   * Called by the middleware once per `eval` invocation, before eval runs.
    * Pass `undefined` to clear the context (no skill imports will resolve).
    */
   setSkillsContext(ctx?: SkillsContext): void {

--- a/libs/providers/quickjs/src/types.ts
+++ b/libs/providers/quickjs/src/types.ts
@@ -7,9 +7,9 @@ import type {
 } from "deepagents";
 
 /**
- * Configuration options for the QuickJS REPL middleware.
+ * Configuration options for the REPL middleware.
  */
-export interface QuickJSMiddlewareOptions {
+export interface REPLMiddlewareOptions {
   /**
    * Enable programmatic tool calling from within the REPL.
    *
@@ -22,7 +22,7 @@ export interface QuickJSMiddlewareOptions {
 
   /**
    * Memory limit in bytes.
-   * @default 52428800 (50MB)
+   * @default 67108864 (64MB)
    */
   memoryLimitBytes?: number;
 
@@ -35,7 +35,7 @@ export interface QuickJSMiddlewareOptions {
   /**
    * Execution timeout in milliseconds per evaluation.
    * Set to a negative value to disable the timeout entirely.
-   * @default 30000 (30s)
+   * @default 5000 (5s)
    */
   executionTimeoutMs?: number;
 
@@ -74,6 +74,20 @@ export interface QuickJSMiddlewareOptions {
    * @default 4000
    */
   maxResultChars?: number;
+
+  /**
+   * Name of the tool exposed to the model.
+   * @default "eval"
+   */
+  toolName?: string;
+
+  /**
+   * If true, install a `console` object that buffers `console.log/warn/error`
+   * calls and emits them alongside the result. If false, console output is
+   * silently discarded.
+   * @default true
+   */
+  captureConsole?: boolean;
 }
 
 /**
@@ -86,6 +100,7 @@ export interface ReplSessionOptions {
   skillsEnabled?: boolean;
   maxPtcCalls?: number | null;
   maxResultChars?: number;
+  captureConsole?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Summary

- Rename `createQuickJSMiddleware` → `createREPLMiddleware` and `QuickJSMiddlewareOptions` → `REPLMiddlewareOptions` to match the Python `REPLMiddleware` naming
- Rename middleware registration from `"QuickJSMiddleware"` → `"REPLMiddleware"`
- Rename default tool name from `"js_eval"` → `"eval"`, now configurable via `toolName` option
- Add `captureConsole` option (default `true`) to toggle console output capture
- Align default memory limit to 64 MiB (was 50 MiB) and timeout to 5s (was 30s) to match Python

### Tests

- All 156 existing unit tests pass with updated references
- Updated `middleware.test.ts`, `middleware.int.test.ts`, and example files to use new names