### PR TITLE
chore(deepagents): move required ptc tools to metadata

### DIFF
--- a/.changeset/ten-trams-carry.md
+++ b/.changeset/ten-trams-carry.md
@@ -1,0 +1,6 @@
+---
+"@langchain/quickjs": patch
+"deepagents": patch
+---
+
+chore(deepagents): move required ptc tools to metadata

--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -1432,7 +1432,7 @@ Content
     expect(result?.metadata).toEqual({ count: "42", active: "true" });
   });
 
-  it("should parse space-delimited required-ptc-tools from metadata", () => {
+  it("should preserve required-ptc-tools in metadata without promoting it", () => {
     const content = `---
 name: test-skill
 description: A test skill
@@ -1448,48 +1448,10 @@ Content
       "test-skill",
     );
     expect(result).not.toBeNull();
-    expect(result?.requiredPtcTools).toEqual([
-      "task",
-      "read_file",
-      "write_file",
-      "glob",
-    ]);
-  });
-
-  it("should return empty requiredPtcTools when metadata has no required-ptc-tools", () => {
-    const content = `---
-name: test-skill
-description: A test skill
-metadata:
-  version: "1.0"
----
-
-Content
-`;
-    const result = parseSkillMetadataFromContent(
-      content,
-      "/skills/test-skill/SKILL.md",
-      "test-skill",
+    expect(result).not.toHaveProperty("requiredPtcTools");
+    expect(result?.metadata["required-ptc-tools"]).toBe(
+      "task read_file write_file glob",
     );
-    expect(result).not.toBeNull();
-    expect(result?.requiredPtcTools).toEqual([]);
-  });
-
-  it("should return empty requiredPtcTools when no metadata field exists", () => {
-    const content = `---
-name: test-skill
-description: A test skill
----
-
-Content
-`;
-    const result = parseSkillMetadataFromContent(
-      content,
-      "/skills/test-skill/SKILL.md",
-      "test-skill",
-    );
-    expect(result).not.toBeNull();
-    expect(result?.requiredPtcTools).toEqual([]);
   });
 });
 

--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -1449,7 +1449,7 @@ Content
     );
     expect(result).not.toBeNull();
     expect(result).not.toHaveProperty("requiredPtcTools");
-    expect(result?.metadata["required-ptc-tools"]).toBe(
+    expect(result?.metadata?.["required-ptc-tools"]).toBe(
       "task read_file write_file glob",
     );
   });

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -156,16 +156,6 @@ export interface SkillMetadata {
    * directory.
    */
   module?: string;
-
-  /**
-   * PTC tool names that must be present in the QuickJS middleware's `ptc` configuration
-   * for this skill to function. The middleware validates these at skill-load time and
-   * returns a descriptive error if any are missing.
-   *
-   * Tool names should match the agent tool names as configured in `ptc` (e.g.
-   * `read_file`, not `readFile`).
-   */
-  requiredPtcTools?: string[];
 }
 
 /**
@@ -511,13 +501,6 @@ export function parseSkillMetadataFromContent(
     );
   }
 
-  const metadataObj =
-    (frontmatterData.metadata as Record<string, unknown>) ?? {};
-  const rawRequiredPtcTools = metadataObj["required-ptc-tools"];
-  const requiredPtcTools = rawRequiredPtcTools
-    ? String(rawRequiredPtcTools).split(/\s+/).filter(Boolean)
-    : [];
-
   return {
     name,
     description: descriptionStr,
@@ -527,7 +510,6 @@ export function parseSkillMetadataFromContent(
     compatibility: compatibilityStr,
     allowedTools,
     module: validateModulePath(frontmatterData.module),
-    requiredPtcTools,
   };
 }
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -320,7 +320,7 @@ describe("createCodeInterpreterMiddleware", () => {
             {
               name: "swarm",
               description: "test",
-              requiredPtcTools: ["task", "read_file", "glob"],
+              metadata: { "required-ptc-tools": "task read_file glob" },
             },
           ],
         }),
@@ -339,7 +339,7 @@ describe("createCodeInterpreterMiddleware", () => {
             {
               name: "my-skill",
               description: "test",
-              requiredPtcTools: ["write_file"],
+              metadata: { "required-ptc-tools": "write_file" },
             },
           ],
         }),
@@ -358,14 +358,14 @@ describe("createCodeInterpreterMiddleware", () => {
             {
               name: "swarm",
               description: "test",
-              requiredPtcTools: ["task", "read_file"],
+              metadata: { "required-ptc-tools": "task read_file" },
             },
           ],
         }),
       ).not.toThrow();
     });
 
-    it("does not throw when skill has no requiredPtcTools", () => {
+    it("does not throw when skill has no required-ptc-tools in metadata", () => {
       const middleware = createCodeInterpreterMiddleware({
         ptc: ["task"],
         skillsBackend: {} as any,
@@ -373,7 +373,7 @@ describe("createCodeInterpreterMiddleware", () => {
 
       expect(() =>
         (middleware as any).beforeAgent({
-          skillsMetadata: [{ name: "simple", description: "test" }],
+          skillsMetadata: [{ name: "simple", description: "test", metadata: {} }],
         }),
       ).not.toThrow();
     });
@@ -387,7 +387,7 @@ describe("createCodeInterpreterMiddleware", () => {
             {
               name: "swarm",
               description: "test",
-              requiredPtcTools: ["task"],
+              metadata: { "required-ptc-tools": "task" },
             },
           ],
         }),

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -373,7 +373,9 @@ describe("createCodeInterpreterMiddleware", () => {
 
       expect(() =>
         (middleware as any).beforeAgent({
-          skillsMetadata: [{ name: "simple", description: "test", metadata: {} }],
+          skillsMetadata: [
+            { name: "simple", description: "test", metadata: {} },
+          ],
         }),
       ).not.toThrow();
     });

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -170,9 +170,7 @@ async function prepareSkillsForEval(
       const requiredPtc = rawPtc
         ? String(rawPtc).split(/\s+/).filter(Boolean)
         : [];
-      const missingPtc = requiredPtc.filter(
-        (t) => !ptcToolNames.has(t),
-      );
+      const missingPtc = requiredPtc.filter((t) => !ptcToolNames.has(t));
 
       if (missingPtc.length > 0) {
         session.setSkillsContext(undefined);
@@ -311,9 +309,7 @@ export function createCodeInterpreterMiddleware(
         const requiredPtc = rawPtc
           ? String(rawPtc).split(/\s+/).filter(Boolean)
           : [];
-        const missing = requiredPtc.filter(
-          (t) => !ptcToolNames.has(t),
-        );
+        const missing = requiredPtc.filter((t) => !ptcToolNames.has(t));
         if (missing.length > 0) {
           throw new Error(
             `Skill '${skill.name}' requires PTC tools that are not configured: ${missing.join(", ")}. ` +

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -166,7 +166,11 @@ async function prepareSkillsForEval(
         continue;
       }
 
-      const missingPtc = (skill.requiredPtcTools ?? []).filter(
+      const rawPtc = skill.metadata?.["required-ptc-tools"] ?? "";
+      const requiredPtc = rawPtc
+        ? String(rawPtc).split(/\s+/).filter(Boolean)
+        : [];
+      const missingPtc = requiredPtc.filter(
         (t) => !ptcToolNames.has(t),
       );
 
@@ -303,7 +307,11 @@ export function createCodeInterpreterMiddleware(
           .skillsMetadata as SkillMetadata[]) ?? [];
 
       for (const skill of metadata) {
-        const missing = (skill.requiredPtcTools ?? []).filter(
+        const rawPtc = skill.metadata?.["required-ptc-tools"] ?? "";
+        const requiredPtc = rawPtc
+          ? String(rawPtc).split(/\s+/).filter(Boolean)
+          : [];
+        const missing = requiredPtc.filter(
           (t) => !ptcToolNames.has(t),
         );
         if (missing.length > 0) {


### PR DESCRIPTION
This PR aligns SkillMetadata with the agent skills spec by removing the top level required ptc tools field and keeps it contained within metadata