### PR TITLE
fix(deepagents): align LangSmith sandbox create options with SDK

### DIFF
--- a/libs/deepagents/src/backends/langsmith.test.ts
+++ b/libs/deepagents/src/backends/langsmith.test.ts
@@ -10,6 +10,10 @@ let mockStop: ReturnType<typeof vi.fn>;
 let mockCaptureSnapshot: ReturnType<typeof vi.fn>;
 let MockLangSmithResourceNotFoundError: new (message?: string) => Error;
 let MockLangSmithSandboxError: new (message?: string) => Error;
+const sandboxClientMocks = vi.hoisted(() => ({
+  createSandbox: vi.fn(),
+  configs: [] as unknown[],
+}));
 
 vi.mock("langsmith/experimental/sandbox", () => {
   class LangSmithSandboxError extends Error {
@@ -30,7 +34,15 @@ vi.mock("langsmith/experimental/sandbox", () => {
     LangSmithSandboxError,
     LangSmithResourceNotFoundError,
     Sandbox: class {},
-    SandboxClient: class {},
+    SandboxClient: class {
+      constructor(config?: unknown) {
+        sandboxClientMocks.configs.push(config);
+      }
+
+      createSandbox(...args: unknown[]) {
+        return sandboxClientMocks.createSandbox(...args);
+      }
+    },
   };
 });
 
@@ -84,6 +96,7 @@ function makeSandbox(options?: {
 describe("LangSmithSandbox", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sandboxClientMocks.configs.length = 0;
   });
 
   describe("id", () => {
@@ -171,6 +184,57 @@ describe("LangSmithSandbox", () => {
 
       expect(mockCaptureSnapshot).toHaveBeenCalledWith("my-snapshot", {
         timeout: 120,
+      });
+    });
+  });
+
+  describe("create()", () => {
+    it("throws when neither snapshotId nor templateName is provided", async () => {
+      await expect(LangSmithSandbox.create({})).rejects.toThrow(
+        "Either snapshotId or templateName is required",
+      );
+    });
+
+    it("throws when both snapshotId and templateName are provided", async () => {
+      await expect(
+        LangSmithSandbox.create({
+          snapshotId: "snap-123",
+          templateName: "deepagents",
+        }),
+      ).rejects.toThrow("snapshotId and templateName are mutually exclusive");
+    });
+
+    it("calls SandboxClient.createSandbox with snapshotId", async () => {
+      const sdkSandbox = makeMockSandbox("snapshot-sandbox");
+      sandboxClientMocks.createSandbox.mockResolvedValue(sdkSandbox);
+
+      const sandbox = await LangSmithSandbox.create({
+        snapshotId: "snap-123",
+        apiKey: "test-key",
+        defaultTimeout: 45,
+        idleTtlSeconds: 600,
+      });
+
+      expect(sandboxClientMocks.configs).toEqual([{ apiKey: "test-key" }]);
+      expect(sandboxClientMocks.createSandbox).toHaveBeenCalledWith(
+        "snap-123",
+        {
+          idleTtlSeconds: 600,
+        },
+      );
+      expect(sandbox.id).toBe("snapshot-sandbox");
+    });
+
+    it("maps templateName to snapshotName in createSandbox options", async () => {
+      const sdkSandbox = makeMockSandbox("template-sandbox");
+      sandboxClientMocks.createSandbox.mockResolvedValue(sdkSandbox);
+
+      await LangSmithSandbox.create({
+        templateName: "deepagents-template",
+      });
+
+      expect(sandboxClientMocks.createSandbox).toHaveBeenCalledWith(undefined, {
+        snapshotName: "deepagents-template",
       });
     });
   });

--- a/libs/deepagents/src/backends/langsmith.ts
+++ b/libs/deepagents/src/backends/langsmith.ts
@@ -51,8 +51,13 @@ export interface LangSmithSandboxOptions {
 /** Options for the `LangSmithSandbox.create()` static factory. */
 export interface LangSmithSandboxCreateOptions extends Omit<
   CreateSandboxOptions,
-  "name" | "timeout" | "waitForReady"
+  "name" | "timeout" | "waitForReady" | "snapshotName"
 > {
+  /**
+   * Snapshot ID to boot from.
+   * Mutually exclusive with `templateName`.
+   */
+  snapshotId?: string;
   /**
    * Name of the LangSmith sandbox template to use.
    * Mutually exclusive with `snapshotId`.
@@ -271,6 +276,13 @@ export class LangSmithSandbox extends BaseSandbox {
       ...createSandboxOptions
     } = options;
 
+    if (snapshotId && templateName) {
+      throw new Error(
+        "snapshotId and templateName are mutually exclusive. " +
+          "Pass only one creation source.",
+      );
+    }
+
     if (!snapshotId && !templateName) {
       throw new Error(
         "Either snapshotId or templateName is required. " +
@@ -278,11 +290,16 @@ export class LangSmithSandbox extends BaseSandbox {
       );
     }
 
-    const client = new SandboxClient({ apiKey });
-    const sandbox = await client.createSandbox(templateName, {
+    const sandboxOptions: CreateSandboxOptions = {
       ...createSandboxOptions,
-      snapshotId,
-    });
+    };
+
+    if (templateName) {
+      sandboxOptions.snapshotName = templateName;
+    }
+
+    const client = new SandboxClient({ apiKey });
+    const sandbox = await client.createSandbox(snapshotId, sandboxOptions);
     return new LangSmithSandbox({ sandbox, defaultTimeout });
   }
 }


### PR DESCRIPTION
## Summary

This fixes a CI-breaking type mismatch in the LangSmith sandbox backend introduced by the snapshot lifecycle update. `LangSmithSandbox.create()` was using a `snapshotId` flow that did not match the current `langsmith` SDK typings, which surfaced as unhandled Vitest typecheck errors in CI.
