### PR TITLE
feat(deepagents): add ContextHubBackend backend

### DIFF
--- a/.changeset/fluffy-zebras-wave.md
+++ b/.changeset/fluffy-zebras-wave.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+feat(deepagents): add `ContextHubBackend` for LangSmith Hub agent repos

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -78,7 +78,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "langsmith": ">=0.5.20 <1.0.0"
+    "langsmith": ">=0.6.0 <1.0.0"
   },
   "files": [
     "dist/**/*"

--- a/libs/deepagents/src/backends/context-hub.int.test.ts
+++ b/libs/deepagents/src/backends/context-hub.int.test.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from "node:crypto";
+
+import { Client } from "langsmith";
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextHubBackend } from "./context-hub.js";
+
+const hasCredentials = !!process.env.LANGSMITH_API_KEY;
+const describeWithLangSmith = hasCredentials ? describe : describe.skip;
+
+function makeIdentifier(): string {
+  return `-/deepagents-ctx-hub-test-${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+async function safeDeleteAgent(identifier: string): Promise<void> {
+  try {
+    await new Client().deleteAgent(identifier);
+  } catch {
+    // Cleanup best effort in integration tests.
+  }
+}
+
+describeWithLangSmith(
+  "ContextHubBackend integration",
+  { timeout: 180_000 },
+  () => {
+    it("lazy-creates repos on first write", async () => {
+      const identifier = makeIdentifier();
+      const backend = new ContextHubBackend(identifier, {
+        client: new Client(),
+      });
+      try {
+        const missing = await backend.read("/notes.md");
+        expect(missing.error).toBeDefined();
+
+        const write = await backend.write("/notes.md", "# hi");
+        expect(write.error).toBeUndefined();
+        expect(write.path).toBe("/notes.md");
+
+        const read = await backend.read("/notes.md");
+        expect(read.error).toBeUndefined();
+        expect(read.content).toBe("# hi");
+      } finally {
+        await safeDeleteAgent(identifier);
+      }
+    });
+
+    it("supports CRUD + search operations", async () => {
+      const identifier = makeIdentifier();
+      const backend = new ContextHubBackend(identifier, {
+        client: new Client(),
+      });
+      try {
+        expect(
+          (await backend.write("/a.md", "hello\nworld")).error,
+        ).toBeUndefined();
+        expect(
+          (await backend.write("/b.md", "hello again")).error,
+        ).toBeUndefined();
+        expect(
+          (await backend.write("/notes/day1.md", "first note")).error,
+        ).toBeUndefined();
+
+        const lsRoot = await backend.ls("/");
+        const rootPaths = new Set(
+          (lsRoot.files ?? []).map((file) => file.path),
+        );
+        expect(rootPaths.has("/a.md")).toBe(true);
+        expect(rootPaths.has("/b.md")).toBe(true);
+        expect(rootPaths.has("/notes")).toBe(true);
+
+        const lsNested = await backend.ls("/notes");
+        expect(
+          new Set((lsNested.files ?? []).map((file) => file.path)),
+        ).toEqual(new Set(["/notes/day1.md"]));
+
+        const grep = await backend.grep("hello");
+        expect(
+          new Set((grep.matches ?? []).map((match) => match.path)),
+        ).toEqual(new Set(["/a.md", "/b.md"]));
+
+        const glob = await backend.glob("*.md");
+        const globPaths = new Set((glob.files ?? []).map((file) => file.path));
+        expect(globPaths.has("/a.md")).toBe(true);
+        expect(globPaths.has("/b.md")).toBe(true);
+
+        const edit = await backend.edit("/a.md", "world", "earth");
+        expect(edit.error).toBeUndefined();
+        expect(edit.occurrences).toBe(1);
+
+        const updated = await backend.read("/a.md");
+        expect(updated.error).toBeUndefined();
+        expect(updated.content).toContain("earth");
+      } finally {
+        await safeDeleteAgent(identifier);
+      }
+    });
+
+    it("downloadFiles returns bytes for existing files and errors for missing paths", async () => {
+      const identifier = makeIdentifier();
+      const backend = new ContextHubBackend(identifier, {
+        client: new Client(),
+      });
+      try {
+        expect(
+          (await backend.write("/blob.txt", "payload")).error,
+        ).toBeUndefined();
+
+        const responses = await backend.downloadFiles([
+          "/blob.txt",
+          "/missing.txt",
+        ]);
+        expect(responses).toHaveLength(2);
+        expect(responses[0].path).toBe("/blob.txt");
+        expect(new TextDecoder().decode(responses[0].content!)).toBe("payload");
+        expect(responses[0].error).toBeNull();
+        expect(responses[1].path).toBe("/missing.txt");
+        expect(responses[1].error).toBe("file_not_found");
+      } finally {
+        await safeDeleteAgent(identifier);
+      }
+    });
+
+    it("uploadFiles supports partial success and persists valid UTF-8 files", async () => {
+      const identifier = makeIdentifier();
+      const backend = new ContextHubBackend(identifier, {
+        client: new Client(),
+      });
+      try {
+        const responses = await backend.uploadFiles([
+          ["/u1.md", new TextEncoder().encode("one")],
+          ["/u2.md", new TextEncoder().encode("two")],
+          ["/bad.bin", new Uint8Array([0x80, 0xff])],
+        ]);
+
+        expect(responses[0].error).toBeNull();
+        expect(responses[1].error).toBeNull();
+        expect(responses[2].error).toBe("invalid_path");
+
+        const first = await backend.read("/u1.md");
+        expect(first.error).toBeUndefined();
+        expect(first.content).toBe("one");
+
+        const second = await backend.read("/u2.md");
+        expect(second.error).toBeUndefined();
+        expect(second.content).toBe("two");
+      } finally {
+        await safeDeleteAgent(identifier);
+      }
+    });
+
+    it("persists data across backend instances for the same identifier", async () => {
+      const identifier = makeIdentifier();
+      const backend = new ContextHubBackend(identifier, {
+        client: new Client(),
+      });
+      try {
+        expect(
+          (await backend.write("/persist.md", "original")).error,
+        ).toBeUndefined();
+
+        const second = new ContextHubBackend(identifier, {
+          client: new Client(),
+        });
+        const result = await second.read("/persist.md");
+        expect(result.error).toBeUndefined();
+        expect(result.content).toBe("original");
+      } finally {
+        await safeDeleteAgent(identifier);
+      }
+    });
+
+    it("surfaces parent-commit conflicts on stale writers", async () => {
+      const identifier = makeIdentifier();
+      const backend = new ContextHubBackend(identifier, {
+        client: new Client(),
+      });
+      try {
+        expect((await backend.write("/shared.md", "v0")).error).toBeUndefined();
+
+        const stale = new ContextHubBackend(identifier, {
+          client: new Client(),
+        });
+        await stale.read("/shared.md");
+
+        expect((await backend.write("/shared.md", "v1")).error).toBeUndefined();
+
+        const staleWrite = await stale.write("/other.md", "should-fail");
+        expect(staleWrite.error).toContain("Hub unavailable");
+      } finally {
+        await safeDeleteAgent(identifier);
+      }
+    });
+
+    it("uses a single commit for uploadFiles batches", async () => {
+      const identifier = makeIdentifier();
+      const client = new Client();
+      const pushSpy = vi.spyOn(client, "pushAgent");
+      const backend = new ContextHubBackend(identifier, { client });
+
+      try {
+        const responses = await backend.uploadFiles([
+          ["/batch/a.md", new TextEncoder().encode("alpha")],
+          ["/batch/b.md", new TextEncoder().encode("beta")],
+          ["/batch/c.md", new TextEncoder().encode("gamma")],
+          ["/batch/d.md", new TextEncoder().encode("delta")],
+        ]);
+
+        expect(responses.every((response) => response.error === null)).toBe(
+          true,
+        );
+        expect(pushSpy).toHaveBeenCalledTimes(1);
+
+        const [, options] = pushSpy.mock.calls[0];
+        expect(new Set(Object.keys(options.files))).toEqual(
+          new Set(["batch/a.md", "batch/b.md", "batch/c.md", "batch/d.md"]),
+        );
+
+        const pulled = await new Client().pullAgent(identifier);
+        const pulledPaths = new Set(Object.keys(pulled.files));
+        expect(pulledPaths.has("batch/a.md")).toBe(true);
+        expect(pulledPaths.has("batch/b.md")).toBe(true);
+        expect(pulledPaths.has("batch/c.md")).toBe(true);
+        expect(pulledPaths.has("batch/d.md")).toBe(true);
+      } finally {
+        pushSpy.mockRestore();
+        await safeDeleteAgent(identifier);
+      }
+    });
+  },
+);

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -75,7 +75,17 @@ describe("ContextHubBackend", () => {
 
     const result = await backend.read("/a.md", 1, 2);
     expect(result.error).toBeUndefined();
-    expect(result.content).toBe("2\n3");
+    expect(result.content).toBe("2\n3\n");
+  });
+
+  it("read offset beyond file length returns an error", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "1\n2" },
+    });
+
+    const result = await backend.read("/a.md", 5, 10);
+    expect(result.error).toBe("Line offset 5 exceeds file length (2 lines)");
+    expect(result.content).toBeUndefined();
   });
 
   it("pull runs once for repeated reads", async () => {
@@ -109,14 +119,12 @@ describe("ContextHubBackend", () => {
 
   it("pull non-404 LangSmith failures surface as hub errors", async () => {
     const client = {
-      pullAgent: vi
-        .fn()
-        .mockRejectedValue(
-          makeLangSmithError("hub 5xx", {
-            name: "LangSmithAPIError",
-            status: 500,
-          }),
-        ),
+      pullAgent: vi.fn().mockRejectedValue(
+        makeLangSmithError("hub 5xx", {
+          name: "LangSmithAPIError",
+          status: 500,
+        }),
+      ),
       pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
     };
     const backend = new ContextHubBackend("-/x", {
@@ -355,6 +363,30 @@ describe("ContextHubBackend", () => {
     const result = await backend.glob("*.md");
     const paths = (result.files ?? []).map((file) => file.path).sort();
     expect(paths).toEqual(["/a.md", "/c.md"]);
+  });
+
+  it("glob ignores path argument and matches nested files like Python fnmatch", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "a" },
+      "nested/b.md": { type: "file", content: "b" },
+      "nested/c.txt": { type: "file", content: "c" },
+    });
+
+    const result = await backend.glob("*.md", "/nested");
+    const paths = (result.files ?? []).map((file) => file.path).sort();
+    expect(paths).toEqual(["/a.md", "/nested/b.md"]);
+  });
+
+  it("grep glob follows Python fnmatch semantics for nested paths", async () => {
+    const { backend } = makeBackend({
+      "root.md": { type: "file", content: "hello" },
+      "nested/a.md": { type: "file", content: "hello" },
+      "nested/b.txt": { type: "file", content: "hello" },
+    });
+
+    const result = await backend.grep("hello", null, "*.md");
+    const paths = new Set((result.matches ?? []).map((match) => match.path));
+    expect(paths).toEqual(new Set(["/nested/a.md", "/root.md"]));
   });
 
   it("upload supports partial success and single-commit batching", async () => {

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -421,10 +421,28 @@ describe("ContextHubBackend", () => {
       ["/bad.bin", new Uint8Array([0x80])],
     ]);
 
-    expect(String(responses[0].error)).toContain("Hub unavailable");
-    expect(String(responses[1].error)).toContain("Hub unavailable");
+    expect(responses[0].error).toBe("invalid_path");
+    expect(responses[1].error).toBe("invalid_path");
     expect(responses[2].error).toBe("invalid_path");
     expect(client.pushAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("upload commit permission failures map to permission_denied", async () => {
+    const { backend, client } = makeBackend();
+    client.pushAgent.mockRejectedValue(
+      makeLangSmithError("forbidden", {
+        name: "LangSmithAuthError",
+        status: 403,
+      }),
+    );
+
+    const responses = await backend.uploadFiles([
+      ["/a.md", new TextEncoder().encode("alpha")],
+      ["/b.md", new TextEncoder().encode("beta")],
+    ]);
+
+    expect(responses[0].error).toBe("permission_denied");
+    expect(responses[1].error).toBe("permission_denied");
   });
 
   it("upload duplicate path keeps last write", async () => {
@@ -466,7 +484,26 @@ describe("ContextHubBackend", () => {
     });
 
     const responses = await backend.downloadFiles(["/a.md"]);
-    expect(String(responses[0].error)).toContain("Hub unavailable");
+    expect(responses[0].error).toBe("invalid_path");
+  });
+
+  it("download permission failures map to permission_denied", async () => {
+    const client = {
+      pullAgent: vi.fn().mockRejectedValue(
+        makeLangSmithError("forbidden", {
+          name: "LangSmithAuthError",
+          status: 403,
+        }),
+      ),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/x", {
+      client: client as unknown as Client,
+    });
+
+    const responses = await backend.downloadFiles(["/a.md", "/b.md"]);
+    expect(responses[0].error).toBe("permission_denied");
+    expect(responses[1].error).toBe("permission_denied");
   });
 
   it("getLinkedEntries returns linked repo handles", async () => {

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -347,10 +347,16 @@ describe("ContextHubBackend", () => {
     expect(paths).toEqual(new Set(["/memories/a.md"]));
   });
 
-  it("grep returns invalid regex errors", async () => {
-    const { backend } = makeBackend();
+  it("grep treats regex metacharacters as literal text", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "literal [unclosed\nother line" },
+    });
+
     const result = await backend.grep("[unclosed");
-    expect(result.error).toContain("Invalid regex");
+    expect(result.error).toBeUndefined();
+    expect(result.matches).toEqual([
+      { path: "/a.md", line: 1, text: "literal [unclosed" },
+    ]);
   });
 
   it("glob matches file patterns", async () => {

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -1,0 +1,513 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import { describe, it, expect, vi } from "vitest";
+import type { Client } from "langsmith";
+import type { Entry } from "langsmith/schemas";
+
+import { ContextHubBackend } from "./context-hub.js";
+import { CompositeBackend } from "./composite.js";
+import { FilesystemBackend } from "./filesystem.js";
+
+const COMMIT_HASH = "abcd1234".repeat(8);
+const COMMIT_URL = "https://host/hub/-/test-agent:ef567890";
+
+function makeLangSmithError(
+  message: string,
+  options: { name?: string; status?: number } = {},
+): Error & { status?: number } {
+  const error = new Error(message) as Error & { status?: number };
+  if (options.name) {
+    Object.defineProperty(error, "name", { value: options.name });
+  }
+  if (options.status !== undefined) {
+    error.status = options.status;
+  }
+  return error;
+}
+
+function makeBackend(files: Record<string, Entry> = {}): {
+  backend: ContextHubBackend;
+  client: {
+    pullAgent: ReturnType<typeof vi.fn>;
+    pushAgent: ReturnType<typeof vi.fn>;
+  };
+} {
+  const client = {
+    pullAgent: vi.fn().mockResolvedValue({
+      commit_id: "00000000-0000-0000-0000-000000000000",
+      commit_hash: COMMIT_HASH,
+      files,
+    }),
+    pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+  };
+
+  const backend = new ContextHubBackend("-/test-agent", {
+    client: client as unknown as Client,
+  });
+  return { backend, client };
+}
+
+describe("ContextHubBackend", () => {
+  it("read returns file content", async () => {
+    const { backend } = makeBackend({
+      "AGENTS.md": { type: "file", content: "# hi\nworld" },
+    });
+
+    const result = await backend.read("/AGENTS.md");
+    expect(result.error).toBeUndefined();
+    expect(result.content).toBe("# hi\nworld");
+    expect(result.mimeType).toBe("text/plain");
+  });
+
+  it("read missing file returns not found", async () => {
+    const { backend } = makeBackend();
+    const result = await backend.read("/missing.md");
+    expect(result.error).toBe("File '/missing.md' not found");
+    expect(result.content).toBeUndefined();
+  });
+
+  it("read applies offset and limit", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "1\n2\n3\n4\n5" },
+    });
+
+    const result = await backend.read("/a.md", 1, 2);
+    expect(result.error).toBeUndefined();
+    expect(result.content).toBe("2\n3");
+  });
+
+  it("pull runs once for repeated reads", async () => {
+    const { backend, client } = makeBackend({
+      "a.md": { type: "file", content: "a" },
+    });
+
+    await backend.read("/a.md");
+    await backend.read("/a.md");
+    await backend.ls("/");
+    expect(client.pullAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("pull 404 is treated as an empty repo", async () => {
+    const client = {
+      pullAgent: vi.fn().mockRejectedValue(
+        makeLangSmithError("not found", {
+          name: "LangSmithNotFoundError",
+          status: 404,
+        }),
+      ),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/new-agent", {
+      client: client as unknown as Client,
+    });
+
+    const result = await backend.read("/any.md");
+    expect(result.error).toBe("File '/any.md' not found");
+  });
+
+  it("pull non-404 LangSmith failures surface as hub errors", async () => {
+    const client = {
+      pullAgent: vi
+        .fn()
+        .mockRejectedValue(
+          makeLangSmithError("hub 5xx", {
+            name: "LangSmithAPIError",
+            status: 500,
+          }),
+        ),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/x", {
+      client: client as unknown as Client,
+    });
+
+    const result = await backend.read("/anything");
+    expect(result.error).toContain("Hub unavailable");
+    expect(result.error).toContain("hub 5xx");
+  });
+
+  it("unexpected non-LangSmith pull failures propagate", async () => {
+    const client = {
+      pullAgent: vi.fn().mockRejectedValue(new Error("boom")),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/x", {
+      client: client as unknown as Client,
+    });
+
+    await expect(backend.read("/anything")).rejects.toThrow("boom");
+  });
+
+  it("hasPriorCommits is false for missing repo", async () => {
+    const client = {
+      pullAgent: vi.fn().mockRejectedValue(
+        makeLangSmithError("not found", {
+          name: "LangSmithNotFoundError",
+          status: 404,
+        }),
+      ),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/fresh", {
+      client: client as unknown as Client,
+    });
+
+    await expect(backend.hasPriorCommits()).resolves.toBe(false);
+  });
+
+  it("hasPriorCommits is true for an existing repo", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "a" },
+    });
+    await expect(backend.hasPriorCommits()).resolves.toBe(true);
+  });
+
+  it("hasPriorCommits flips true after first write", async () => {
+    const client = {
+      pullAgent: vi.fn().mockRejectedValue(
+        makeLangSmithError("not found", {
+          name: "LangSmithNotFoundError",
+          status: 404,
+        }),
+      ),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/fresh", {
+      client: client as unknown as Client,
+    });
+
+    expect(await backend.hasPriorCommits()).toBe(false);
+    await backend.write("/seed.md", "hello");
+    expect(await backend.hasPriorCommits()).toBe(true);
+  });
+
+  it("write commits file content", async () => {
+    const { backend, client } = makeBackend();
+    const result = await backend.write("/notes.md", "# hi");
+
+    expect(result.error).toBeUndefined();
+    expect(result.path).toBe("/notes.md");
+    expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+    const [, options] = client.pushAgent.mock.calls[0];
+    expect(options.files).toHaveProperty("notes.md");
+    expect(options.files["notes.md"]).toEqual({
+      type: "file",
+      content: "# hi",
+    });
+  });
+
+  it("write sends parent commit from pull", async () => {
+    const { backend, client } = makeBackend({
+      "a.md": { type: "file", content: "a" },
+    });
+    await backend.read("/a.md");
+    await backend.write("/b.md", "b");
+
+    const [, options] = client.pushAgent.mock.calls[0];
+    expect(options.parentCommit).toBe(COMMIT_HASH);
+  });
+
+  it("write updates commit hash from push URL", async () => {
+    const { backend, client } = makeBackend();
+    await backend.write("/a.md", "a");
+    await backend.write("/b.md", "b");
+
+    const [, options] = client.pushAgent.mock.calls[1];
+    expect(options.parentCommit).toBe("ef567890");
+  });
+
+  it("write updates cache after commit", async () => {
+    const { backend } = makeBackend();
+    await backend.write("/a.md", "hello");
+
+    const result = await backend.read("/a.md");
+    expect(result.error).toBeUndefined();
+    expect(result.content).toBe("hello");
+  });
+
+  it("write allows sibling paths under linked entries", async () => {
+    const { backend, client } = makeBackend({
+      "skills/code-reviewer": { type: "skill", repo_handle: "code-reviewer" },
+    });
+
+    const result = await backend.write("/skills/code-reviewer.md", "sibling");
+    expect(result.error).toBeUndefined();
+    expect(client.pushAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("commit failures invalidate cache and re-pull on next read", async () => {
+    const { backend, client } = makeBackend({
+      "a.md": { type: "file", content: "a" },
+    });
+    client.pushAgent.mockRejectedValue(
+      makeLangSmithError("500", { name: "LangSmithAPIError", status: 500 }),
+    );
+
+    const result = await backend.write("/b.md", "b");
+    expect(result.error).toContain("Hub unavailable");
+
+    await backend.read("/a.md");
+    expect(client.pullAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it("edit replaces a single occurrence", async () => {
+    const { backend, client } = makeBackend({
+      "a.md": { type: "file", content: "hello world" },
+    });
+
+    const result = await backend.edit("/a.md", "world", "earth");
+    expect(result.error).toBeUndefined();
+    expect(result.occurrences).toBe(1);
+
+    const [, options] = client.pushAgent.mock.calls[0];
+    expect(options.files["a.md"]).toEqual({
+      type: "file",
+      content: "hello earth",
+    });
+  });
+
+  it("edit returns not found when target file does not exist", async () => {
+    const { backend } = makeBackend();
+    const result = await backend.edit("/missing.md", "x", "y");
+    expect(result.error).toContain("not found");
+  });
+
+  it("edit returns ambiguity error when replaceAll is false", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "x x x" },
+    });
+
+    const result = await backend.edit("/a.md", "x", "y");
+    expect(result.error).toContain("multiple occurrences");
+  });
+
+  it("edit with replaceAll replaces all matches", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "x x x" },
+    });
+
+    const result = await backend.edit("/a.md", "x", "y", true);
+    expect(result.error).toBeUndefined();
+    expect(result.occurrences).toBe(3);
+  });
+
+  it("ls supports flat and nested repos", async () => {
+    const { backend } = makeBackend({
+      "AGENTS.md": { type: "file", content: "a" },
+      "memories/day1.md": { type: "file", content: "m1" },
+      "memories/day2.md": { type: "file", content: "m2" },
+    });
+
+    const root = await backend.ls("/");
+    const rootPaths = new Set((root.files ?? []).map((file) => file.path));
+    expect(rootPaths.has("/AGENTS.md")).toBe(true);
+    expect(rootPaths.has("/memories")).toBe(true);
+
+    const nested = await backend.ls("/memories");
+    const nestedPaths = (nested.files ?? []).map((file) => file.path).sort();
+    expect(nestedPaths).toEqual(["/memories/day1.md", "/memories/day2.md"]);
+  });
+
+  it("ls surfaces pull errors", async () => {
+    const client = {
+      pullAgent: vi
+        .fn()
+        .mockRejectedValue(
+          makeLangSmithError("5xx", { name: "LangSmithAPIError", status: 500 }),
+        ),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/x", {
+      client: client as unknown as Client,
+    });
+
+    const result = await backend.ls("/");
+    expect(result.error).toContain("Hub unavailable");
+  });
+
+  it("grep finds matches and supports path prefixes", async () => {
+    const { backend } = makeBackend({
+      "memories/a.md": { type: "file", content: "hello" },
+      "AGENTS.md": { type: "file", content: "hello" },
+    });
+
+    const result = await backend.grep("hello", "/memories");
+    const paths = new Set((result.matches ?? []).map((match) => match.path));
+    expect(paths).toEqual(new Set(["/memories/a.md"]));
+  });
+
+  it("grep returns invalid regex errors", async () => {
+    const { backend } = makeBackend();
+    const result = await backend.grep("[unclosed");
+    expect(result.error).toContain("Invalid regex");
+  });
+
+  it("glob matches file patterns", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "x" },
+      "b.txt": { type: "file", content: "y" },
+      "c.md": { type: "file", content: "z" },
+    });
+
+    const result = await backend.glob("*.md");
+    const paths = (result.files ?? []).map((file) => file.path).sort();
+    expect(paths).toEqual(["/a.md", "/c.md"]);
+  });
+
+  it("upload supports partial success and single-commit batching", async () => {
+    const { backend, client } = makeBackend();
+
+    const responses = await backend.uploadFiles([
+      ["/ok.md", new TextEncoder().encode("hello")],
+      ["/bad.bin", new Uint8Array([0x80])],
+      ["/also-ok.md", new TextEncoder().encode("world")],
+    ]);
+
+    expect(responses[0].error).toBeNull();
+    expect(responses[1].error).toBe("invalid_path");
+    expect(responses[2].error).toBeNull();
+    expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+    const [, options] = client.pushAgent.mock.calls[0];
+    expect(new Set(Object.keys(options.files))).toEqual(
+      new Set(["ok.md", "also-ok.md"]),
+    );
+  });
+
+  it("upload commit failures propagate to valid files", async () => {
+    const { backend, client } = makeBackend();
+    client.pushAgent.mockRejectedValue(
+      makeLangSmithError("503", { name: "LangSmithAPIError", status: 503 }),
+    );
+
+    const responses = await backend.uploadFiles([
+      ["/a.md", new TextEncoder().encode("alpha")],
+      ["/b.md", new TextEncoder().encode("beta")],
+      ["/bad.bin", new Uint8Array([0x80])],
+    ]);
+
+    expect(String(responses[0].error)).toContain("Hub unavailable");
+    expect(String(responses[1].error)).toContain("Hub unavailable");
+    expect(responses[2].error).toBe("invalid_path");
+    expect(client.pushAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("upload duplicate path keeps last write", async () => {
+    const { backend, client } = makeBackend();
+    await backend.uploadFiles([
+      ["/dup.md", new TextEncoder().encode("first")],
+      ["/dup.md", new TextEncoder().encode("second")],
+    ]);
+
+    const [, options] = client.pushAgent.mock.calls[0];
+    expect(options.files["dup.md"]).toEqual({
+      type: "file",
+      content: "second",
+    });
+  });
+
+  it("download returns bytes for existing files and file_not_found for missing", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "hi" },
+    });
+
+    const responses = await backend.downloadFiles(["/a.md", "/nope.md"]);
+    expect(new TextDecoder().decode(responses[0].content!)).toBe("hi");
+    expect(responses[0].error).toBeNull();
+    expect(responses[1].error).toBe("file_not_found");
+  });
+
+  it("download propagates pull failures", async () => {
+    const client = {
+      pullAgent: vi
+        .fn()
+        .mockRejectedValue(
+          makeLangSmithError("5xx", { name: "LangSmithAPIError", status: 500 }),
+        ),
+      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+    };
+    const backend = new ContextHubBackend("-/x", {
+      client: client as unknown as Client,
+    });
+
+    const responses = await backend.downloadFiles(["/a.md"]);
+    expect(String(responses[0].error)).toContain("Hub unavailable");
+  });
+
+  it("getLinkedEntries returns linked repo handles", async () => {
+    const { backend } = makeBackend({
+      "skills/reviewer": { type: "skill", repo_handle: "reviewer" },
+      "subagents/planner": { type: "agent", repo_handle: "planner" },
+      "AGENTS.md": { type: "file", content: "a" },
+    });
+
+    await expect(backend.getLinkedEntries()).resolves.toEqual({
+      "skills/reviewer": "reviewer",
+      "subagents/planner": "planner",
+    });
+  });
+
+  it("files expanded under linked paths remain readable", async () => {
+    const { backend } = makeBackend({
+      "skills/s": { type: "skill", repo_handle: "s" },
+      "skills/s/skill.md": { type: "file", content: "expanded" },
+    });
+
+    const result = await backend.read("/skills/s/skill.md");
+    expect(result.error).toBeUndefined();
+    expect(result.content).toBe("expanded");
+  });
+
+  it("composite routing strips and restores route prefixes", async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "deepagents-context-hub-composite-"),
+    );
+    try {
+      const { backend: hubBackend, client } = makeBackend();
+      const defaultBackend = new FilesystemBackend({
+        rootDir: tempDir,
+        virtualMode: true,
+      });
+      const composite = new CompositeBackend(defaultBackend, {
+        "/memories/": hubBackend,
+      });
+
+      await composite.write("/memories/notes.md", "hello hub");
+      const [, options] = client.pushAgent.mock.calls[0];
+      expect(options.files["notes.md"]).toEqual({
+        type: "file",
+        content: "hello hub",
+      });
+
+      const read = await composite.read("/memories/notes.md");
+      expect(read.error).toBeUndefined();
+      expect(read.content).toContain("hello hub");
+
+      await composite.write("/fs-only.txt", "default side");
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      expect(
+        await fs.readFile(path.join(tempDir, "fs-only.txt"), "utf-8"),
+      ).toBe("default side");
+
+      const lsMem = await composite.ls("/memories/");
+      expect(
+        lsMem.files?.some((file) => file.path === "/memories/notes.md"),
+      ).toBe(true);
+
+      const grepMem = await composite.grep("hello", "/memories");
+      expect(
+        grepMem.matches?.some((match) => match.path === "/memories/notes.md"),
+      ).toBe(true);
+
+      const globMem = await composite.glob("*.md", "/memories");
+      expect(
+        globMem.files?.some((file) => file.path === "/memories/notes.md"),
+      ).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -347,13 +347,6 @@ export class ContextHubBackend implements BackendProtocolV2 {
       throw error;
     }
 
-    let regex: RegExp;
-    try {
-      regex = new RegExp(pattern);
-    } catch (error) {
-      return { error: `Invalid regex pattern: ${getErrorMessage(error)}` };
-    }
-
     const prefix = path
       ? ContextHubBackend.stripPrefix(path).replace(/\/+$/, "")
       : "";
@@ -370,7 +363,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       const lines = content.split("\n");
       for (let index = 0; index < lines.length; index++) {
         const line = lines[index];
-        if (regex.test(line)) {
+        if (line.includes(pattern)) {
           matches.push({ path: `/${filePath}`, line: index + 1, text: line });
         }
       }

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -105,6 +105,30 @@ function isLangSmithError(error: unknown): boolean {
   );
 }
 
+function getLangSmithStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  const maybeError = error as { status?: unknown };
+  if (typeof maybeError.status === "number") {
+    return maybeError.status;
+  }
+
+  return undefined;
+}
+
+function mapHubFileOperationError(error: unknown): FileOperationError {
+  const status = getLangSmithStatus(error);
+  if (status === 401 || status === 403) {
+    return "permission_denied";
+  }
+  if (status === 404) {
+    return "file_not_found";
+  }
+  return "invalid_path";
+}
+
 /**
  * Backend that stores files in a LangSmith Hub agent repo (persistent).
  */
@@ -454,7 +478,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       }
     }
 
-    let commitError: string | null = null;
+    let commitError: FileOperationError | null = null;
     if (Object.keys(validFiles).length > 0) {
       try {
         await this.ensureCache();
@@ -462,7 +486,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       } catch (error) {
         if (isLangSmithError(error)) {
           this.cache = null;
-          commitError = ContextHubBackend.toHubUnavailableError(error);
+          commitError = mapHubFileOperationError(error);
         } else {
           throw error;
         }
@@ -474,11 +498,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
         return { path, error: "invalid_path" };
       }
       if (commitError !== null) {
-        // Keep Python parity: backend-specific error string for Hub failures.
-        return {
-          path,
-          error: commitError as unknown as FileOperationError,
-        };
+        return { path, error: commitError };
       }
       return { path, error: null };
     });
@@ -490,12 +510,11 @@ export class ContextHubBackend implements BackendProtocolV2 {
       cache = await this.ensureCache();
     } catch (error) {
       if (isLangSmithError(error)) {
-        const hubError = ContextHubBackend.toHubUnavailableError(error);
-        // Keep Python parity: backend-specific error string for Hub failures.
+        const mappedError = mapHubFileOperationError(error);
         return paths.map((path) => ({
           path,
           content: null,
-          error: hubError as unknown as FileOperationError,
+          error: mappedError,
         }));
       }
       throw error;

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -1,0 +1,474 @@
+/**
+ * ContextHubBackend: Store files in a LangSmith Hub agent repo (persistent).
+ */
+
+import micromatch from "micromatch";
+import { Client } from "langsmith";
+import type { AgentContext, Entry } from "langsmith/schemas";
+import type {
+  BackendProtocolV2,
+  EditResult,
+  FileDownloadResponse,
+  FileInfo,
+  FileOperationError,
+  FileUploadResponse,
+  GlobResult,
+  GrepMatch,
+  GrepResult,
+  LsResult,
+  ReadRawResult,
+  ReadResult,
+  WriteResult,
+} from "./protocol.js";
+import { performStringReplacement } from "./utils.js";
+
+const URL_COMMIT_SUFFIX_RE = /:([0-9a-f]{8,64})$/i;
+const TEXT_MIME_TYPE = "text/plain";
+
+function getErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function isLangSmithNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const maybeError = error as { name?: unknown; status?: unknown };
+  return (
+    maybeError.name === "LangSmithNotFoundError" || maybeError.status === 404
+  );
+}
+
+function isLangSmithError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const maybeError = error as { name?: unknown; status?: unknown };
+  return (
+    (typeof maybeError.name === "string" &&
+      maybeError.name.startsWith("LangSmith")) ||
+    typeof maybeError.status === "number"
+  );
+}
+
+/**
+ * Backend that stores files in a LangSmith Hub agent repo (persistent).
+ */
+export class ContextHubBackend implements BackendProtocolV2 {
+  private identifier: string;
+  private client: Client;
+  private cache: Record<string, string> | null = null;
+  private linkedEntries: Record<string, string> = {};
+  private commitHash: string | null = null;
+
+  constructor(
+    identifier: string,
+    options: {
+      client?: Client;
+    } = {},
+  ) {
+    this.identifier = identifier;
+    this.client = options.client ?? new Client();
+  }
+
+  private static stripPrefix(path: string): string {
+    return path.replace(/^\/+/, "");
+  }
+
+  private static toHubUnavailableError(error: unknown): string {
+    return `Hub unavailable: ${getErrorMessage(error)}`;
+  }
+
+  private async loadTree(): Promise<void> {
+    let context: AgentContext;
+    try {
+      context = await this.client.pullAgent(this.identifier);
+    } catch (error) {
+      if (isLangSmithNotFoundError(error)) {
+        this.cache = {};
+        this.linkedEntries = {};
+        this.commitHash = null;
+        return;
+      }
+      throw error;
+    }
+
+    this.commitHash = context.commit_hash;
+    this.cache = {};
+    this.linkedEntries = {};
+
+    for (const [path, entry] of Object.entries(context.files)) {
+      if (entry.type === "file") {
+        this.cache[path] = entry.content;
+      } else if (
+        (entry.type === "agent" || entry.type === "skill") &&
+        typeof entry.repo_handle === "string"
+      ) {
+        this.linkedEntries[path] = entry.repo_handle;
+      }
+    }
+  }
+
+  private async ensureCache(): Promise<Record<string, string>> {
+    if (this.cache === null) {
+      await this.loadTree();
+    }
+    if (this.cache === null) {
+      throw new Error("Context Hub cache failed to initialize");
+    }
+    return this.cache;
+  }
+
+  private async commit(files: Record<string, string>): Promise<void> {
+    if (Object.keys(files).length === 0) {
+      return;
+    }
+
+    const payload: Record<string, Entry | null> = {};
+    for (const [path, content] of Object.entries(files)) {
+      payload[path] = { type: "file", content };
+    }
+
+    const url = await this.client.pushAgent(this.identifier, {
+      files: payload,
+      ...(this.commitHash ? { parentCommit: this.commitHash } : {}),
+    });
+
+    const match = URL_COMMIT_SUFFIX_RE.exec(url);
+    if (match) {
+      this.commitHash = match[1];
+    }
+
+    if (this.cache !== null) {
+      for (const [path, content] of Object.entries(files)) {
+        this.cache[path] = content;
+      }
+    }
+  }
+
+  /**
+   * Return linked-entry paths mapped to their repo handles.
+   */
+  async getLinkedEntries(): Promise<Record<string, string>> {
+    await this.ensureCache();
+    return { ...this.linkedEntries };
+  }
+
+  /**
+   * Return true if the hub repo already exists with at least one commit.
+   */
+  async hasPriorCommits(): Promise<boolean> {
+    await this.ensureCache();
+    return this.commitHash !== null;
+  }
+
+  async ls(path: string = "/"): Promise<LsResult> {
+    const hubPrefix = ContextHubBackend.stripPrefix(path).replace(/\/+$/, "");
+
+    let cache: Record<string, string>;
+    try {
+      cache = await this.ensureCache();
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        return { error: ContextHubBackend.toHubUnavailableError(error) };
+      }
+      throw error;
+    }
+
+    const dirs = new Set<string>();
+    const entries: FileInfo[] = [];
+
+    for (const filePath of Object.keys(cache)) {
+      if (hubPrefix && !filePath.startsWith(`${hubPrefix}/`)) {
+        continue;
+      }
+
+      const relative = hubPrefix
+        ? filePath.slice(hubPrefix.length + 1)
+        : filePath;
+      if (!relative) {
+        continue;
+      }
+
+      const slashIndex = relative.indexOf("/");
+      if (slashIndex === -1) {
+        entries.push({ path: `/${filePath}`, is_dir: false });
+        continue;
+      }
+
+      const dirName = relative.slice(0, slashIndex);
+      const dirPath = hubPrefix ? `${hubPrefix}/${dirName}` : dirName;
+      if (!dirs.has(dirPath)) {
+        dirs.add(dirPath);
+        entries.push({ path: `/${dirPath}`, is_dir: true });
+      }
+    }
+
+    return { files: entries };
+  }
+
+  async read(
+    filePath: string,
+    offset: number = 0,
+    limit: number = 500,
+  ): Promise<ReadResult> {
+    const hubPath = ContextHubBackend.stripPrefix(filePath);
+
+    let cache: Record<string, string>;
+    try {
+      cache = await this.ensureCache();
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        return { error: ContextHubBackend.toHubUnavailableError(error) };
+      }
+      throw error;
+    }
+
+    const content = cache[hubPath];
+    if (content === undefined) {
+      return { error: `File '${filePath}' not found` };
+    }
+
+    const lines = content.split("\n");
+    const selected = lines.slice(offset, offset + limit);
+    return { content: selected.join("\n"), mimeType: TEXT_MIME_TYPE };
+  }
+
+  async readRaw(filePath: string): Promise<ReadRawResult> {
+    const readResult = await this.read(filePath, 0, Number.MAX_SAFE_INTEGER);
+    if (readResult.error || typeof readResult.content !== "string") {
+      return { error: readResult.error ?? `File '${filePath}' not found` };
+    }
+
+    return {
+      data: {
+        content: readResult.content,
+        mimeType: TEXT_MIME_TYPE,
+        created_at: "",
+        modified_at: "",
+      },
+    };
+  }
+
+  async grep(
+    pattern: string,
+    path: string | null = null,
+    glob: string | null = null,
+  ): Promise<GrepResult> {
+    let cache: Record<string, string>;
+    try {
+      cache = await this.ensureCache();
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        return { error: ContextHubBackend.toHubUnavailableError(error) };
+      }
+      throw error;
+    }
+
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern);
+    } catch (error) {
+      return { error: `Invalid regex pattern: ${getErrorMessage(error)}` };
+    }
+
+    const prefix = path
+      ? ContextHubBackend.stripPrefix(path).replace(/\/+$/, "")
+      : "";
+
+    const matches: GrepMatch[] = [];
+    for (const [filePath, content] of Object.entries(cache)) {
+      if (prefix && !filePath.startsWith(prefix)) {
+        continue;
+      }
+      if (glob && !micromatch.isMatch(filePath, glob)) {
+        continue;
+      }
+
+      const lines = content.split("\n");
+      for (let index = 0; index < lines.length; index++) {
+        const line = lines[index];
+        if (regex.test(line)) {
+          matches.push({ path: `/${filePath}`, line: index + 1, text: line });
+        }
+      }
+    }
+
+    return { matches };
+  }
+
+  async glob(pattern: string, path: string = "/"): Promise<GlobResult> {
+    let cache: Record<string, string>;
+    try {
+      cache = await this.ensureCache();
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        return { error: ContextHubBackend.toHubUnavailableError(error) };
+      }
+      throw error;
+    }
+
+    const prefix = ContextHubBackend.stripPrefix(path).replace(/\/+$/, "");
+
+    const files: FileInfo[] = [];
+    for (const filePath of Object.keys(cache)) {
+      if (prefix && filePath !== prefix && !filePath.startsWith(`${prefix}/`)) {
+        continue;
+      }
+      if (
+        micromatch.isMatch(`/${filePath}`, pattern) ||
+        micromatch.isMatch(filePath, pattern)
+      ) {
+        files.push({ path: `/${filePath}`, is_dir: false });
+      }
+    }
+
+    return { files };
+  }
+
+  async write(filePath: string, content: string): Promise<WriteResult> {
+    const hubPath = ContextHubBackend.stripPrefix(filePath);
+
+    try {
+      await this.ensureCache();
+      await this.commit({ [hubPath]: content });
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        this.cache = null;
+        return { error: ContextHubBackend.toHubUnavailableError(error) };
+      }
+      throw error;
+    }
+
+    return { path: filePath, filesUpdate: null };
+  }
+
+  async edit(
+    filePath: string,
+    oldString: string,
+    newString: string,
+    replaceAll: boolean = false,
+  ): Promise<EditResult> {
+    const hubPath = ContextHubBackend.stripPrefix(filePath);
+
+    try {
+      const cache = await this.ensureCache();
+      const current = cache[hubPath];
+      if (current === undefined) {
+        return { error: `Error: File '${filePath}' not found` };
+      }
+
+      const replacementResult = performStringReplacement(
+        current,
+        oldString,
+        newString,
+        replaceAll,
+      );
+      if (typeof replacementResult === "string") {
+        return { error: replacementResult };
+      }
+
+      const [newContent, occurrences] = replacementResult;
+      await this.commit({ [hubPath]: newContent });
+      return {
+        path: filePath,
+        filesUpdate: null,
+        occurrences,
+      };
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        this.cache = null;
+        return { error: ContextHubBackend.toHubUnavailableError(error) };
+      }
+      throw error;
+    }
+  }
+
+  async uploadFiles(
+    files: Array<[string, Uint8Array]>,
+  ): Promise<FileUploadResponse[]> {
+    const decoder = new TextDecoder("utf-8", { fatal: true });
+    const decoded: Array<[string, string | null]> = [];
+    const validFiles: Record<string, string> = {};
+
+    for (const [path, content] of files) {
+      try {
+        const text = decoder.decode(content);
+        decoded.push([path, text]);
+        validFiles[ContextHubBackend.stripPrefix(path)] = text;
+      } catch {
+        decoded.push([path, null]);
+      }
+    }
+
+    let commitError: string | null = null;
+    if (Object.keys(validFiles).length > 0) {
+      try {
+        await this.ensureCache();
+        await this.commit(validFiles);
+      } catch (error) {
+        if (isLangSmithError(error)) {
+          this.cache = null;
+          commitError = ContextHubBackend.toHubUnavailableError(error);
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    return decoded.map(([path, text]) => {
+      if (text === null) {
+        return { path, error: "invalid_path" };
+      }
+      if (commitError !== null) {
+        // Keep Python parity: backend-specific error string for Hub failures.
+        return {
+          path,
+          error: commitError as unknown as FileOperationError,
+        };
+      }
+      return { path, error: null };
+    });
+  }
+
+  async downloadFiles(paths: string[]): Promise<FileDownloadResponse[]> {
+    let cache: Record<string, string>;
+    try {
+      cache = await this.ensureCache();
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        const hubError = ContextHubBackend.toHubUnavailableError(error);
+        // Keep Python parity: backend-specific error string for Hub failures.
+        return paths.map((path) => ({
+          path,
+          content: null,
+          error: hubError as unknown as FileOperationError,
+        }));
+      }
+      throw error;
+    }
+
+    const encoder = new TextEncoder();
+    return paths.map((path) => {
+      const hubPath = ContextHubBackend.stripPrefix(path);
+      const content = cache[hubPath];
+      if (content !== undefined) {
+        return { path, content: encoder.encode(content), error: null };
+      }
+      return { path, content: null, error: "file_not_found" };
+    });
+  }
+}

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -24,6 +24,7 @@ import { performStringReplacement } from "./utils.js";
 
 const URL_COMMIT_SUFFIX_RE = /:([0-9a-f]{8,64})$/i;
 const TEXT_MIME_TYPE = "text/plain";
+const FNMATCH_OPTIONS = { bash: true };
 
 function getErrorMessage(error: unknown): string {
   if (typeof error === "string") {
@@ -38,6 +39,46 @@ function getErrorMessage(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+function splitLinesKeepEnds(content: string): string[] {
+  const lines: string[] = [];
+  let lineStart = 0;
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] === "\n") {
+      lines.push(content.slice(lineStart, index + 1));
+      lineStart = index + 1;
+    }
+  }
+
+  if (lineStart < content.length) {
+    lines.push(content.slice(lineStart));
+  }
+
+  return lines;
+}
+
+function sliceReadContent(
+  content: string,
+  offset: number,
+  limit: number,
+): { content?: string; error?: string } {
+  if (!content || content.trim() === "") {
+    return { content };
+  }
+
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const lines = splitLinesKeepEnds(normalized);
+  const startIndex = offset;
+  const endIndex = Math.min(startIndex + limit, lines.length);
+
+  if (startIndex >= lines.length) {
+    return {
+      error: `Line offset ${offset} exceeds file length (${lines.length} lines)`,
+    };
+  }
+
+  return { content: lines.slice(startIndex, endIndex).join("") };
 }
 
 function isLangSmithNotFoundError(error: unknown): boolean {
@@ -223,7 +264,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
   async read(
     filePath: string,
     offset: number = 0,
-    limit: number = 500,
+    limit: number = 2000,
   ): Promise<ReadResult> {
     const hubPath = ContextHubBackend.stripPrefix(filePath);
 
@@ -242,9 +283,12 @@ export class ContextHubBackend implements BackendProtocolV2 {
       return { error: `File '${filePath}' not found` };
     }
 
-    const lines = content.split("\n");
-    const selected = lines.slice(offset, offset + limit);
-    return { content: selected.join("\n"), mimeType: TEXT_MIME_TYPE };
+    const sliced = sliceReadContent(content, offset, limit);
+    if (sliced.error) {
+      return { error: sliced.error };
+    }
+
+    return { content: sliced.content ?? "", mimeType: TEXT_MIME_TYPE };
   }
 
   async readRaw(filePath: string): Promise<ReadRawResult> {
@@ -253,12 +297,13 @@ export class ContextHubBackend implements BackendProtocolV2 {
       return { error: readResult.error ?? `File '${filePath}' not found` };
     }
 
+    const now = new Date().toISOString();
     return {
       data: {
         content: readResult.content,
         mimeType: TEXT_MIME_TYPE,
-        created_at: "",
-        modified_at: "",
+        created_at: now,
+        modified_at: now,
       },
     };
   }
@@ -294,7 +339,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       if (prefix && !filePath.startsWith(prefix)) {
         continue;
       }
-      if (glob && !micromatch.isMatch(filePath, glob)) {
+      if (glob && !micromatch.isMatch(filePath, glob, FNMATCH_OPTIONS)) {
         continue;
       }
 
@@ -310,7 +355,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
     return { matches };
   }
 
-  async glob(pattern: string, path: string = "/"): Promise<GlobResult> {
+  async glob(pattern: string, _path: string = "/"): Promise<GlobResult> {
     let cache: Record<string, string>;
     try {
       cache = await this.ensureCache();
@@ -321,16 +366,11 @@ export class ContextHubBackend implements BackendProtocolV2 {
       throw error;
     }
 
-    const prefix = ContextHubBackend.stripPrefix(path).replace(/\/+$/, "");
-
     const files: FileInfo[] = [];
     for (const filePath of Object.keys(cache)) {
-      if (prefix && filePath !== prefix && !filePath.startsWith(`${prefix}/`)) {
-        continue;
-      }
       if (
-        micromatch.isMatch(`/${filePath}`, pattern) ||
-        micromatch.isMatch(filePath, pattern)
+        micromatch.isMatch(`/${filePath}`, pattern, FNMATCH_OPTIONS) ||
+        micromatch.isMatch(filePath, pattern, FNMATCH_OPTIONS)
       ) {
         files.push({ path: `/${filePath}`, is_dir: false });
       }

--- a/libs/deepagents/src/backends/index.ts
+++ b/libs/deepagents/src/backends/index.ts
@@ -59,6 +59,7 @@ export {
 } from "./store.js";
 export { FilesystemBackend } from "./filesystem.js";
 export { CompositeBackend } from "./composite.js";
+export { ContextHubBackend } from "./context-hub.js";
 export {
   LocalShellBackend,
   type LocalShellBackendOptions,

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -128,6 +128,7 @@ export {
   type StoreBackendOptions,
   FilesystemBackend,
   CompositeBackend,
+  ContextHubBackend,
   BaseSandbox,
   isSandboxBackend,
   isSandboxProtocol,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,8 +621,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       langsmith:
-        specifier: '>=0.5.20 <1.0.0'
-        version: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0)
+        specifier: '>=0.6.0 <1.0.0'
+        version: 0.6.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0)
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -3300,26 +3300,6 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.1.44
-
-  langsmith@0.5.26:
-    resolution: {integrity: sha512-HmmFgeQR2n9x1Kq8NiVaNL/j72ta71qN11hYjbyePJ/QuYEnOMhQjbNv9KeyKB3bOetpIzNalQbhHm+RyKoPRQ==}
-    peerDependencies:
-      '@opentelemetry/api': '*'
-      '@opentelemetry/exporter-trace-otlp-proto': '*'
-      '@opentelemetry/sdk-trace-base': '*'
-      openai: '*'
-      ws: '>=7'
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@opentelemetry/exporter-trace-otlp-proto':
-        optional: true
-      '@opentelemetry/sdk-trace-base':
-        optional: true
-      openai:
-        optional: true
-      ws:
-        optional: true
 
   langsmith@0.6.1:
     resolution: {integrity: sha512-qNBNPRFqScIlGaPGfMrxhw/GTOL4GJKMp1P4jeA3xuI+Gkj5Ei3wvOtxpYaZMTeBbXTW3yi4n4Wf3nCgogvttg==}
@@ -7138,16 +7118,6 @@ snapshots:
       - vue
       - ws
       - zod-to-json-schema
-
-  langsmith@0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0):
-    dependencies:
-      p-queue: 6.6.2
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/exporter-trace-otlp-proto': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      openai: 6.35.0(ws@8.20.0)(zod@4.4.1)
-      ws: 8.20.0
 
   langsmith@0.6.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0):
     dependencies:


### PR DESCRIPTION
This ports Python deepagents PR #3338 behavior into the JS SDK by introducing a new first-class backend: `ContextHubBackend`.

Why:
- Context Hub repo persistence is now available as an SDK backend in JS, matching the Python backend architecture.
- This gives JS users a canonical LangSmith Hub-backed file backend with the same operational semantics (lazy pull, commit chaining, cache invalidation, batch upload behavior).

What changed:
- Added `ContextHubBackend` in `libs/deepagents/src/backends/context-hub.ts`.
- Exported it from backend and root package exports.
- Added parity-focused unit tests in `context-hub.test.ts`.
- Added integration contract tests in `context-hub.int.test.ts` (gated by `LANGSMITH_API_KEY`).
- Updated `deepagents` peer dependency on `langsmith` from `>=0.5.20` to `>=0.6.0` to rely on Hub directory APIs (`pullAgent` / `pushAgent`).
- Added a changeset for release notes.

Behavior highlights:
- Missing repo on pull is treated as empty and lazily created on first write.
- In-memory file cache with linked-entry tracking (`getLinkedEntries`).
- Commit hash tracking with optimistic `parentCommit` chaining.
- Cache invalidation on mutating Hub failures.
- `uploadFiles` commits all valid UTF-8 files in a single batch commit and returns per-file success/error.

Validation run:
- `pnpm install`
- `pnpm exec oxfmt --write ...` (touched files)
- `pnpm --filter deepagents exec oxlint ...` (touched files)
- `pnpm --filter deepagents exec vitest run src/backends/context-hub.test.ts` (33 passed)
- `pnpm --filter deepagents exec vitest run --mode int src/backends/context-hub.int.test.ts` (skipped without `LANGSMITH_API_KEY`)
