### PR TITLE
fix(acp): run filesystem backend in virtual mode

### DIFF
--- a/.changeset/acp-virtual-mode.md
+++ b/.changeset/acp-virtual-mode.md
@@ -1,0 +1,6 @@
+---
+"deepagents-acp": patch
+"deepagents": patch
+---
+
+fix(acp): run the filesystem backend in virtual mode so tool searches stay within the workspace instead of scanning (and crashing on) the host filesystem

--- a/libs/acp/src/acp-filesystem-backend.test.ts
+++ b/libs/acp/src/acp-filesystem-backend.test.ts
@@ -44,24 +44,34 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const result = await backend.read(path.join(tmpDir, "local.txt"));
+      const result = await backend.read("/local.txt");
 
       expect(mockConn.readTextFile).toHaveBeenCalledTimes(1);
       expect(result.content).toBe("acp file content");
     });
 
-    it("should resolve relative paths using cwd", async () => {
+    it("should resolve virtual paths under the workspace root", async () => {
       const backend = new ACPFilesystemBackend({
         conn: mockConn,
         rootDir: tmpDir,
       });
       backend.setSessionId("sess_123");
 
-      await backend.read("local.txt");
+      await backend.read("/local.txt");
 
       const callArgs = mockConn.readTextFile.mock.calls[0][0];
-      expect(callArgs.path).toContain(tmpDir);
-      expect(callArgs.path).toContain("local.txt");
+      expect(callArgs.path).toBe(path.join(tmpDir, "local.txt"));
+    });
+
+    it("should reject paths that escape the workspace root", async () => {
+      const backend = new ACPFilesystemBackend({
+        conn: mockConn,
+        rootDir: tmpDir,
+      });
+      backend.setSessionId("sess_123");
+
+      await expect(backend.read("/../outside.txt")).rejects.toThrow();
+      expect(mockConn.readTextFile).not.toHaveBeenCalled();
     });
 
     it("should fall back to local FS when no session is set", async () => {
@@ -70,7 +80,7 @@ describe("ACPFilesystemBackend", () => {
         rootDir: tmpDir,
       });
 
-      const result = await backend.read(path.join(tmpDir, "local.txt"));
+      const result = await backend.read("/local.txt");
 
       expect(mockConn.readTextFile).not.toHaveBeenCalled();
       expect(result.content).toContain("local file content");
@@ -84,7 +94,7 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const result = await backend.read(path.join(tmpDir, "local.txt"));
+      const result = await backend.read("/local.txt");
 
       expect(mockConn.readTextFile).toHaveBeenCalledTimes(1);
       expect(result.content).toContain("local file content");
@@ -100,7 +110,7 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const result = await backend.read(path.join(tmpDir, "local.txt"), 1, 2);
+      const result = await backend.read("/local.txt", 1, 2);
 
       expect(result.content).toBe("line1\nline2");
     });
@@ -112,7 +122,7 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_abc");
 
-      await backend.read(path.join(tmpDir, "local.txt"));
+      await backend.read("/local.txt");
 
       expect(mockConn.readTextFile.mock.calls[0][0].sessionId).toBe("sess_abc");
     });
@@ -126,27 +136,23 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const result = await backend.write(
-        path.join(tmpDir, "output.txt"),
-        "new content",
-      );
+      const result = await backend.write("/output.txt", "new content");
 
       expect(mockConn.writeTextFile).toHaveBeenCalledTimes(1);
       expect(result.filesUpdate).toBeNull();
     });
 
-    it("should pass correct params to writeTextFile", async () => {
+    it("should resolve the virtual path to a real path for writeTextFile", async () => {
       const backend = new ACPFilesystemBackend({
         conn: mockConn,
         rootDir: tmpDir,
       });
       backend.setSessionId("sess_123");
 
-      const targetPath = path.join(tmpDir, "output.txt");
-      await backend.write(targetPath, "data");
+      await backend.write("/output.txt", "data");
 
       const callArgs = mockConn.writeTextFile.mock.calls[0][0];
-      expect(callArgs.path).toBe(targetPath);
+      expect(callArgs.path).toBe(path.join(tmpDir, "output.txt"));
       expect(callArgs.content).toBe("data");
     });
 
@@ -156,11 +162,12 @@ describe("ACPFilesystemBackend", () => {
         rootDir: tmpDir,
       });
 
-      const targetPath = path.join(tmpDir, "fallback-write.txt");
-      await backend.write(targetPath, "written locally");
+      await backend.write("/fallback-write.txt", "written locally");
 
       expect(mockConn.writeTextFile).not.toHaveBeenCalled();
-      expect(fs.readFileSync(targetPath, "utf-8")).toBe("written locally");
+      expect(fs.readFileSync(path.join(tmpDir, "fallback-write.txt"), "utf-8")).toBe(
+        "written locally",
+      );
     });
 
     it("should fall back to local FS when ACP write fails", async () => {
@@ -171,12 +178,13 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const targetPath = path.join(tmpDir, "fallback-err.txt");
-      const result = await backend.write(targetPath, "fallback content");
+      const result = await backend.write("/fallback-err.txt", "fallback content");
 
       expect(mockConn.writeTextFile).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined();
-      expect(fs.readFileSync(targetPath, "utf-8")).toBe("fallback content");
+      expect(fs.readFileSync(path.join(tmpDir, "fallback-err.txt"), "utf-8")).toBe(
+        "fallback content",
+      );
     });
   });
 
@@ -186,14 +194,13 @@ describe("ACPFilesystemBackend", () => {
         conn: mockConn,
         rootDir: tmpDir,
       });
-      const filePath = path.join(tmpDir, "local.txt");
 
       backend.setSessionId("sess_1");
-      await backend.read(filePath);
+      await backend.read("/local.txt");
       expect(mockConn.readTextFile.mock.calls[0][0].sessionId).toBe("sess_1");
 
       backend.setSessionId("sess_2");
-      await backend.read(filePath);
+      await backend.read("/local.txt");
       expect(mockConn.readTextFile.mock.calls[1][0].sessionId).toBe("sess_2");
     });
   });
@@ -206,7 +213,7 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const lsResult = await backend.ls(tmpDir);
+      const lsResult = await backend.ls("/");
 
       expect(mockConn.readTextFile).not.toHaveBeenCalled();
       expect(mockConn.writeTextFile).not.toHaveBeenCalled();
@@ -222,7 +229,7 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      await backend.grep("local", tmpDir);
+      await backend.grep("local", "/");
 
       expect(mockConn.readTextFile).not.toHaveBeenCalled();
     });
@@ -234,7 +241,7 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const globResult = await backend.glob("*.txt", tmpDir);
+      const globResult = await backend.glob("*.txt", "/");
 
       expect(mockConn.readTextFile).not.toHaveBeenCalled();
       expect(globResult.error).toBeUndefined();

--- a/libs/acp/src/acp-filesystem-backend.test.ts
+++ b/libs/acp/src/acp-filesystem-backend.test.ts
@@ -165,9 +165,9 @@ describe("ACPFilesystemBackend", () => {
       await backend.write("/fallback-write.txt", "written locally");
 
       expect(mockConn.writeTextFile).not.toHaveBeenCalled();
-      expect(fs.readFileSync(path.join(tmpDir, "fallback-write.txt"), "utf-8")).toBe(
-        "written locally",
-      );
+      expect(
+        fs.readFileSync(path.join(tmpDir, "fallback-write.txt"), "utf-8"),
+      ).toBe("written locally");
     });
 
     it("should fall back to local FS when ACP write fails", async () => {
@@ -178,13 +178,16 @@ describe("ACPFilesystemBackend", () => {
       });
       backend.setSessionId("sess_123");
 
-      const result = await backend.write("/fallback-err.txt", "fallback content");
+      const result = await backend.write(
+        "/fallback-err.txt",
+        "fallback content",
+      );
 
       expect(mockConn.writeTextFile).toHaveBeenCalledTimes(1);
       expect(result).toBeDefined();
-      expect(fs.readFileSync(path.join(tmpDir, "fallback-err.txt"), "utf-8")).toBe(
-        "fallback content",
-      );
+      expect(
+        fs.readFileSync(path.join(tmpDir, "fallback-err.txt"), "utf-8"),
+      ).toBe("fallback content");
     });
   });
 

--- a/libs/acp/src/acp-filesystem-backend.ts
+++ b/libs/acp/src/acp-filesystem-backend.ts
@@ -12,7 +12,6 @@ import {
   type WriteResult,
   type ReadResult,
 } from "deepagents";
-import path from "node:path";
 
 /**
  * Backend that proxies read/write through ACP client while using local
@@ -23,7 +22,12 @@ export class ACPFilesystemBackend extends FilesystemBackend {
   private currentSessionId: string | null = null;
 
   constructor(options: { conn: AgentSideConnection; rootDir: string }) {
-    super({ rootDir: options.rootDir });
+    // virtualMode confines all path resolution to rootDir: tool paths are
+    // treated as virtual paths under the workspace and traversal (.., ~) is
+    // blocked, so searches can never escape to the host filesystem. This
+    // matches the Python deepagents-acp server, which constructs its backend
+    // as FilesystemBackend(root_dir=cwd, virtual_mode=True).
+    super({ rootDir: options.rootDir, virtualMode: true });
     this.conn = options.conn;
   }
 
@@ -31,9 +35,10 @@ export class ACPFilesystemBackend extends FilesystemBackend {
     this.currentSessionId = sessionId;
   }
 
+  // Map an incoming (virtual) tool path to the real absolute path the ACP
+  // client expects, reusing the backend's virtual-aware resolution.
   private resolveAbsPath(filePath: string): string {
-    if (path.isAbsolute(filePath)) return filePath;
-    return path.resolve(this.cwd, filePath);
+    return this.resolvePath(filePath);
   }
 
   /**

--- a/libs/acp/src/adapter.test.ts
+++ b/libs/acp/src/adapter.test.ts
@@ -502,13 +502,13 @@ describe("formatToolCallTitle", () => {
 });
 
 describe("extractToolCallLocations", () => {
-  it("should extract location for read_file with absolute path", () => {
+  it("should resolve a virtual absolute path under the workspace root", () => {
     const result = extractToolCallLocations(
       "read_file",
       { path: "/src/index.ts" },
       "/workspace",
     );
-    expect(result).toEqual([{ path: "/src/index.ts" }]);
+    expect(result).toEqual([{ path: "/workspace/src/index.ts" }]);
   });
 
   it("should resolve relative path using workspace root", () => {
@@ -526,7 +526,7 @@ describe("extractToolCallLocations", () => {
       { path: "/src/file.ts", line: 42 },
       "/workspace",
     );
-    expect(result).toEqual([{ path: "/src/file.ts", line: 42 }]);
+    expect(result).toEqual([{ path: "/workspace/src/file.ts", line: 42 }]);
   });
 
   it("should include startLine as line when present", () => {
@@ -535,7 +535,7 @@ describe("extractToolCallLocations", () => {
       { path: "/src/file.ts", startLine: 10 },
       "/workspace",
     );
-    expect(result).toEqual([{ path: "/src/file.ts", line: 10 }]);
+    expect(result).toEqual([{ path: "/workspace/src/file.ts", line: 10 }]);
   });
 
   it("should return undefined for tools without path arg", () => {
@@ -572,7 +572,7 @@ describe("extractToolCallLocations", () => {
         "/ws",
       );
       expect(result).toBeDefined();
-      expect(result![0].path).toBe("/test.txt");
+      expect(result![0].path).toBe("/ws/test.txt");
     }
   });
 

--- a/libs/acp/src/adapter.ts
+++ b/libs/acp/src/adapter.ts
@@ -7,6 +7,7 @@
 
 import { HumanMessage, AIMessage, BaseMessage } from "@langchain/core/messages";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
+import path from "node:path";
 
 import type { ToolCallInfo, PlanEntry } from "./types.js";
 
@@ -251,10 +252,10 @@ export function extractToolCallLocations(
   ];
   if (!toolsWithPaths.includes(toolName)) return undefined;
 
-  const relativePath = filePath.replace(/^\/+/, "");
-  const absPath = workspaceRoot
-    ? `${workspaceRoot.replace(/\/+$/, "")}/${relativePath}`
-    : `/${relativePath}`;
+  // Virtual paths are rooted at the workspace; join under workspaceRoot to
+  // produce the real path ACP clients expect. posix.join also normalizes a
+  // leading "/" on the virtual path, so no regex stripping is needed.
+  const absPath = path.posix.join(workspaceRoot ?? "/", filePath);
 
   const line = (args.line ?? args.startLine) as number | undefined;
   return [{ path: absPath, ...(line != null ? { line } : {}) }];

--- a/libs/acp/src/adapter.ts
+++ b/libs/acp/src/adapter.ts
@@ -227,7 +227,11 @@ export function formatToolCallTitle(
 }
 
 /**
- * Extract file locations from tool call arguments for ACP follow-along
+ * Extract file locations from tool call arguments for ACP follow-along.
+ *
+ * The backend runs in virtual mode, so tool paths are virtual paths rooted at
+ * the workspace (e.g. "/src/index.ts"). ACP clients expect real filesystem
+ * paths, so resolve them under workspaceRoot.
  */
 export function extractToolCallLocations(
   toolName: string,
@@ -247,9 +251,10 @@ export function extractToolCallLocations(
   ];
   if (!toolsWithPaths.includes(toolName)) return undefined;
 
-  const absPath = filePath.startsWith("/")
-    ? filePath
-    : `${workspaceRoot ?? ""}/${filePath}`;
+  const relativePath = filePath.replace(/^\/+/, "");
+  const absPath = workspaceRoot
+    ? `${workspaceRoot.replace(/\/+$/, "")}/${relativePath}`
+    : `/${relativePath}`;
 
   const line = (args.line ?? args.startLine) as number | undefined;
   return [{ path: absPath, ...(line != null ? { line } : {}) }];

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -75,7 +75,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
    * @returns Resolved absolute path string
    * @throws Error if path traversal detected or path outside root
    */
-  private resolvePath(key: string): string {
+  protected resolvePath(key: string): string {
     if (this.virtualMode) {
       const vpath = key.startsWith("/") ? key : "/" + key;
       if (vpath.includes("..") || vpath.startsWith("~")) {


### PR DESCRIPTION
## Problem

The ACP filesystem backend runs non-virtual, so a path-less `grep` (default `path = "/"`) resolves to the real filesystem root and scans the whole disk — wasteful, and crashes on unreadable dirs (e.g. macOS `/Library/Trial` without Full Disk Access) as `session/prompt -> Internal error`.

## Fix

`virtualMode: true` on the backend, matching Python (`FilesystemBackend(root_dir=cwd, virtual_mode=True)` in `deepagents_acp/server.py`). Paths become virtual, rooted at the workspace; `..`/`~` blocked.

- `FilesystemBackend.resolvePath` → `protected` so the ACP subclass reuses it for read/write proxying.
- `extractToolCallLocations` resolves virtual paths under `workspaceRoot` so clients still get real paths.

## Test

ACP unit suite (157) and deepagents filesystem (20) pass. `server.ts` typecheck errors are pre-existing (unchanged on `main`).

Complements #556 (scope fix here; #556 hardens unreadable dirs within a valid workspace).