### PR TITLE
fix: skip unreadable dirs in glob/grep instead of crashing

### DIFF
--- a/.changeset/two-teeth-share.md
+++ b/.changeset/two-teeth-share.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+skip unreadable dirs in glob/grep instead of crashing

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -625,6 +625,9 @@ export class FilesystemBackend implements BackendProtocolV2 {
       absolute: true,
       onlyFiles: true,
       dot: true,
+      // Skip directories we cannot read (e.g. OS-protected paths) instead of
+      // throwing EPERM and aborting the whole search.
+      suppressErrors: true,
     });
 
     for (const fp of files) {
@@ -715,6 +718,9 @@ export class FilesystemBackend implements BackendProtocolV2 {
         absolute: true,
         onlyFiles: true,
         dot: true,
+        // Skip directories we cannot read (e.g. OS-protected paths) instead of
+        // throwing EPERM and aborting the whole search.
+        suppressErrors: true,
       });
 
       for (const matchedPath of matches) {


### PR DESCRIPTION
## Problem

`grep`/`glob` call `fast-glob` without `suppressErrors`, so one unreadable directory during traversal (e.g. macOS-protected `/Library/Trial`) throws `EPERM` and aborts the whole search. Via `deepagents-acp` this surfaces as `session/prompt -> Internal error`. Hits packaged apps without Full Disk Access; terminal runs (with access) work.

## Fix

`suppressErrors: true` on both `fast-glob` calls — skip unreadable dirs instead of throwing, matching the Python `FilesystemBackend`.

## Test

`vitest run src/backends/filesystem.test.ts` → 20/20 pass; `filesystem.ts` typechecks clean.