### PR TITLE
chore(quickjs): update swarm task tool to use withStructuredOutput

### DIFF
--- a/.changeset/hip-friends-make.md
+++ b/.changeset/hip-friends-make.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+chore(quickjs): update swarm task tool to use withStructuredOutput

--- a/libs/providers/quickjs/src/index.ts
+++ b/libs/providers/quickjs/src/index.ts
@@ -53,7 +53,6 @@ export {
 export {
   createSwarmTaskTool,
   VariantCache,
-  normalizeSchema,
   type SwarmTaskToolOptions,
   type SwarmSubAgent,
   type SwarmTaskMode,

--- a/libs/providers/quickjs/src/tools/swarm-task.test.ts
+++ b/libs/providers/quickjs/src/tools/swarm-task.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { RunnableLambda } from "@langchain/core/runnables";
+import { FakeToolCallingModel } from "langchain";
 import * as langchain from "langchain";
 
 vi.mock("langchain", async (importOriginal) => {
@@ -15,15 +16,12 @@ vi.mock("langchain", async (importOriginal) => {
   };
 });
 
-import {
-  createSwarmTaskTool,
-  VariantCache,
-  normalizeSchema,
-} from "./swarm-task.js";
+import { createSwarmTaskTool, VariantCache } from "./swarm-task.js";
 
 function makeMockModel(response: string = "model response"): any {
   return {
     invoke: vi.fn(async () => new AIMessage({ content: response })),
+    withStructuredOutput: vi.fn(),
   };
 }
 
@@ -223,7 +221,6 @@ describe("agent mode", () => {
       expect.objectContaining({
         responseFormat: expect.objectContaining({
           type: "object",
-          additionalProperties: false,
           properties: { label: { type: "string" } },
           required: ["label"],
         }),
@@ -247,45 +244,6 @@ describe("agent mode", () => {
 
     // No additional calls — uses pre-compiled agent
     expect(langchain.createAgent).toHaveBeenCalledTimes(1);
-  });
-
-  it("validates response_schema must have type 'object'", async () => {
-    const swarmTask = createSwarmTaskTool({
-      subagents: [{ name: "worker", description: "W", systemPrompt: "W." }],
-      defaultModel: makeMockModel(),
-    });
-
-    await expect(
-      swarmTask.invoke({
-        description: "work",
-        subagent_type: "worker",
-        response_schema: { type: "array", items: { type: "string" } },
-      }),
-    ).rejects.toThrow('response_schema must have type: "object"');
-  });
-
-  it("normalizes schema by adding additionalProperties: false", async () => {
-    const swarmTask = createSwarmTaskTool({
-      subagents: [{ name: "worker", description: "W", systemPrompt: "W." }],
-      defaultModel: makeMockModel(),
-    });
-
-    await swarmTask.invoke({
-      description: "work",
-      subagent_type: "worker",
-      response_schema: {
-        type: "object",
-        properties: { x: { type: "string" } },
-      },
-    });
-
-    expect(langchain.createAgent).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        responseFormat: expect.objectContaining({
-          additionalProperties: false,
-        }),
-      }),
-    );
   });
 });
 
@@ -339,28 +297,19 @@ describe("invoke mode", () => {
     expect(langchain.createAgent).toHaveBeenCalledTimes(afterConstruction);
   });
 
-  it("uses bindTools when response_schema is provided", async () => {
+  it("uses withStructuredOutput when response_schema is provided", async () => {
     const structuredResult = { label: "positive" };
-    const boundModel = {
-      invoke: vi.fn(
-        async () =>
-          new AIMessage({
-            content: [],
-            tool_calls: [
-              {
-                name: "structured_output",
-                args: structuredResult,
-                id: "tc_1",
-                type: "tool_call" as const,
-              },
-            ],
-          }),
-      ),
+    const schema = {
+      type: "object",
+      properties: { label: { type: "string" } },
     };
-    const model: any = {
-      invoke: vi.fn(),
-      bindTools: vi.fn(() => boundModel),
+    const structuredRunnable = {
+      invoke: vi.fn(async () => structuredResult),
     };
+    const model = new FakeToolCallingModel({ toolCalls: [] });
+    const withStructuredOutputSpy = vi
+      .spyOn(model, "withStructuredOutput")
+      .mockReturnValue(structuredRunnable as any);
 
     const swarmTask = createSwarmTaskTool({
       subagents: [],
@@ -370,49 +319,12 @@ describe("invoke mode", () => {
     const result = await swarmTask.invoke({
       description: "work",
       mode: "invoke",
-      response_schema: {
-        type: "object",
-        properties: { label: { type: "string" } },
-      },
+      response_schema: schema,
     });
 
-    expect(model.bindTools).toHaveBeenCalledWith(
-      [
-        {
-          name: "structured_output",
-          description: "Return the structured result.",
-          schema: {
-            type: "object",
-            additionalProperties: false,
-            properties: { label: { type: "string" } },
-          },
-        },
-      ],
-      { tool_choice: "structured_output" },
-    );
-    expect(boundModel.invoke).toHaveBeenCalledOnce();
-    expect(model.invoke).not.toHaveBeenCalled();
+    expect(withStructuredOutputSpy).toHaveBeenCalledWith(schema);
+    expect(structuredRunnable.invoke).toHaveBeenCalledOnce();
     expect(result).toBe(JSON.stringify(structuredResult));
-  });
-
-  it("throws when model does not support bindTools", async () => {
-    const model = makeMockModel();
-
-    const swarmTask = createSwarmTaskTool({
-      subagents: [],
-      defaultModel: model,
-    });
-
-    await expect(
-      swarmTask.invoke({
-        description: "work",
-        mode: "invoke",
-        response_schema: {
-          type: "object",
-          properties: { label: { type: "string" } },
-        },
-      }),
-    ).rejects.toThrow("bindTools");
   });
 
   it("returns string content from model response", async () => {
@@ -445,21 +357,6 @@ describe("invoke mode", () => {
       mode: "invoke",
     });
     expect(result).toBe("plain string response");
-  });
-
-  it("validates response_schema must have type 'object'", async () => {
-    const swarmTask = createSwarmTaskTool({
-      subagents: [],
-      defaultModel: makeMockModel(),
-    });
-
-    await expect(
-      swarmTask.invoke({
-        description: "work",
-        mode: "invoke",
-        response_schema: { type: "array", items: { type: "string" } },
-      }),
-    ).rejects.toThrow('response_schema must have type: "object"');
   });
 
   it("works without response_schema", async () => {
@@ -797,124 +694,5 @@ describe("VariantCache", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// normalizeSchema
-// ---------------------------------------------------------------------------
-
-describe("normalizeSchema", () => {
-  it("adds additionalProperties: false to a top-level object", () => {
-    const result = normalizeSchema({
-      type: "object",
-      properties: { x: { type: "string" } },
-      required: ["x"],
-    });
-    expect(result.additionalProperties).toBe(false);
-  });
-
-  it("preserves an existing additionalProperties: false", () => {
-    const result = normalizeSchema({
-      type: "object",
-      additionalProperties: false,
-      properties: {},
-    });
-    expect(result.additionalProperties).toBe(false);
-  });
-
-  it("recurses into nested object properties", () => {
-    const schema = {
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        counts: {
-          type: "object",
-          properties: { a: { type: "number" } },
-          required: ["a"],
-        },
-      },
-      required: ["counts"],
-    };
-    const result = normalizeSchema(schema);
-    const counts = (result.properties as Record<string, unknown>)
-      .counts as Record<string, unknown>;
-    expect(counts.additionalProperties).toBe(false);
-  });
-
-  it("recurses into array items", () => {
-    const schema = {
-      type: "array",
-      items: {
-        type: "object",
-        properties: { id: { type: "string" } },
-        required: ["id"],
-      },
-    };
-    const result = normalizeSchema(schema);
-    const items = result.items as Record<string, unknown>;
-    expect(items.additionalProperties).toBe(false);
-  });
-
-  it("handles deeply nested objects", () => {
-    const schema = {
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        results: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            properties: {
-              counts: {
-                type: "object",
-                properties: { a: { type: "number" } },
-              },
-            },
-          },
-        },
-      },
-    };
-    const result = normalizeSchema(schema);
-    const items = (
-      (result.properties as Record<string, unknown>).results as Record<
-        string,
-        unknown
-      >
-    ).items as Record<string, unknown>;
-    const counts = (items.properties as Record<string, unknown>)
-      .counts as Record<string, unknown>;
-    expect(counts.additionalProperties).toBe(false);
-  });
-
-  it("passes through non-object/array types unchanged", () => {
-    const schema = { type: "string" };
-    expect(normalizeSchema(schema)).toEqual({ type: "string" });
-  });
-
-  it("preserves minItems on array types", () => {
-    expect(
-      normalizeSchema({ type: "array", minItems: 6, items: { type: "string" } })
-        .minItems,
-    ).toBe(6);
-    expect(
-      normalizeSchema({ type: "array", minItems: 0, items: { type: "string" } })
-        .minItems,
-    ).toBe(0);
-    expect(
-      normalizeSchema({ type: "array", minItems: 1, items: { type: "string" } })
-        .minItems,
-    ).toBe(1);
-  });
-
-  it("preserves maxItems on array types", () => {
-    expect(
-      normalizeSchema({
-        type: "array",
-        maxItems: 10,
-        items: { type: "string" },
-      }).maxItems,
-    ).toBe(10);
   });
 });

--- a/libs/providers/quickjs/src/tools/swarm-task.ts
+++ b/libs/providers/quickjs/src/tools/swarm-task.ts
@@ -1,6 +1,5 @@
 import { z } from "zod/v4";
 import { createAgent, tool, type ReactAgent, StructuredTool } from "langchain";
-import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
 import type { Runnable } from "@langchain/core/runnables";
 import type { StructuredToolInterface } from "@langchain/core/tools";
@@ -199,8 +198,8 @@ async function invokeModel(
     return result;
   }
 
-  if (result instanceof BaseMessage) {
-    return result.text;
+  if (result != null && typeof result === "object" && "text" in result) {
+    return String(result.text);
   }
 
   return JSON.stringify(result);
@@ -211,7 +210,10 @@ async function invokeWithStructuredOutput(
   messages: HumanMessage[],
   responseSchema: Record<string, unknown>,
 ): Promise<string> {
-  if (!(model instanceof BaseChatModel)) {
+  if (
+    !("withStructuredOutput" in model) ||
+    typeof model.withStructuredOutput !== "function"
+  ) {
     throw new Error(
       "invoke mode with response_schema requires a model that supports withStructuredOutput().",
     );

--- a/libs/providers/quickjs/src/tools/swarm-task.ts
+++ b/libs/providers/quickjs/src/tools/swarm-task.ts
@@ -1,9 +1,10 @@
 import { z } from "zod/v4";
 import { createAgent, tool, type ReactAgent, StructuredTool } from "langchain";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
 import type { Runnable } from "@langchain/core/runnables";
 import type { StructuredToolInterface } from "@langchain/core/tools";
-import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { BaseMessage, HumanMessage } from "@langchain/core/messages";
 import { initChatModel } from "langchain/chat_models/universal";
 
 /**
@@ -113,43 +114,6 @@ interface AgentSpec {
   name: string;
 }
 
-/**
- * JSON Schema with a validated `type: "object"` constraint.
- */
-interface ObjectSchema {
-  /**
-   * The schema type, always `"object"` after validation.
-   */
-  type: "object";
-
-  /**
-   * Additional schema properties (e.g. `properties`, `required`).
-   */
-  [key: string]: unknown;
-}
-
-/**
- * A model that supports the `bindTools` method for structured output.
- */
-interface BindableModel {
-  /**
-   * Bind tool definitions to the model, returning a new runnable that
-   * will invoke the model with the given tools available.
-   */
-  bindTools(
-    tools: Array<Record<string, unknown>>,
-    kwargs?: Record<string, unknown>,
-  ): Runnable;
-}
-
-/**
- * Default time-to-live for cached schema-constrained agent variants.
- *
- * Entries are evicted when they haven't been accessed for this duration.
- * Within a `run()`, rows keep hitting the cache so entries stay warm.
- * After the run finishes, nobody accesses the entry and it expires on
- * the next cache access.
- */
 const VARIANT_TTL_MS = 60_000;
 
 /**
@@ -215,116 +179,6 @@ export class VariantCache<T> {
   }
 }
 
-/**
- * Check whether a value is a plain object suitable for JSON Schema traversal.
- */
-function isSchemaNode(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === "object" && !Array.isArray(value);
-}
-
-/**
- * Recursively add `additionalProperties: false` to every object-typed node
- * in a JSON Schema.
- */
-export function normalizeSchema(
-  schema: Record<string, unknown>,
-): Record<string, unknown> {
-  if (schema.type !== "object" && schema.type !== "array") {
-    return schema;
-  }
-
-  if (schema.type === "array") {
-    const result: Record<string, unknown> = { ...schema };
-
-    if (isSchemaNode(result.items)) {
-      result.items = normalizeSchema(result.items);
-    }
-
-    return result;
-  }
-
-  const result: Record<string, unknown> = {
-    ...schema,
-    additionalProperties: false,
-  };
-
-  const props = schema.properties;
-
-  if (isSchemaNode(props)) {
-    const normalized: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(props)) {
-      normalized[key] = isSchemaNode(value) ? normalizeSchema(value) : value;
-    }
-
-    result.properties = normalized;
-  }
-
-  return result;
-}
-
-/**
- * Normalize a response schema and validate it has `type: "object"`.
- *
- * Combines `normalizeSchema` with the object-type check that both
- * `invokeModel` and `invokeAgent` require.
- */
-function normalizeResponseSchema(
-  schema: Record<string, unknown>,
-): ObjectSchema {
-  const normalized = normalizeSchema(schema);
-
-  if (normalized.type !== "object") {
-    throw new Error(
-      `response_schema must have type: "object", got: ${JSON.stringify(normalized.type)}`,
-    );
-  }
-
-  return normalized as ObjectSchema;
-}
-
-/**
- * Check whether a model supports `bindTools` for structured output.
- */
-function hasBindTools(model: unknown): model is BindableModel {
-  return (
-    model != null &&
-    typeof model === "object" &&
-    "bindTools" in model &&
-    typeof model.bindTools === "function"
-  );
-}
-
-/**
- * Convert message content (string or content-block array) to a plain string.
- *
- * Content blocks with a `text` field are concatenated. Non-text blocks
- * are JSON-stringified.
- */
-function contentToString(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
-  }
-
-  if (Array.isArray(content)) {
-    return content
-      .map((block) => {
-        if (isSchemaNode(block) && "text" in block) {
-          return String(block.text);
-        }
-
-        return JSON.stringify(block);
-      })
-      .join("\n");
-  }
-
-  return JSON.stringify(content);
-}
-
-/**
- * Direct model invocation — single LLM call with optional structured output.
- * No tools, no agentic loop.
- */
 async function invokeModel(
   model: LanguageModelLike | string,
   description: string,
@@ -345,52 +199,27 @@ async function invokeModel(
     return result;
   }
 
-  if (result && typeof result === "object" && "content" in result) {
-    return contentToString(result.content);
+  if (result instanceof BaseMessage) {
+    return result.text;
   }
 
   return JSON.stringify(result);
 }
 
-/**
- * Bind a structured output tool to the model and extract the result
- * from the response's `tool_calls`.
- */
 async function invokeWithStructuredOutput(
   model: LanguageModelLike,
   messages: HumanMessage[],
   responseSchema: Record<string, unknown>,
 ): Promise<string> {
-  const normalized = normalizeResponseSchema(responseSchema);
-
-  if (!hasBindTools(model)) {
+  if (!(model instanceof BaseChatModel)) {
     throw new Error(
-      "invoke mode with response_schema requires a model that supports bindTools().",
+      "invoke mode with response_schema requires a model that supports withStructuredOutput().",
     );
   }
 
-  const toolName = "structured_output";
-
-  const bound = model.bindTools(
-    [
-      {
-        name: toolName,
-        description: "Return the structured result.",
-        schema: normalized,
-      },
-    ],
-    { tool_choice: toolName },
-  );
-
-  const response = await bound.invoke(messages);
-
-  if (!AIMessage.isInstance(response) || !response.tool_calls?.length) {
-    throw new Error(
-      "invoke mode with response_schema: model did not return structured output",
-    );
-  }
-
-  return JSON.stringify(response.tool_calls[0].args);
+  const structuredModel = model.withStructuredOutput(responseSchema);
+  const result = await structuredModel.invoke(messages);
+  return JSON.stringify(result);
 }
 
 /**
@@ -413,13 +242,18 @@ async function invokeAgent(
   let agent = entry.agent;
 
   if (responseSchema) {
-    const normalized = normalizeResponseSchema(responseSchema);
-    const cacheKey = `${entry.spec.name}::${JSON.stringify(normalized)}`;
+    if (responseSchema.type !== "object") {
+      throw new Error(
+        `response_schema must have type: "object", got: ${JSON.stringify(responseSchema.type)}`,
+      );
+    }
+    const schema = { ...responseSchema, type: "object" as const };
+    const cacheKey = `${entry.spec.name}::${JSON.stringify(schema)}`;
 
     agent = variantCache.getOrCreate(cacheKey, () =>
       createAgent({
         ...entry.spec,
-        responseFormat: normalized,
+        responseFormat: schema,
       }),
     );
   }
@@ -434,14 +268,14 @@ async function invokeAgent(
     return JSON.stringify(result.structuredResponse);
   }
 
-  const messages = result.messages as Array<{ content: unknown }>;
+  const messages = result.messages as BaseMessage[];
   const lastMessage = messages?.[messages.length - 1];
 
   if (!lastMessage) {
     return "Task completed";
   }
 
-  return contentToString(lastMessage.content);
+  return lastMessage.text;
 }
 
 /**


### PR DESCRIPTION
### Summary

Switch JS swarm task tool to use withStructuredOutput instead of hand-rolled bindTools + tool_calls extraction.

### Tests

- All 202 unit tests pass
- Removed normalizeSchema tests and bindTools-specific tests, replaced with withStructuredOutput test using FakeToolCallingModel