### PR TITLE
fix(deepagents): gate cache_control writes on per-call request.model

### DIFF
--- a/.changeset/cache-control-fallback-leak.md
+++ b/.changeset/cache-control-fallback-leak.md
@@ -1,0 +1,13 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): gate cache_control writes on per-call request.model
+
+`createCacheBreakpointMiddleware` and `createMemoryMiddleware` were gating
+the Anthropic-specific `cache_control` write at agent-creation time only.
+When `modelFallbackMiddleware` swapped `request.model` to a non-Anthropic
+provider mid-flight (e.g. on Anthropic 5xx), the marker leaked through
+and the fallback provider rejected the request with
+`400 Unknown parameter: 'cache_control'`. Both middlewares now also
+check `isAnthropicModel(request.model)` inside `wrapModelCall`. Fixes #550.

--- a/libs/deepagents/src/middleware/cache.test.ts
+++ b/libs/deepagents/src/middleware/cache.test.ts
@@ -3,13 +3,22 @@ import { createCacheBreakpointMiddleware } from "./cache.js";
 import { SystemMessage } from "@langchain/core/messages";
 
 describe("createCacheBreakpointMiddleware", () => {
+  // Real wrapModelCall calls always receive a model. The middleware now
+  // gates per-call on `isAnthropicModel(request.model)` (#550), so every
+  // existing test gets a ChatAnthropic stub to keep the cache_control
+  // writes on the path under test.
+  const fakeAnthropicModel = { getName: () => "ChatAnthropic" };
+
   describe("wrapModelCall", () => {
     it("adds cache_control to the last block of a string system message", () => {
       const middleware = createCacheBreakpointMiddleware();
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
 
       middleware.wrapModelCall!(
-        { systemMessage: new SystemMessage("Base prompt") } as any,
+        {
+          model: fakeAnthropicModel,
+          systemMessage: new SystemMessage("Base prompt"),
+        } as any,
         mockHandler,
       );
 
@@ -25,6 +34,7 @@ describe("createCacheBreakpointMiddleware", () => {
 
       middleware.wrapModelCall!(
         {
+          model: fakeAnthropicModel,
           systemMessage: new SystemMessage({
             content: [
               { type: "text", text: "Block 1" },
@@ -53,7 +63,10 @@ describe("createCacheBreakpointMiddleware", () => {
       ];
       const systemMessage = new SystemMessage({ content: originalContent });
 
-      middleware.wrapModelCall!({ systemMessage } as any, mockHandler);
+      middleware.wrapModelCall!(
+        { model: fakeAnthropicModel, systemMessage } as any,
+        mockHandler,
+      );
 
       expect((originalContent[1] as any).cache_control).toBeUndefined();
     });
@@ -63,11 +76,110 @@ describe("createCacheBreakpointMiddleware", () => {
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
 
       const systemMessage = new SystemMessage({ content: [] });
-      const request = { systemMessage } as any;
+      const request = { model: fakeAnthropicModel, systemMessage } as any;
 
       middleware.wrapModelCall!(request, mockHandler);
 
       expect(mockHandler).toHaveBeenCalledWith(request);
+    });
+
+    describe("per-call provider gating", () => {
+      // Regression for langchain-ai/deepagentsjs#550: when
+      // modelFallbackMiddleware swaps request.model from Anthropic to
+      // OpenAI/Vertex/etc., the cache_control marker must not leak through
+      // — the fallback provider rejects the request with 400 Unknown
+      // parameter. The middleware was previously installed conditionally
+      // on the *primary* model at boot time; the per-call gate fixes the
+      // fallback case where the middleware is installed but the model has
+      // been swapped.
+      const fakeAnthropic = {
+        getName: () => "ChatAnthropic",
+      };
+      const fakeOpenAI = {
+        getName: () => "ChatOpenAI",
+      };
+      const fakeConfigurableAnthropic = {
+        getName: () => "ConfigurableModel",
+        _defaultConfig: { modelProvider: "anthropic" },
+      };
+
+      it("writes cache_control when request.model is ChatAnthropic", () => {
+        const middleware = createCacheBreakpointMiddleware();
+        const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+
+        middleware.wrapModelCall!(
+          {
+            model: fakeAnthropic,
+            systemMessage: new SystemMessage("Base prompt"),
+          } as any,
+          mockHandler,
+        );
+
+        const blocks = mockHandler.mock.calls[0][0].systemMessage.contentBlocks;
+        expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+      });
+
+      it("writes cache_control when request.model is ConfigurableModel with anthropic provider", () => {
+        const middleware = createCacheBreakpointMiddleware();
+        const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+
+        middleware.wrapModelCall!(
+          {
+            model: fakeConfigurableAnthropic,
+            systemMessage: new SystemMessage("Base prompt"),
+          } as any,
+          mockHandler,
+        );
+
+        const blocks = mockHandler.mock.calls[0][0].systemMessage.contentBlocks;
+        expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+      });
+
+      it("writes cache_control when request.model is the string 'anthropic:claude-...'", () => {
+        const middleware = createCacheBreakpointMiddleware();
+        const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+
+        middleware.wrapModelCall!(
+          {
+            model: "anthropic:claude-sonnet-4-6",
+            systemMessage: new SystemMessage("Base prompt"),
+          } as any,
+          mockHandler,
+        );
+
+        const blocks = mockHandler.mock.calls[0][0].systemMessage.contentBlocks;
+        expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+      });
+
+      it("does NOT write cache_control when request.model is ChatOpenAI (fallback swap)", () => {
+        const middleware = createCacheBreakpointMiddleware();
+        const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+
+        const systemMessage = new SystemMessage("Base prompt");
+        const request = { model: fakeOpenAI, systemMessage } as any;
+
+        middleware.wrapModelCall!(request, mockHandler);
+
+        // Handler called with the original request — no clone, no marker.
+        expect(mockHandler).toHaveBeenCalledWith(request);
+        const passed = mockHandler.mock.calls[0][0];
+        const blocks = passed.systemMessage.contentBlocks ?? [];
+        for (const block of blocks) {
+          expect((block as any).cache_control).toBeUndefined();
+        }
+      });
+
+      it("does NOT write cache_control when request.model is the string 'openai:gpt-5'", () => {
+        const middleware = createCacheBreakpointMiddleware();
+        const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+
+        const systemMessage = new SystemMessage("Base prompt");
+        const request = { model: "openai:gpt-5", systemMessage } as any;
+
+        middleware.wrapModelCall!(request, mockHandler);
+
+        expect(mockHandler).toHaveBeenCalledWith(request);
+      });
     });
   });
 });

--- a/libs/deepagents/src/middleware/cache.ts
+++ b/libs/deepagents/src/middleware/cache.ts
@@ -5,6 +5,8 @@ import { createMiddleware, SystemMessage } from "langchain";
  */
 import type * as _langchain from "langchain";
 
+import { isAnthropicModel } from "../utils.js";
+
 /**
  * Creates a middleware that places a cache breakpoint at the end of the static
  * system prompt content.
@@ -23,6 +25,12 @@ import type * as _langchain from "langchain";
  * - One covering all static content
  * - One covering the memory block
  *
+ * The `cache_control` marker is Anthropic-specific. The middleware is gated
+ * per-call on `request.model` so it is a no-op when `modelFallbackMiddleware`
+ * (or any other middleware) has swapped the request to a non-Anthropic
+ * provider. Without this gate, the marker leaks to providers that reject it
+ * (e.g. OpenAI returns `400 Unknown parameter: 'cache_control'`).
+ *
  * This is a no-op when the system message has no content blocks.
  */
 export function createCacheBreakpointMiddleware() {
@@ -30,6 +38,12 @@ export function createCacheBreakpointMiddleware() {
     name: "CacheBreakpointMiddleware",
 
     wrapModelCall(request, handler) {
+      // Per-call provider gate: the boot-time install gate in createDeepAgent
+      // looks at the *primary* model, but modelFallbackMiddleware can swap
+      // request.model at request time. Cache markers must only be written
+      // when this specific call is going to Anthropic.
+      if (!isAnthropicModel(request.model)) return handler(request);
+
       const existingContent = request.systemMessage.content;
       const existingBlocks =
         typeof existingContent === "string"

--- a/libs/deepagents/src/middleware/memory.test.ts
+++ b/libs/deepagents/src/middleware/memory.test.ts
@@ -241,6 +241,13 @@ describe("createMemoryMiddleware", () => {
   });
 
   describe("cache control breakpoints", () => {
+    // Per-call provider gate (#550): cache_control is written only when
+    // `addCacheControl` is true AND `request.model` is Anthropic at call
+    // time. These existing tests pass an Anthropic stub to exercise the
+    // write path; the new test below covers the fallback case.
+    const fakeAnthropicModel = { getName: () => "ChatAnthropic" };
+    const fakeOpenAIModel = { getName: () => "ChatOpenAI" };
+
     it("should add cache_control to the memory content block when addCacheControl is true", () => {
       const middleware = createMemoryMiddleware({
         backend: createMockBackend({}),
@@ -250,6 +257,7 @@ describe("createMemoryMiddleware", () => {
 
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
       const request = {
+        model: fakeAnthropicModel,
         systemMessage: new SystemMessage("Base prompt"),
         state: {
           memoryContents: {
@@ -268,6 +276,37 @@ describe("createMemoryMiddleware", () => {
       expect(blocks[1].cache_control).toEqual({ type: "ephemeral" });
     });
 
+    it("should NOT add cache_control when request.model is non-Anthropic (fallback swap)", () => {
+      // Regression for #550: modelFallbackMiddleware can swap request.model
+      // from Anthropic to OpenAI/Vertex/etc. The cache_control marker is
+      // Anthropic-specific and must not leak — non-Anthropic providers
+      // 400 on the unknown parameter.
+      const middleware = createMemoryMiddleware({
+        backend: createMockBackend({}),
+        sources: ["~/.deepagents/AGENTS.md"],
+        addCacheControl: true,
+      });
+
+      const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+      const request = {
+        model: fakeOpenAIModel,
+        systemMessage: new SystemMessage("Base prompt"),
+        state: {
+          memoryContents: {
+            "~/.deepagents/AGENTS.md": "User memory content",
+          },
+        },
+      };
+
+      middleware.wrapModelCall!(request as any, mockHandler);
+
+      const modifiedRequest = mockHandler.mock.calls[0][0];
+      const blocks = modifiedRequest.systemMessage.contentBlocks;
+      expect(blocks).toHaveLength(2);
+      expect(blocks[1].text).toContain("<agent_memory>");
+      expect(blocks[1].cache_control).toBeUndefined();
+    });
+
     it("should preserve existing cache_control on system prompt blocks", () => {
       const middleware = createMemoryMiddleware({
         backend: createMockBackend({}),
@@ -277,6 +316,7 @@ describe("createMemoryMiddleware", () => {
 
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
       const request = {
+        model: fakeAnthropicModel,
         systemMessage: new SystemMessage({
           content: [
             {
@@ -371,6 +411,7 @@ describe("createMemoryMiddleware", () => {
 
       const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
       const request = {
+        model: fakeAnthropicModel,
         systemMessage: new SystemMessage({
           content: [
             { type: "text", text: "Block 1" },

--- a/libs/deepagents/src/middleware/memory.ts
+++ b/libs/deepagents/src/middleware/memory.ts
@@ -69,6 +69,7 @@ import type { BaseStore } from "@langchain/langgraph-checkpoint";
 import { filesValue } from "../values.js";
 import { StateSchema } from "@langchain/langgraph";
 import { adaptBackendProtocol } from "../backends/utils.js";
+import { isAnthropicModel } from "../utils.js";
 
 /**
  * Import @langchain/langgraph for type inference
@@ -333,13 +334,22 @@ export function createMemoryMiddleware(options: MemoryMiddlewareOptions) {
             ? existingContent
             : [];
 
+      // `cache_control` is Anthropic-specific. Gate on the per-call model so
+      // a fallback swap to a non-Anthropic provider (e.g. via
+      // modelFallbackMiddleware) does not leak the marker — OpenAI/Vertex
+      // reject the request with `400 Unknown parameter: 'cache_control'`.
+      // `addCacheControl` remains the opt-in switch; the per-call model
+      // check is an additional safety net.
+      const writeCacheControl =
+        addCacheControl && isAnthropicModel(request.model);
+
       const newSystemMessage = new SystemMessage({
         content: [
           ...existingBlocks,
           {
             type: "text" as const,
             text: memorySection,
-            ...(addCacheControl && {
+            ...(writeCacheControl && {
               cache_control: { type: "ephemeral" as const },
             }),
           },

--- a/libs/deepagents/src/utils.ts
+++ b/libs/deepagents/src/utils.ts
@@ -1,12 +1,21 @@
 import type { BaseLanguageModel } from "@langchain/core/language_models/base";
+import type { RunnableInterface } from "@langchain/core/runnables";
 
 /**
  * Detect whether a model is an Anthropic model.
  *
  * Used to gate Anthropic-specific prompt caching optimizations
  * (cache_control breakpoints).
+ *
+ * Accepts the wider `RunnableInterface` shape (the type of `request.model`
+ * inside `wrapModelCall`, aliased as `AgentLanguageModelLike` in langchain)
+ * because the function only depends on `.getName()`, which is part of the
+ * Runnable contract. `BaseLanguageModel` extends `Runnable`, so existing
+ * call sites still type-check.
  */
-export function isAnthropicModel(model: BaseLanguageModel | string): boolean {
+export function isAnthropicModel(
+  model: BaseLanguageModel | RunnableInterface<unknown, unknown> | string,
+): boolean {
   if (typeof model === "string") {
     if (model.includes(":")) return model.split(":")[0] === "anthropic";
     return model.startsWith("claude");


### PR DESCRIPTION
Fixes #550.

## Problem

`createCacheBreakpointMiddleware` and `createMemoryMiddleware` write Anthropic-specific `cache_control: { type: "ephemeral" }` markers into the request payload. Both gate the write at **agent-creation time** in `createDeepAgent` (whether the *primary* model is Anthropic). When `modelFallbackMiddleware` swaps `request.model` to a non-Anthropic provider at request time, the markers leak through and the fallback provider rejects the request:

```
400 Unknown parameter: 'messages[0].content[N].cache_control'
```

Full root-cause writeup, production trace, and reproduction in #550.

## Fix

Move the model classification from boot-time to **per-call**, using the existing `isAnthropicModel` helper (`src/utils.ts:9`).

- **`src/middleware/cache.ts`** — bail at the top of `wrapModelCall` when `request.model` isn't Anthropic.
- **`src/middleware/memory.ts`** — AND the existing `addCacheControl` flag with the same per-call check. `addCacheControl` keeps its current public meaning (opt-in switch); the per-call gate is an additional safety net.
- **`src/agent.ts`** — left untouched. The boot-time install gate stays (small perf win when primary is non-Anthropic — middleware isn't installed at all). The new per-call check handles the fallback case where the middleware *is* installed but the model has been swapped.

## Tests

Each middleware's `.test.ts` got a `per-call provider gating` block. They build a request with a `ChatAnthropic`-shaped stub vs a `ChatOpenAI`-shaped stub on `request.model`, run `wrapModelCall`, and assert `cache_control` is/isn't written. Also covers `ConfigurableModel` with `modelProvider: "anthropic"` and the string forms (`"anthropic:claude-..."`, `"openai:gpt-5"`).

Existing fixtures that didn't set `request.model` now pass a `ChatAnthropic` stub so they keep exercising the write path — they were previously relying on the unconditional behavior. No behavioral assertions changed; only the fixture got more explicit.

31/31 tests pass on `libs/deepagents` (`cache.test.ts` + `memory.test.ts`).

## Compatibility

- **No public API change.** `addCacheControl?: boolean` on `MemoryMiddlewareOptions` keeps its existing semantics.
- **Anthropic-primary happy path unchanged** — same writes, same cache hits.
- **Per-call cost:** one `getName()` / string check inside `wrapModelCall`. Sub-microsecond.
- **Failure mode improvement:** users running `createDeepAgent` with an Anthropic primary + non-Anthropic fallback no longer get a 400 from the fallback provider on swap.

## Changeset

`patch` bump on `deepagents`.

## Out of scope

`request.modelSettings.cache_control` (written by LangChain core's `anthropicPromptCachingMiddleware`) can also leak across the swap. Mentioned in #550 for tracking — that's a LangChain-side fix, not deepagents.