### PR TITLE
fix(deepagents): isolate subagent projections per task invocation

### DIFF
--- a/.changeset/fix-subagent-stream-invocation-keys.md
+++ b/.changeset/fix-subagent-stream-invocation-keys.md
@@ -1,0 +1,9 @@
+---
+"deepagents": patch
+---
+
+fix(stream): isolate subagent projections per task invocation
+
+Key `createSubagentTransformer` channels by `task:${tool_call_id}` instead of
+`subagent_type` so parallel same-type subagents no longer share `messages` and
+`toolCalls` streams. Closes #560.

--- a/libs/deepagents/src/stream.test.ts
+++ b/libs/deepagents/src/stream.test.ts
@@ -322,6 +322,91 @@ describe("streamEvents", () => {
     }
   });
 
+  it("isolates toolCalls for parallel same-type subagent invocations", async () => {
+    const transformer = createSubagentTransformer([])();
+    const projection = transformer.init();
+    const iterator = projection.subagents[Symbol.asyncIterator]();
+
+    const nextA = iterator.next();
+    transformer.process(
+      makeToolEvent([], {
+        event: "tool-started",
+        tool_name: "task",
+        tool_call_id: "task-a",
+        input: {
+          description: "Task A",
+          subagent_type: "researcher",
+        },
+      }),
+    );
+    const subA = (await nextA).value;
+
+    const nextB = iterator.next();
+    transformer.process(
+      makeToolEvent([], {
+        event: "tool-started",
+        tool_name: "task",
+        tool_call_id: "task-b",
+        input: {
+          description: "Task B",
+          subagent_type: "researcher",
+        },
+      }),
+    );
+    const subB = (await nextB).value;
+
+    expect(subA.name).toBe("researcher");
+    expect(subB.name).toBe("researcher");
+    expect(subA.toolCalls).not.toBe(subB.toolCalls);
+
+    const pingAIter = subA.toolCalls[Symbol.asyncIterator]();
+    const pingBIter = subB.toolCalls[Symbol.asyncIterator]();
+
+    const nextPingA = pingAIter.next();
+    transformer.process(
+      makeToolEvent(["tools:task-a", "tools"], {
+        event: "tool-started",
+        tool_name: "ping",
+        tool_call_id: "ping-a",
+        input: { value: "from-A" },
+      }),
+    );
+    transformer.process(
+      makeToolEvent(["tools:task-a", "tools"], {
+        event: "tool-finished",
+        tool_name: "ping",
+        tool_call_id: "ping-a",
+        output: "pong:A",
+      }),
+    );
+    const pingA = (await nextPingA).value;
+    expect(pingA.name).toBe("ping");
+    expect(pingA.input).toEqual({ value: "from-A" });
+
+    const nextPingB = pingBIter.next();
+    transformer.process(
+      makeToolEvent(["tools:task-b", "tools"], {
+        event: "tool-started",
+        tool_name: "ping",
+        tool_call_id: "ping-b",
+        input: { value: "from-B" },
+      }),
+    );
+    transformer.process(
+      makeToolEvent(["tools:task-b", "tools"], {
+        event: "tool-finished",
+        tool_name: "ping",
+        tool_call_id: "ping-b",
+        output: "pong:B",
+      }),
+    );
+    const pingB = (await nextPingB).value;
+    expect(pingB.name).toBe("ping");
+    expect(pingB.input).toEqual({ value: "from-B" });
+
+    transformer.finalize?.();
+  });
+
   it("resolves subagent output from the subagent lifecycle before root task completion", async () => {
     const transformer = createSubagentTransformer([])();
     const projection = transformer.init();

--- a/libs/deepagents/src/stream.ts
+++ b/libs/deepagents/src/stream.ts
@@ -148,10 +148,17 @@ interface SubagentProjection {
 interface PendingSubagent {
   name: string;
   callId: string;
+  invocationKey: string;
   resolveTaskInput: (v: string) => void;
   resolveOutput: (v: unknown) => void;
   rejectOutput: (e: unknown) => void;
 }
+
+type SubagentStreamLogs = {
+  messagesLog: StreamChannel<ChatModelStream>;
+  toolCallsLog: StreamChannel<ToolCallStream<string, unknown, ToolMessage>>;
+  nestedSubagentsLog: StreamChannel<SubagentRunStream>;
+};
 
 /**
  * Native transformer that correlates `task` tool calls into
@@ -170,19 +177,12 @@ export function createSubagentTransformer(
     const pendingByNamespaceSegment = new Map<string, PendingSubagent>();
     const latestValuesByNamespaceSegment = new Map<string, unknown>();
 
-    const subagentsByName = new Map<
-      string,
-      {
-        messagesLog: StreamChannel<ChatModelStream>;
-        toolCallsLog: StreamChannel<
-          ToolCallStream<string, unknown, ToolMessage>
-        >;
-        nestedSubagentsLog: StreamChannel<SubagentRunStream>;
-      }
-    >();
+    const subagentsByKey = new Map<string, SubagentStreamLogs>();
 
-    /** Maps tools-node namespace segment to subagent name. */
-    const toolsNodeToName = new Map<string, string>();
+    /** Maps tools-node namespace segment to subagent invocation key. */
+    const toolsNodeToKey = new Map<string, string>();
+
+    let fallbackInvocationSeq = 0;
 
     const childToolCalls = new Map<
       string,
@@ -194,7 +194,7 @@ export function createSubagentTransformer(
       }
     >();
 
-    /** Active ChatModelStreamImpl per subagent (keyed by subagent name). */
+    /** Active ChatModelStreamImpl per subagent invocation. */
     const activeMessages = new Map<
       string,
       {
@@ -202,6 +202,12 @@ export function createSubagentTransformer(
         eventsLog: StreamChannel<ChatModelStreamEvent>;
       }
     >();
+
+    function subagentInvocationKey(toolCallId: string | undefined): string {
+      if (toolCallId) return `task:${toolCallId}`;
+      fallbackInvocationSeq += 1;
+      return `subagent:${fallbackInvocationSeq}`;
+    }
 
     function deletePendingSubagent(pending: PendingSubagent): void {
       pendingByCallId.delete(pending.callId);
@@ -217,8 +223,8 @@ export function createSubagentTransformer(
       return ns.length === path.length + 1 ? ns[path.length] : undefined;
     }
 
-    function getOrCreateSubagentLogs(name: string) {
-      let logs = subagentsByName.get(name);
+    function getOrCreateSubagentLogs(invocationKey: string) {
+      let logs = subagentsByKey.get(invocationKey);
       if (!logs) {
         logs = {
           messagesLog: StreamChannel.local<ChatModelStream>(),
@@ -226,7 +232,7 @@ export function createSubagentTransformer(
             StreamChannel.local<ToolCallStream<string, unknown, ToolMessage>>(),
           nestedSubagentsLog: StreamChannel.local<SubagentRunStream>(),
         };
-        subagentsByName.set(name, logs);
+        subagentsByKey.set(invocationKey, logs);
       }
       return logs;
     }
@@ -274,9 +280,12 @@ export function createSubagentTransformer(
               rejectOutput = rej;
             });
 
+            const invocationKey = subagentInvocationKey(toolCallId);
+
             const pending: PendingSubagent = {
               name: subagentName,
               callId: toolCallId,
+              invocationKey,
               resolveTaskInput,
               resolveOutput,
               rejectOutput,
@@ -289,16 +298,16 @@ export function createSubagentTransformer(
             resolveTaskInput(taskDescription);
 
             if (depth === 1) {
-              toolsNodeToName.set(ns[path.length], subagentName);
+              toolsNodeToKey.set(ns[path.length], invocationKey);
               pendingByNamespaceSegment.set(ns[path.length], pending);
             }
             if (toolCallId) {
               const taskSegment = `tools:${toolCallId}`;
-              toolsNodeToName.set(taskSegment, subagentName);
+              toolsNodeToKey.set(taskSegment, invocationKey);
               pendingByNamespaceSegment.set(taskSegment, pending);
             }
 
-            const logs = getOrCreateSubagentLogs(subagentName);
+            const logs = getOrCreateSubagentLogs(invocationKey);
 
             subagentsLog.push({
               name: subagentName,
@@ -353,12 +362,12 @@ export function createSubagentTransformer(
         // ── Child namespace events → route into per-subagent channels ──
         if (depth >= 2) {
           const parentSegment = ns[path.length];
-          const subagentName = toolsNodeToName.get(parentSegment);
-          const logs = subagentName
-            ? subagentsByName.get(subagentName)
+          const invocationKey = toolsNodeToKey.get(parentSegment);
+          const logs = invocationKey
+            ? subagentsByKey.get(invocationKey)
             : undefined;
 
-          if (logs && subagentName) {
+          if (logs && invocationKey) {
             // ── Route tools events ──
             if (event.method === "tools") {
               const data = event.params.data as ToolsEventData;
@@ -388,7 +397,8 @@ export function createSubagentTransformer(
                   resolveError = res;
                 });
 
-                childToolCalls.set(toolCallId, {
+                const childToolCallKey = `${invocationKey}:${toolCallId}`;
+                childToolCalls.set(childToolCallKey, {
                   resolveOutput,
                   rejectOutput,
                   resolveStatus,
@@ -410,25 +420,28 @@ export function createSubagentTransformer(
                 });
               }
 
-              const pending = toolCallId
-                ? childToolCalls.get(toolCallId)
+              const childToolCallKey = toolCallId
+                ? `${invocationKey}:${toolCallId}`
                 : undefined;
-              if (pending) {
+              const pendingChild = childToolCallKey
+                ? childToolCalls.get(childToolCallKey)
+                : undefined;
+              if (pendingChild && childToolCallKey) {
                 if (data.event === "tool-finished") {
-                  pending.resolveOutput(
+                  pendingChild.resolveOutput(
                     (data as Record<string, unknown>).output,
                   );
-                  pending.resolveStatus("finished");
-                  pending.resolveError(undefined);
-                  childToolCalls.delete(toolCallId);
+                  pendingChild.resolveStatus("finished");
+                  pendingChild.resolveError(undefined);
+                  childToolCalls.delete(childToolCallKey);
                 } else if (data.event === "tool-error") {
                   const message =
                     ((data as Record<string, unknown>).message as string) ??
                     "unknown error";
-                  pending.rejectOutput(new Error(message));
-                  pending.resolveStatus("error");
-                  pending.resolveError(message);
-                  childToolCalls.delete(toolCallId);
+                  pendingChild.rejectOutput(new Error(message));
+                  pendingChild.resolveStatus("error");
+                  pendingChild.resolveError(message);
+                  childToolCalls.delete(childToolCallKey);
                 }
               }
             }
@@ -441,17 +454,17 @@ export function createSubagentTransformer(
                 const eventsLog = StreamChannel.local<ChatModelStreamEvent>();
                 const stream = new ChatModelStreamImpl(eventsLog);
                 eventsLog.push(data as ChatModelStreamEvent);
-                activeMessages.set(subagentName, { stream, eventsLog });
+                activeMessages.set(invocationKey, { stream, eventsLog });
                 logs.messagesLog.push(stream as unknown as ChatModelStream);
               } else if (data.event === "message-finish") {
-                const active = activeMessages.get(subagentName);
+                const active = activeMessages.get(invocationKey);
                 if (active) {
                   active.eventsLog.push(data as ChatModelStreamEvent);
                   active.eventsLog.close();
-                  activeMessages.delete(subagentName);
+                  activeMessages.delete(invocationKey);
                 }
               } else {
-                const active = activeMessages.get(subagentName);
+                const active = activeMessages.get(invocationKey);
                 active?.eventsLog.push(data as ChatModelStreamEvent);
               }
             }
@@ -479,7 +492,7 @@ export function createSubagentTransformer(
         }
         activeMessages.clear();
         subagentsLog.close();
-        for (const logs of subagentsByName.values()) {
+        for (const logs of subagentsByKey.values()) {
           logs.toolCallsLog.close();
           logs.messagesLog.close();
           logs.nestedSubagentsLog.close();
@@ -505,7 +518,7 @@ export function createSubagentTransformer(
         }
         activeMessages.clear();
         subagentsLog.fail(err);
-        for (const logs of subagentsByName.values()) {
+        for (const logs of subagentsByKey.values()) {
           logs.toolCallsLog.fail(err);
           logs.messagesLog.fail(err);
           logs.nestedSubagentsLog.fail(err);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,40 +520,6 @@ importers:
         specifier: ^8.0.3
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  examples/e2e-swarm:
-    dependencies:
-      '@langchain/anthropic':
-        specifier: ^1.3.26
-        version: 1.3.28(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))
-      '@langchain/core':
-        specifier: ^1.1.42
-        version: 1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0)
-      '@langchain/langgraph':
-        specifier: ^1.2.9
-        version: 1.3.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.1)
-      '@langchain/langgraph-sdk':
-        specifier: ^1.9.1
-        version: 1.9.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      '@langchain/quickjs':
-        specifier: file:./langchain-quickjs-0.4.0.tgz
-        version: file:examples/e2e-swarm/langchain-quickjs-0.4.0.tgz(deepagents@file:examples/e2e-swarm/deepagents-1.10.1.tgz(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))
-      deepagents:
-        specifier: file:./deepagents-1.10.1.tgz
-        version: file:examples/e2e-swarm/deepagents-1.10.1.tgz(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      dotenv:
-        specifier: ^17.2.4
-        version: 17.4.2
-      langchain:
-        specifier: ^1.3.1
-        version: 1.4.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-    devDependencies:
-      tsx:
-        specifier: ^4.19.0
-        version: 4.21.0
-      typescript:
-        specifier: ^5.5.0
-        version: 5.9.3
-
   internal/eval-harness:
     dependencies:
       '@langchain/anthropic':
@@ -1693,12 +1659,6 @@ packages:
 
   '@langchain/protocol@0.0.15':
     resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
-
-  '@langchain/quickjs@file:examples/e2e-swarm/langchain-quickjs-0.4.0.tgz':
-    resolution: {integrity: sha512-SR2kKg1sRY/XPGi8EMaQfMquXMSoJ2RHiKOxhEtICgDKeb2NIAOvVQhM8/4/w6dwbWvrCh4Ei7knSpk+ES/mQg==, tarball: file:examples/e2e-swarm/langchain-quickjs-0.4.0.tgz}
-    version: 0.4.0
-    peerDependencies:
-      deepagents: '>=1.9.0-alpha.0'
 
   '@langchain/tavily@1.2.0':
     resolution: {integrity: sha512-aPLPgtw8+b/Rnr3H+X8H8z98T/Y7JuCE4B5eqRDHoEWgZvMDUFF7divqwQqCTMq2deQttlVrm5bN5JbKaAR7/w==}
@@ -2939,12 +2899,6 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  deepagents@file:examples/e2e-swarm/deepagents-1.10.1.tgz:
-    resolution: {integrity: sha512-ctAgLBHOPlgY0t6Uio2obsqGrde/80pDSfG7F3DF6BFBDCD0qyk9WUwcca8EcWgCBnarVL46gkAkYxMJ3qqkmQ==, tarball: file:examples/e2e-swarm/deepagents-1.10.1.tgz}
-    version: 1.10.1
-    peerDependencies:
-      langsmith: '>=0.6.0 <1.0.0'
-
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -4091,11 +4045,6 @@ packages:
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
     hasBin: true
 
   typescript@6.0.3:
@@ -5521,21 +5470,6 @@ snapshots:
 
   '@langchain/protocol@0.0.15': {}
 
-  '@langchain/quickjs@file:examples/e2e-swarm/langchain-quickjs-0.4.0.tgz(deepagents@file:examples/e2e-swarm/deepagents-1.10.1.tgz(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))':
-    dependencies:
-      '@jitl/quickjs-ng-wasmfile-release-asyncify': 0.32.0
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      acorn: 8.16.0
-      dedent: 1.7.2
-      deepagents: file:examples/e2e-swarm/deepagents-1.10.1.tgz(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      estree-walker: 3.0.3
-      json-schema-to-typescript: 15.0.4
-      magic-string: 0.30.21
-      quickjs-emscripten: 0.32.0
-      quickjs-emscripten-core: 0.32.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-
   '@langchain/tavily@1.2.0(@langchain/core@1.1.42(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))':
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0)
@@ -6773,29 +6707,6 @@ snapshots:
 
   dedent@1.7.2: {}
 
-  deepagents@file:examples/e2e-swarm/deepagents-1.10.1.tgz(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
-    dependencies:
-      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0)
-      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.1)
-      '@langchain/langgraph-sdk': 1.9.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      fast-glob: 3.3.3
-      langchain: 1.4.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.35.0(ws@8.20.0)(zod@4.4.1))(ws@8.20.0)
-      micromatch: 4.0.8
-      yaml: 2.8.3
-      zod: 4.4.1
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-      - zod-to-json-schema
-
   defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
@@ -7908,8 +7819,6 @@ snapshots:
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
## Summary
- Fix `createSubagentTransformer` so each `task` invocation gets its own `messages` / `toolCalls` / nested `subagents` channels, keyed by `task:${tool_call_id}` instead of `subagent_type`.
- Route child-namespace events via `toolsNodeToKey` and scope pending child tool state with `${invocationKey}:${toolCallId}` to avoid collisions across sibling subagents.
- Add a unit regression test for two parallel `researcher` invocations with isolated ping tool-call routing.

fixes #560