### PR TITLE
fix(quickjs): individual repl sessions use individual wasm module causing inefficient memory usage

### DIFF
--- a/.changeset/wet-tables-notice.md
+++ b/.changeset/wet-tables-notice.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+fix(quickjs): individual repl sessions use individual wasm module causing inefficient memory usage

--- a/libs/providers/quickjs/src/eval-queue.test.ts
+++ b/libs/providers/quickjs/src/eval-queue.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { AsyncEvalQueue } from "./eval-queue.js";
+
+describe("AsyncEvalQueue", () => {
+  it("serializes concurrent operations", async () => {
+    const queue = new AsyncEvalQueue();
+    const log: string[] = [];
+
+    const a = queue.enqueue(async () => {
+      log.push("a:start");
+      await new Promise((r) => setTimeout(r, 20));
+      log.push("a:end");
+    });
+
+    const b = queue.enqueue(async () => {
+      log.push("b:start");
+      await new Promise((r) => setTimeout(r, 10));
+      log.push("b:end");
+    });
+
+    const c = queue.enqueue(async () => {
+      log.push("c:start");
+      log.push("c:end");
+    });
+
+    await Promise.all([a, b, c]);
+
+    expect(log).toEqual([
+      "a:start",
+      "a:end",
+      "b:start",
+      "b:end",
+      "c:start",
+      "c:end",
+    ]);
+  });
+
+  it("returns the value from each enqueued operation", async () => {
+    const queue = new AsyncEvalQueue();
+
+    const [a, b, c] = await Promise.all([
+      queue.enqueue(async () => 1),
+      queue.enqueue(async () => "two"),
+      queue.enqueue(async () => ({ n: 3 })),
+    ]);
+
+    expect(a).toBe(1);
+    expect(b).toBe("two");
+    expect(c).toEqual({ n: 3 });
+  });
+
+  it("continues after a rejected operation", async () => {
+    const queue = new AsyncEvalQueue();
+
+    const failing = queue.enqueue(async () => {
+      throw new Error("boom");
+    });
+    await expect(failing).rejects.toThrow("boom");
+
+    const result = await queue.enqueue(async () => "recovered");
+    expect(result).toBe("recovered");
+  });
+
+  it("preserves insertion order", async () => {
+    const queue = new AsyncEvalQueue();
+    const order: number[] = [];
+
+    const ops = Array.from({ length: 10 }, (_, i) =>
+      queue.enqueue(async () => {
+        order.push(i);
+      }),
+    );
+
+    await Promise.all(ops);
+    expect(order).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});

--- a/libs/providers/quickjs/src/eval-queue.ts
+++ b/libs/providers/quickjs/src/eval-queue.ts
@@ -1,0 +1,33 @@
+/**
+ * Serializes async operations on a shared WASM module.
+ *
+ * The quickjs-emscripten asyncify variant allows only one concurrent
+ * async call per module instance. This queue enforces that constraint
+ * by chaining operations into a promise queue — each caller waits for
+ * the previous one to finish before executing.
+ */
+export class AsyncEvalQueue {
+  private tail = Promise.resolve();
+
+  /**
+   * Enqueue an async operation. The operation will not start until all
+   * previously enqueued operations have completed.
+   */
+  async enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const prev = this.tail;
+    this.tail = gate;
+
+    return prev.then(async () => {
+      try {
+        return await fn();
+      } finally {
+        release();
+      }
+    });
+  }
+}

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -23,6 +23,7 @@ import { newQuickJSAsyncWASMModuleFromVariant } from "quickjs-emscripten-core";
 import type {
   QuickJSAsyncContext,
   QuickJSAsyncRuntime,
+  QuickJSAsyncWASMModule,
 } from "quickjs-emscripten-core";
 import type { StructuredToolInterface } from "@langchain/core/tools";
 
@@ -31,6 +32,7 @@ import { PTCCallBudgetExceededError } from "./errors.js";
 import type { ReplSessionOptions, ReplResult, SkillsContext } from "./types.js";
 import { toCamelCase } from "./utils.js";
 import { transformForEval } from "./transform.js";
+import { AsyncEvalQueue } from "./eval-queue.js";
 
 export const DEFAULT_MEMORY_LIMIT = 64 * 1024 * 1024;
 export const DEFAULT_MAX_STACK_SIZE = 320 * 1024;
@@ -39,20 +41,43 @@ export const DEFAULT_SESSION_ID = "__default__";
 export const DEFAULT_MAX_PTC_CALLS = 256;
 export const DEFAULT_MAX_RESULTS_CHARS = 4000;
 
-// The variant descriptor (WASM binary + glue) is safe to share across sessions;
-// only the instantiated module carries asyncify state. Import once, instantiate per session.
 const variantImport = import("@jitl/quickjs-ng-wasmfile-release-asyncify");
 
-// Each ReplSession needs its own WASM module. The asyncify WASM variant allows only one
-// concurrent async call per module instance, and multi-file skill imports (2+ unwind/rewind
-// cycles inside a single evalCodeAsync) leave the module's asyncify state corrupted after
-// the owning runtime is disposed — new runtimes on the same module silently skip module
-// loader callbacks. A fresh instantiation per session gives each session clean asyncify state.
-async function newAsyncModule() {
-  const variant = await variantImport;
-  return newQuickJSAsyncWASMModuleFromVariant(
-    (variant.default ?? variant) as any,
-  );
+/**
+ * Process-global eval queue. Serializes all evalCodeAsync calls across
+ * sessions to enforce the asyncify one-at-a-time constraint.
+ */
+const sharedEvalQueue = new AsyncEvalQueue();
+
+/**
+ * Process-global WASM module shared by all sessions.
+ *
+ * Each session creates its own runtime and context on this module,
+ * providing full isolation for globals, heap, and stack. The module
+ * itself is stateless between runtimes — only the compiled WASM code
+ * and Emscripten infrastructure are shared.
+ *
+ * This is safe because:
+ * - The module loader is synchronous (preloaded skill cache), so
+ *   imports don't cause asyncify suspensions.
+ * - Tool injection uses the promise-based pattern (newFunction +
+ *   newPromise), not newAsyncifiedFunction, so tool calls don't
+ *   cause asyncify suspensions.
+ * - The eval queue serializes evalCodeAsync calls to satisfy the
+ *   one-concurrent-async-call-per-module constraint.
+ */
+let sharedModulePromise: Promise<QuickJSAsyncWASMModule> | undefined;
+
+function getSharedModule(): Promise<QuickJSAsyncWASMModule> {
+  if (!sharedModulePromise) {
+    sharedModulePromise = (async () => {
+      const variant = await variantImport;
+      return newQuickJSAsyncWASMModuleFromVariant(
+        (variant.default ?? variant) as any,
+      );
+    })();
+  }
+  return sharedModulePromise;
 }
 
 // After a successful asyncify unwind/rewind cycle, a rejected module loader
@@ -222,6 +247,17 @@ export class ReplSession {
   private readonly maxPtcCalls: number | null;
   private ptcCallsRemaining: number | null = null;
 
+  /**
+   * Reset the shared WASM module. Forces the next session to instantiate
+   * a fresh module. Only needed in tests where module state must be
+   * isolated between test files.
+   *
+   * @internal
+   */
+  static resetSharedModule(): void {
+    sharedModulePromise = undefined;
+  }
+
   constructor(id: string, options: ReplSessionOptions = {}) {
     this.id = id;
     this.options = options;
@@ -243,7 +279,7 @@ export class ReplSession {
       captureConsole = true,
     } = this.options;
 
-    const asyncModule = await newAsyncModule();
+    const asyncModule = await getSharedModule();
     const runtime: QuickJSAsyncRuntime = asyncModule.newRuntime();
     runtime.setMemoryLimit(memoryLimitBytes);
     runtime.setMaxStackSize(maxStackSizeBytes);
@@ -304,17 +340,55 @@ export class ReplSession {
     }
   }
 
-  private async resolveSpecifier(specifier: string): Promise<string> {
+  /**
+   * Pre-load all skills referenced in source code into the in-memory
+   * cache. Must be called before `evalCodeAsync` so the module loader
+   * can resolve synchronously. An async loader would cause asyncify
+   * suspensions on each import, which is incompatible with the shared
+   * WASM module used by all sessions.
+   */
+  async preloadReferencedSkills(code: string): Promise<void> {
+    const refs = scanSkillReferences(code);
+    for (const name of refs) {
+      if (this.skillsLoaded.has(name) || this.skillsFailed.has(name)) {
+        continue;
+      }
+
+      try {
+        await this.ensureSkillLoaded(name);
+      } catch (err) {
+        if (!this.skillsFailed.has(name)) {
+          this.skillsFailed.set(name, err as Error);
+        }
+      }
+    }
+  }
+
+  /**
+   * Resolve a module specifier to source code. Strictly synchronous —
+   * only reads from the in-memory skill cache populated by
+   * `preloadReferencedSkills`. Returns error source (not a thrown
+   * exception) for missing or failed skills so QuickJS reports the
+   * error inside the VM.
+   */
+  private resolveSpecifier(specifier: string): string {
     const parsed = parseSkillSpecifier(specifier);
     if (parsed === undefined) {
       return makeErrorSource(`Module not found: ${specifier}`);
     }
 
-    let loaded: LoadedSkill;
-    try {
-      loaded = await this.ensureSkillLoaded(parsed.name);
-    } catch (err) {
-      return makeErrorSource((err as Error).message ?? String(err));
+    const cachedError = this.skillsFailed.get(parsed.name);
+    if (cachedError !== undefined) {
+      return makeErrorSource(cachedError.message ?? String(cachedError));
+    }
+
+    const loaded = this.skillsLoaded.get(parsed.name);
+    if (loaded === undefined) {
+      return makeErrorSource(
+        `Skill '${parsed.name}' was not preloaded. ` +
+          `Ensure the import specifier is a static string literal ` +
+          `(dynamic specifiers like \`import("@/skills/" + name)\` are not supported).`,
+      );
     }
 
     if (parsed.rel === undefined) {
@@ -327,7 +401,11 @@ export class ReplSession {
       return source;
     }
 
-    const source = loaded.files.get(parsed.rel);
+    let source = loaded.files.get(parsed.rel);
+    // TS convention: source files use .ts but import specifiers use .js
+    if (source === undefined && parsed.rel.endsWith(".js")) {
+      source = loaded.files.get(parsed.rel.slice(0, -3) + ".ts");
+    }
     if (source === undefined) {
       return makeErrorSource(
         `Skill '${parsed.name}': '${parsed.rel}' not found in bundle`,
@@ -380,7 +458,7 @@ export class ReplSession {
     }
 
     this.runtime.setModuleLoader(
-      async (specifier: string) => this.resolveSpecifier(specifier),
+      (specifier: string) => this.resolveSpecifier(specifier),
       (base: string, requested: string) =>
         this.normalizeSpecifier(base, requested),
     );
@@ -492,6 +570,9 @@ export class ReplSession {
     const runtime = this.runtime!;
     const context = this.context!;
 
+    // Pre-load referenced skills so the module loader resolves synchronously.
+    await this.preloadReferencedSkills(code);
+
     const drainLogs = (): { logs: string[]; logsDroppedChars: number } => {
       const [raw, dropped] = this.consoleBuffer.drain();
       return {
@@ -511,7 +592,9 @@ export class ReplSession {
       }
 
       const transformed = transformForEval(code);
-      const result = await context.evalCodeAsync(transformed);
+      const result = await sharedEvalQueue.enqueue(() =>
+        context.evalCodeAsync(transformed),
+      );
 
       if (result.error) {
         const error = context.dump(result.error);

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -80,17 +80,14 @@ function getSharedModule(): Promise<QuickJSAsyncWASMModule> {
   return sharedModulePromise;
 }
 
-// After a successful asyncify unwind/rewind cycle, a rejected module loader
-// Promise causes a WASM crash ("memory access out of bounds"). The rejection
-// path in quickjs-emscripten's `maybeAsyncFn` catch block calls
-// `context.throw(error)` — a WASM FFI call while the asyncify stack is still
-// unwound — which corrupts memory. To avoid this, the module loader must never
-// reject. This helper returns source code that throws at evaluation time inside
-// the VM instead.
+// The module loader must never reject. A rejected Promise in the loader
+// path triggers a WASM FFI call at the wrong point in the asyncify
+// lifecycle, which corrupts memory. This helper returns source code that
+// throws at evaluation time inside the VM instead.
 //
-// The thrown value is a plain object (not `new Error()`) because QuickJS stores
-// Error's `name` and `message` as non-enumerable properties (per spec), which
-// causes `context.dump()` (JSON.stringify) to return `{}`.
+// The thrown value is a plain object (not `new Error()`) because QuickJS
+// stores Error's `name` and `message` as non-enumerable properties (per
+// spec), which causes `context.dump()` (JSON.stringify) to return `{}`.
 function makeErrorSource(message: string): string {
   return `throw { name: "Error", message: ${JSON.stringify(message)} };`;
 }
@@ -451,6 +448,12 @@ export class ReplSession {
 
   /**
    * Wire the QuickJS module loader and normalizer on this session's runtime.
+   *
+   * The loader is strictly synchronous — it reads from the in-memory skill
+   * cache populated by `preloadReferencedSkills`. This is critical: an async
+   * module loader causes asyncify suspensions on each import, and disposing
+   * a runtime after multi-file imports corrupts the shared module's asyncify
+   * state, silently breaking the loader for all subsequent sessions.
    */
   private installModuleLoader(): void {
     if (this.runtime === null) {

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -26,7 +26,7 @@ import type {
 } from "quickjs-emscripten-core";
 import type { StructuredToolInterface } from "@langchain/core/tools";
 
-import { loadSkill, type LoadedSkill } from "./skills.js";
+import { loadSkill, scanSkillReferences, type LoadedSkill } from "./skills.js";
 import { PTCCallBudgetExceededError } from "./errors.js";
 import type { ReplSessionOptions, ReplResult, SkillsContext } from "./types.js";
 import { toCamelCase } from "./utils.js";


### PR DESCRIPTION
### Summary

This PR optimizes memory usage by allowing us to use a single WASM module. To do this we needed to fix two failure modes that occur when multiple sessions share a single WASM module. Both are caused by the async module loader creating asyncify suspensions (unwind/rewind cycles on a module-global stack buffer) during import resolution.

__Failure 1__: Concurrent eval crash. The asyncify variant allows only one async operation per module at a time. If two sessions eval simultaneously and both hit an import, the second eval tries to suspend asyncify while the first is already suspended. This crashes with QuickJSAsyncifySuspended: Already suspended.
Fix: AsyncEvalQueue queues evalCodeAsync calls so only one runs at a time.

__Failure 2__: Silent disposal corruption. When a session imports a multi-file skill (e.g. an entry point that imports greet.js and shout.js), each import causes an asyncify unwind/rewind cycle. The eval succeeds. But when the session's runtime is disposed, the disposal does not fully reset the module's asyncify stack buffer and the unwind/rewind cycles left residual state (saved stack frames, rewind pointers) that emscripten manages at the module level, not the runtime level. The next session creates a fresh runtime on the same module, but the corrupted asyncify state causes module loader callbacks to silently never fire.
Fix: synchronous module loader. Skill files are preloaded into a Map before eval starts. The loader callback does a plain map.get(). No await, no asyncify suspension, no residual state on disposal.

Note: The eval queue alone does not fix failure 2. The corruption happens at runtime disposal, which runs outside the queue. Both fixes are required.

#### What This PR Adds
- Replaces per-session WASM module instantiation with a process-global singleton shared by all sessions. Each session still gets its own runtime and context (full isolation); only the underlying WASM module is shared. Reduces WASM memory from ~16 MB per session to ~16 MB total.
- Adds AsyncEvalQueue to serialize evalCodeAsync calls across sessions, enforcing the asyncify one-concurrent-async-call-per-module constraint.
- Makes the module loader synchronous by preloading skill files into an in-memory cache before eval (preloadReferencedSkills). Why is this needed? An async module loader causes asyncify suspensions on each import. Disposing a runtime after multi-file skill imports corrupts the shared module's asyncify state and silently breaks the loader for all subsequent sessions. The sync loader eliminates asyncify suspensions from imports entirely.

#### Synchronous Module Loading

As stated above, synchronous module loading is a necessary change due to async module loading causing asyncify suspensions on each import which corrupts the singleton WASM module's asyncify state which silently breaks the loader for all subsequent sessions. The following demonstrates the before and after regarding this change:

__Before__:
User code: `import { run } from "@/skills/demo"`

1. eval() is called
2. evalCodeAsync() runs the code
3. QuickJS hits the import, calls the module loader callback
4. The callback is async: await ensureSkillLoaded("demo")
   → fetches /skills/demo/index.js from the backend (network I/O)
   → this await causes the first asyncify suspension in the WASM module
5. index.js has: import { greet } from "./greet.js"
6. QuickJS calls the loader again for greet.js
   → await ensureSkillLoaded() → network fetch
   → The second asyncify suspension in the WASM module is hit
7. index.js has: import { shout } from "./shout.js"
8. QuickJS calls the loader again for shout.js
   → await ensureSkillLoaded() → network fetch
   → third asyncify suspension in the WASM module is hit
9. eval completes, runtime is disposed
10. runtime.dispose() is called to clean up the session
11. The runtime disposal does NOT fully reset the module's asyncify stack buffer. The 3 unwind/rewind cycles left residual state (saved stack frames, rewind pointers, etc.) that the dispose path doesn't know to clean up, because asyncify bookkeeping is managed by emscripten at the module level, not by QuickJS at the runtime level.
12. Next session creates a fresh runtime on the same module, but the module's asyncify machinery is corrupted. When QuickJS tries to call the new session's module loader, the stale asyncify state causes the callback to silently not fire. No crash, no error. Imports just resolve to nothing.

__After__:
User code: `import { run } from "@/skills/demo"`

1. eval() is called
2. preloadReferencedSkills() runs BEFORE evalCodeAsync():
   → scans source code for "@/skills/*" specifiers
   → finds "demo"
   → fetches all 3 files from the backend into a Map:
     "@/skills/demo"          → source code
     "@/skills/demo/greet.js" → source code
     "@/skills/demo/shout.js" → source code
   → (this is async but happens OUTSIDE the WASM module so no asyncify)
3. evalCodeAsync() runs the code
4. QuickJS hits the import, calls the module loader callback
5. The callback is sync: map.get("@/skills/demo") → returns source immediately
   → NO asyncify suspension
6. QuickJS resolves greet.js → map.get("@/skills/demo/greet.js") → immediate
   → NO asyncify suspension
7. QuickJS resolves shout.js → map.get("@/skills/demo/shout.js") → immediate
   → NO asyncify suspension
8. eval completes, runtime is disposed
9. Zero asyncify suspensions occurred → no residual state → module is clean
10. Next session works perfectly

### Tests

- 4 new AsyncEvalQueue unit tests: serialization (no interleaving of concurrent ops), return values, error isolation (rejected op doesn't break queue), insertion order preservation
- All 160 existing tests pass (session, skills, middleware, transform, utils, eval queue)

### Memory Benchmarking

#### Per-session module (before)

| Sessions | RSS Delta (MB) | Per-Session RSS (MB) | WASM Memory (MB) | Module Init (ms) | Setup (ms) |
|----------|----------------|----------------------|------------------|------------------|------------|
| 1        | 0.53           | 0.53                 | 16               | 11.4             | 15.9       |
| 5        | 2.13           | 0.43                 | 80               | 30.2             | 37.9       |
| 10       | 5.28           | 0.53                 | 160              | 31.1             | 42.8       |
| 15       | 5.53           | 0.37                 | 240              | 57.4             | 72.1       |
| 20       | 6.80           | 0.34                 | 320              | 73.6             | 91.1       |

---

#### Singleton (after)

| Sessions | RSS Delta (MB) | Per-Session RSS (MB) | WASM Memory (MB) | Module Init (ms) | Setup (ms) |
|----------|----------------|----------------------|------------------|------------------|------------|
| 1        | 0.61           | 0.61                 | 16               | 6.7              | 9.1        |
| 5        | 0.59           | 0.12                 | 16               | 12.5             | 28.5       |
| 10       | 0.91           | 0.09                 | 16               | 12.2             | 37.0       |
| 15       | 1.81           | 0.12                 | 16               | 12.0             | 45.1       |
| 20       | 1.70           | 0.09                 | 16               | 10.4             | 50.4       |

---

#### Comparison at 20 sessions (realistic workload)

| Metric                 | Before  | After  | Improvement     |
|------------------------|---------|--------|-----------------|
| WASM virtual memory    | 320 MB  | 16 MB  | 20x reduction   |
| RSS delta              | 6.80 MB | 1.70 MB| 4x reduction    |
| Module instantiation   | 73.6 ms | 10.4 ms| 7x reduction    |
| Setup time             | 91.1 ms | 50.4 ms| 1.8x reduction  |