### PR TITLE
chore(quickjs): update `REPLMiddleware` to be named `CodeInterpreterMiddleware`

### DIFF
--- a/.changeset/vast-hotels-bow.md
+++ b/.changeset/vast-hotels-bow.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": minor
+---
+
+chore(quickjs): update `REPLMiddleware` to be named `CodeInterpreterMiddleware`

--- a/libs/providers/quickjs/src/index.ts
+++ b/libs/providers/quickjs/src/index.ts
@@ -16,12 +16,12 @@
  * @packageDocumentation
  */
 
-export { createREPLMiddleware } from "./middleware.js";
+export { createCodeInterpreterMiddleware } from "./middleware.js";
 
 export { PTCCallBudgetExceededError } from "./errors.js";
 
 export type {
-  REPLMiddlewareOptions,
+  CodeInterpreterMiddlewareOptions,
   ReplSessionOptions,
   ReplResult,
 } from "./types.js";

--- a/libs/providers/quickjs/src/middleware.int.test.ts
+++ b/libs/providers/quickjs/src/middleware.int.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createAgent } from "langchain";
 import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { MemorySaver } from "@langchain/langgraph";
-import { createREPLMiddleware } from "./middleware.js";
+import { createCodeInterpreterMiddleware } from "./middleware.js";
 import { ReplSession } from "./session.js";
 
 import type * as _zodTypes from "@langchain/core/utils/types";
@@ -20,13 +20,13 @@ describe("REPL middleware integration", () => {
     "should persist REPL state across multiple eval calls within the same thread",
     { timeout: 90_000 },
     async () => {
-      const replMiddleware = createREPLMiddleware();
+      const codeInterpreterMiddleware = createCodeInterpreterMiddleware();
       const checkpointer = new MemorySaver();
       const threadId = `int-repl-persist-${Date.now()}`;
 
       const agent = createAgent({
         model: MODEL,
-        middleware: [replMiddleware],
+        middleware: [codeInterpreterMiddleware],
         checkpointer,
       });
 
@@ -58,13 +58,13 @@ describe("REPL middleware integration", () => {
     "should reference variables from prior cells instead of re-embedding data",
     { timeout: 90_000 },
     async () => {
-      const replMiddleware = createREPLMiddleware();
+      const codeInterpreterMiddleware = createCodeInterpreterMiddleware();
       const checkpointer = new MemorySaver();
       const threadId = `int-repl-reuse-${Date.now()}`;
 
       const agent = createAgent({
         model: MODEL,
-        middleware: [replMiddleware],
+        middleware: [codeInterpreterMiddleware],
         checkpointer,
       });
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -3,20 +3,20 @@ import { tool } from "langchain";
 import * as z from "zod";
 import { SystemMessage } from "@langchain/core/messages";
 import {
-  createREPLMiddleware,
+  createCodeInterpreterMiddleware,
   generatePtcPrompt,
   resolveToolList,
 } from "./middleware.js";
 import { ReplSession } from "./session.js";
 
-describe("createREPLMiddleware", () => {
+describe("createCodeInterpreterMiddleware", () => {
   beforeEach(() => {
     ReplSession.clearCache();
   });
 
   describe("tool registration", () => {
     it("should register eval tool", () => {
-      const middleware = createREPLMiddleware();
+      const middleware = createCodeInterpreterMiddleware();
       expect(middleware.tools).toBeDefined();
       const names = middleware.tools!.map((t: { name: string }) => t.name);
       expect(names).toContain("eval");
@@ -29,7 +29,7 @@ describe("createREPLMiddleware", () => {
     });
 
     it("should register exactly one tool", () => {
-      const middleware = createREPLMiddleware();
+      const middleware = createCodeInterpreterMiddleware();
       expect(middleware.tools!.length).toBe(1);
       expect(
         (middleware.tools![0] as { metadata?: Record<string, unknown> })
@@ -40,7 +40,7 @@ describe("createREPLMiddleware", () => {
 
   describe("wrapModelCall", () => {
     it("should add REPL system prompt with API Reference structure", async () => {
-      const middleware = createREPLMiddleware();
+      const middleware = createCodeInterpreterMiddleware();
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
 
       await middleware.wrapModelCall!(
@@ -65,7 +65,7 @@ describe("createREPLMiddleware", () => {
     });
 
     it("should use custom system prompt when provided", async () => {
-      const middleware = createREPLMiddleware({
+      const middleware = createCodeInterpreterMiddleware({
         systemPrompt: "Custom REPL prompt",
       });
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
@@ -160,7 +160,7 @@ describe("createREPLMiddleware", () => {
     });
 
     it("should include directly injected instances in PTC prompt", async () => {
-      const middleware = createREPLMiddleware({ ptc: [extraTool] });
+      const middleware = createCodeInterpreterMiddleware({ ptc: [extraTool] });
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
 
       await middleware.wrapModelCall!(
@@ -178,7 +178,7 @@ describe("createREPLMiddleware", () => {
     });
 
     it("should include both named agent tools and injected instances in mixed ptc array", async () => {
-      const middleware = createREPLMiddleware({
+      const middleware = createCodeInterpreterMiddleware({
         ptc: ["agent_tool", extraTool],
       });
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
@@ -250,7 +250,7 @@ describe("createREPLMiddleware", () => {
 
   describe("afterAgent call", () => {
     it("should dispose of the session for the current thread", async () => {
-      const middleware = createREPLMiddleware();
+      const middleware = createCodeInterpreterMiddleware();
 
       // Trigger session creation via eval
       const jsTool = middleware.tools!.find(
@@ -273,7 +273,7 @@ describe("createREPLMiddleware", () => {
     });
 
     it("should no-op for afterAgent on a thread with no session", async () => {
-      const middleware = createREPLMiddleware();
+      const middleware = createCodeInterpreterMiddleware();
       await expect(
         (middleware as any).afterAgent(
           {},
@@ -283,7 +283,7 @@ describe("createREPLMiddleware", () => {
     });
 
     it("should only remove the session for the finished thread, not others", async () => {
-      const middleware = createREPLMiddleware();
+      const middleware = createCodeInterpreterMiddleware();
       const jsTool = middleware.tools!.find(
         (t: any) => t.name === "eval",
       ) as any;

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -1,5 +1,5 @@
 /**
- * REPL middleware for deepagents.
+ * Code Interpreter middleware for deepagents.
  *
  * Provides an `eval` tool that runs JavaScript in a WASM-sandboxed QuickJS
  * interpreter. Supports:
@@ -23,7 +23,7 @@ import {
   type BackendFactory,
   type SkillMetadata,
 } from "deepagents";
-import type { REPLMiddlewareOptions } from "./types.js";
+import type { CodeInterpreterMiddlewareOptions } from "./types.js";
 import {
   ReplSession,
   DEFAULT_EXECUTION_TIMEOUT,
@@ -173,9 +173,11 @@ async function prepareSkillsForEval(
 }
 
 /**
- * Create the REPL middleware.
+ * Create the Code Interpreter middleware.
  */
-export function createREPLMiddleware(options: REPLMiddlewareOptions = {}) {
+export function createCodeInterpreterMiddleware(
+  options: CodeInterpreterMiddlewareOptions = {},
+) {
   const {
     ptc,
     memoryLimitBytes = DEFAULT_MEMORY_LIMIT,
@@ -266,7 +268,7 @@ export function createREPLMiddleware(options: REPLMiddlewareOptions = {}) {
   );
 
   return createMiddleware({
-    name: "REPLMiddleware",
+    name: "CodeInterpreterMiddleware",
     tools: [evalTool],
     wrapModelCall: async (request, handler) => {
       const agentTools = (request.tools || []) as StructuredToolInterface[];

--- a/libs/providers/quickjs/src/types.ts
+++ b/libs/providers/quickjs/src/types.ts
@@ -7,9 +7,9 @@ import type {
 } from "deepagents";
 
 /**
- * Configuration options for the REPL middleware.
+ * Configuration options for the Code Interpreter middleware.
  */
-export interface REPLMiddlewareOptions {
+export interface CodeInterpreterMiddlewareOptions {
   /**
    * Enable programmatic tool calling from within the REPL.
    *


### PR DESCRIPTION
### Summary

This PR updates `REPLMiddleware` to `CodeInterpreterMiddleware`