### PR TITLE
fix(quickjs): forward config for skills and PTC tools

### DIFF
--- a/.changeset/rare-buses-switch.md
+++ b/.changeset/rare-buses-switch.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+pass config when preparing task tool

--- a/.changeset/strict-ads-smell.md
+++ b/.changeset/strict-ads-smell.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+Fix browser/web usage of skills backend by passing runnable config into skill preparation.

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -620,7 +620,7 @@ function createTaskTool(options: {
       const subagent = subagentGraphs[subagent_type];
 
       // Get current state and filter it for subagent
-      const currentState = getCurrentTaskInput<Record<string, unknown>>();
+      const currentState = getCurrentTaskInput<Record<string, unknown>>(config);
       const subagentState = filterStateForSubagent(currentState);
       subagentState.messages = [new HumanMessage({ content: description })];
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -197,6 +197,51 @@ describe("createCodeInterpreterMiddleware", () => {
       expect(req.systemMessage.text).toContain("tools.agentTool");
       expect(req.systemMessage.text).toContain("tools.extraTool");
     });
+
+    it("should forward eval tool config to PTC tool invocations", async () => {
+      const capturedConfigs: unknown[] = [];
+      const needsConfigTool = tool(
+        async (_input: Record<string, unknown>, config) => {
+          capturedConfigs.push(config);
+          return "ok";
+        },
+        {
+          name: "needs_config",
+          description: "Needs runnable config",
+          schema: z.object({}),
+        },
+      );
+      const middleware = createCodeInterpreterMiddleware({
+        ptc: ["needs_config"],
+      });
+      const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+
+      await middleware.wrapModelCall!(
+        {
+          systemMessage: new SystemMessage("Base"),
+          state: {},
+          runtime: { configurable: { thread_id: "ptc-config-test" } },
+          tools: [needsConfigTool],
+        } as any,
+        mockHandler,
+      );
+
+      const evalConfig = {
+        configurable: {
+          thread_id: "ptc-config-test",
+          checkpoint_id: "checkpoint-1",
+        },
+      };
+      const jsTool = middleware.tools!.find(
+        (t: any) => t.name === "eval",
+      ) as any;
+
+      await expect(
+        jsTool.invoke({ code: "await tools.needsConfig({})" }, evalConfig),
+      ).resolves.toContain("ok");
+
+      expect(capturedConfigs).toEqual([evalConfig]);
+    });
   });
 
   describe("generatePtcPrompt", () => {

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -275,6 +275,7 @@ export function createCodeInterpreterMiddleware(
         }
       }
 
+      session.setToolConfig(config);
       const result = await session.eval(input.code, executionTimeoutMs);
       return formatReplResult(result);
     },

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -149,8 +149,11 @@ async function prepareSkillsForEval(
   skillsBackend: AnyBackendProtocol | BackendFactory,
   code: string,
   ptcTools: StructuredToolInterface[],
+  config: LangGraphRunnableConfig,
 ): Promise<string | undefined> {
-  const taskInput = getCurrentTaskInput<{ skillsMetadata?: SkillMetadata[] }>();
+  const taskInput = getCurrentTaskInput<{ skillsMetadata?: SkillMetadata[] }>(
+    config,
+  );
   const metadata: SkillMetadata[] = taskInput?.skillsMetadata ?? [];
 
   const referenced = scanSkillReferences(code);
@@ -188,7 +191,10 @@ async function prepareSkillsForEval(
     }
   }
 
-  const resolved = await resolveBackend(skillsBackend, { state: taskInput });
+  const resolved = await resolveBackend(skillsBackend, {
+    ...config,
+    state: taskInput,
+  });
   session.setSkillsContext({ metadata, backend: resolved });
   return undefined;
 }
@@ -262,6 +268,7 @@ export function createCodeInterpreterMiddleware(
           skillsBackend,
           input.code,
           ptcTools,
+          config,
         );
         if (setupError !== undefined) {
           return setupError;

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -26,6 +26,7 @@ import type {
   QuickJSAsyncWASMModule,
 } from "quickjs-emscripten-core";
 import type { StructuredToolInterface } from "@langchain/core/tools";
+import type { RunnableConfig } from "@langchain/core/runnables";
 
 import { loadSkill, scanSkillReferences, type LoadedSkill } from "./skills.js";
 import { PTCCallBudgetExceededError } from "./errors.js";
@@ -309,6 +310,7 @@ export class ReplSession {
   private skillsFailed: Map<string, Error> = new Map();
   private readonly maxPtcCalls: number | null;
   private ptcCallsRemaining: number | null = null;
+  private toolConfig: RunnableConfig | undefined;
 
   /**
    * Reset the shared WASM module. Forces the next session to instantiate
@@ -636,6 +638,14 @@ export class ReplSession {
   }
 
   /**
+   * Store the active LangGraph tool config for the current eval invocation.
+   * Programmatic tool calls inside QuickJS forward this config to bridged tools.
+   */
+  setToolConfig(config?: RunnableConfig): void {
+    this.toolConfig = config;
+  }
+
+  /**
    * Evaluate code in this session.
    *
    * Lazily starts the QuickJS runtime on the first call. Code is
@@ -730,6 +740,7 @@ export class ReplSession {
       };
     } finally {
       this.ptcCallsRemaining = null;
+      this.toolConfig = undefined;
     }
   }
 
@@ -813,7 +824,7 @@ export class ReplSession {
               this.consumePtcBudget(camelName);
               const rawInput =
                 typeof input === "object" && input !== null ? input : {};
-              const result = await t.invoke(rawInput);
+              const result = await t.invoke(rawInput, this.toolConfig);
               let text = extractToolText(result);
               if (t.name === "read_file") {
                 text = stripLineNumbers(text);


### PR DESCRIPTION
## Summary

Fixes #553.

`createCodeInterpreterMiddleware()` had two places where the LangGraph runnable config was available but not forwarded:

- the `skillsBackend` setup path
- Programmatic Tool Calling from inside the QuickJS REPL, e.g. `await tools.task(...)`

In the first case, `getCurrentTaskInput()` fell back to `AsyncLocalStorage`, which breaks in browser/web environments where `AsyncLocalStorage` is unavailable or stubbed.

In the second case, bridged tools were invoked without graph runtime config, which breaks tools that need current graph state, such as DeepAgents’ `task` tool.

## Changes

- Pass config from the code interpreter tool handler into `prepareSkillsForEval()`
- Use `getCurrentTaskInput(config)` in the quickjs skills backend path
- Store the active eval tool config on `ReplSession`
- Forward that config to PTC tool invocations via `t.invoke(rawInput, config)`
- Add coverage proving a PTC tool invoked through `tools.*` receives the eval config

## Why

This allows QuickJS skills and PTC tools to work in browser/web builds and preserves graph runtime context for tools called from inside the interpreter.