### PR TITLE
feat(acp): support persistent checkpointer/sessions and relax visibility

### DIFF
--- a/libs/acp/src/server.ts
+++ b/libs/acp/src/server.ts
@@ -31,7 +31,10 @@ import {
   ToolMessage,
 } from "@langchain/core/messages";
 import type { InteropZodObject } from "@langchain/core/utils/types";
-import { MemorySaver, type BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
+import {
+  MemorySaver,
+  type BaseCheckpointSaver,
+} from "@langchain/langgraph-checkpoint";
 
 import type {
   DeepAgentConfig,

--- a/libs/acp/src/server.ts
+++ b/libs/acp/src/server.ts
@@ -31,7 +31,7 @@ import {
   ToolMessage,
 } from "@langchain/core/messages";
 import type { InteropZodObject } from "@langchain/core/utils/types";
-import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { MemorySaver, type BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 
 import type {
   DeepAgentConfig,
@@ -134,14 +134,15 @@ const DEFAULT_COMMANDS = [
  */
 export class DeepAgentsServer {
   private connection: AgentSideConnection | null = null;
-  private agents: Map<string, ReturnType<typeof createDeepAgent>> = new Map();
-  private agentConfigs: Map<string, DeepAgentConfig> = new Map();
-  private sessions: Map<string, SessionState> = new Map();
-  private checkpointer: MemorySaver;
+  protected agents: Map<string, ReturnType<typeof createDeepAgent>> = new Map();
+  protected agentConfigs: Map<string, DeepAgentConfig> = new Map();
+  protected sessions: Map<string, SessionState> = new Map();
+  protected checkpointer: BaseCheckpointSaver;
   private clientCapabilities: ACPCapabilities = {};
   private isRunning = false;
   private currentPromptAbortController: AbortController | null = null;
-  private acpBackends: Map<string, ACPFilesystemBackend> = new Map();
+  private readonly hasCustomSessions: boolean;
+  protected acpBackends: Map<string, ACPFilesystemBackend> = new Map();
 
   private readonly serverName: string;
   private readonly serverVersion: string;
@@ -165,7 +166,11 @@ export class DeepAgentsServer {
     });
 
     // Shared checkpointer for session persistence
-    this.checkpointer = new MemorySaver();
+    this.checkpointer = options.checkpointer ?? new MemorySaver();
+
+    // Sessions map for session metadata
+    this.hasCustomSessions = options.sessions !== undefined;
+    this.sessions = options.sessions ?? new Map();
 
     // Initialize agent configurations
     const agentConfigs = Array.isArray(options.agents)
@@ -319,7 +324,9 @@ export class DeepAgentsServer {
 
     this.isRunning = false;
     this.connection = null;
-    this.sessions.clear();
+    if (!this.hasCustomSessions) {
+      this.sessions.clear();
+    }
     this.log("Server stopped");
 
     // Close the logger to flush any pending writes
@@ -329,7 +336,7 @@ export class DeepAgentsServer {
   /**
    * Create the Agent handler for ACP
    */
-  private createAgentHandler(conn: AgentSideConnection): Agent {
+  protected createAgentHandler(conn: AgentSideConnection): Agent {
     return {
       initialize: (params) =>
         this.handleInitialize(params as InitializeRequest),
@@ -502,7 +509,7 @@ export class DeepAgentsServer {
   /**
    * Handle ACP session/load request
    */
-  private async handleLoadSession(
+  protected async handleLoadSession(
     params: LoadSessionRequest,
     conn: AgentSideConnection,
   ): Promise<LoadSessionResponse> {
@@ -520,6 +527,12 @@ export class DeepAgentsServer {
       mode: session.mode,
     });
     session.lastActivityAt = new Date();
+
+    // Ensure agent is created (e.g. after server restart with persistent sessions)
+    if (!this.agents.has(session.agentName)) {
+      this.log("Creating agent for loaded session:", session.agentName);
+      this.createAgent(session.agentName);
+    }
 
     const acpBackend = this.acpBackends.get(session.agentName);
     if (acpBackend) {
@@ -1265,7 +1278,7 @@ export class DeepAgentsServer {
   /**
    * Create a DeepAgent instance for the given configuration
    */
-  private createAgent(agentName: string): void {
+  protected createAgent(agentName: string): void {
     const config = this.agentConfigs.get(agentName);
 
     if (!config) {
@@ -1380,7 +1393,7 @@ export class DeepAgentsServer {
   /**
    * Log a debug message
    */
-  private log(...args: unknown[]): void {
+  protected log(...args: unknown[]): void {
     this.logger.log(...args);
   }
 

--- a/libs/acp/src/types.ts
+++ b/libs/acp/src/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CreateDeepAgentParams } from "deepagents";
+import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 
 /**
  * Configuration for a DeepAgent exposed via ACP
@@ -164,6 +165,35 @@ export interface DeepAgentsServerOptions {
    * @see https://agentclientprotocol.com/rfds/auth-methods
    */
   authMethods?: ACPAuthMethod[];
+
+  /**
+   * Custom checkpointer for conversation history persistence.
+   *
+   * Defaults to MemorySaver (in-memory, no persistence across restarts).
+   * Provide a SqliteSaver or other BaseCheckpointSaver implementation
+   * to persist conversation history across server restarts.
+   *
+   * @example
+   * ```typescript
+   * import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
+   *
+   * const server = new DeepAgentsServer({
+   *   agents: { name: "my-agent" },
+   *   checkpointer: SqliteSaver.fromConnString("./sessions.db"),
+   * });
+   * ```
+   */
+  checkpointer?: BaseCheckpointSaver;
+
+  /**
+   * Custom sessions map for storing session metadata.
+   *
+   * Defaults to an in-memory Map. Provide a persistent Map implementation
+   * (e.g., one that syncs to a database) to retain session metadata across
+   * server restarts. The map must implement the Map<string, SessionState>
+   * interface.
+   */
+  sessions?: Map<string, SessionState>;
 }
 
 /**


### PR DESCRIPTION
## Summary
Add persistent session/checkpointer support to the ACP server and relax visibility for extensibility.
## Changes
### feat: persistent checkpointer and sessions (`types.ts`, `server.ts`)
- Added optional `checkpointer` option — allows passing a custom `BaseCheckpointSaver` (e.g. `SqliteSaver`) to persist conversation history across server restarts. Defaults to `MemorySaver`.
- Added optional `sessions` option — allows passing a custom `Map<string, SessionState>` for persisting session metadata. Defaults to in-memory `Map`.
- `handleLoadSession()` now re-creates the agent on demand when recovering a session after server restart.
### fix: guard `sessions.clear()` against persistent sessions (`server.ts`)
- `stop()` no longer calls `sessions.clear()` when a custom sessions map was provided, preventing accidental data loss.
### refactor: relax visibility from `private` to `protected` (`server.ts`)
- Fields: `agents`, `agentConfigs`, `sessions`, `checkpointer`, `acpBackends`
- Methods: `createAgentHandler()`, `handleLoadSession()`, `createAgent()`, `log()`
These changes enable subclassing `DeepAgentsServer` to customize behavior.