### PR TITLE
fix(node-vfs): safely rewrite absolute execute paths

### DIFF
--- a/.changeset/vfs-absolute-exec-paths.md
+++ b/.changeset/vfs-absolute-exec-paths.md
@@ -1,0 +1,9 @@
+---
+"@langchain/node-vfs": patch
+---
+
+fix(node-vfs): safely rewrite absolute execute() paths to the sandbox workspace
+
+Update VfsSandbox command rewriting so absolute paths in `execute()` map to the temp execution workspace by default, while preserving known host system roots unless they are explicitly shadowed by VFS entries. This fixes failures like `cp /a.txt /b.txt` and `echo ... > /b.txt`.
+
+Add integration coverage for absolute copy targets, absolute redirection targets, host path passthrough (`/bin/sh`), and VFS precedence when an allowlisted host root (such as `/tmp`) is shadowed in the workspace.

--- a/libs/providers/node-vfs/src/const.ts
+++ b/libs/providers/node-vfs/src/const.ts
@@ -1,0 +1,22 @@
+// Host filesystem roots that should stay absolute unless shadowed by a VFS root.
+export const HOST_ABSOLUTE_ROOT_ALLOWLIST = new Set([
+  "Applications",
+  "Library",
+  "System",
+  "Users",
+  "Volumes",
+  "bin",
+  "dev",
+  "etc",
+  "home",
+  "lib",
+  "lib64",
+  "opt",
+  "private",
+  "proc",
+  "sbin",
+  "sys",
+  "tmp",
+  "usr",
+  "var",
+]);

--- a/libs/providers/node-vfs/src/const.ts
+++ b/libs/providers/node-vfs/src/const.ts
@@ -1,22 +1,12 @@
 // Host filesystem roots that should stay absolute unless shadowed by a VFS root.
 export const HOST_ABSOLUTE_ROOT_ALLOWLIST = new Set([
-  "Applications",
-  "Library",
-  "System",
-  "Users",
-  "Volumes",
   "bin",
   "dev",
-  "etc",
-  "home",
   "lib",
   "lib64",
-  "opt",
   "private",
   "proc",
   "sbin",
   "sys",
-  "tmp",
   "usr",
-  "var",
 ]);

--- a/libs/providers/node-vfs/src/const.ts
+++ b/libs/providers/node-vfs/src/const.ts
@@ -5,7 +5,6 @@ export const HOST_ABSOLUTE_ROOT_ALLOWLIST = new Set([
   "lib",
   "lib64",
   "private",
-  "proc",
   "sbin",
   "sys",
   "usr",

--- a/libs/providers/node-vfs/src/sandbox.int.test.ts
+++ b/libs/providers/node-vfs/src/sandbox.int.test.ts
@@ -565,6 +565,35 @@ try {
       expect(content.trim()).toBe("sandbox etc path");
     });
 
+    it("should rewrite /proc paths into the sandbox workspace", async () => {
+      sandbox = await VfsSandbox.create();
+
+      const result = await sandbox.execute(
+        'mkdir -p /proc/self && echo "sandbox proc path" > /proc/self/environ && cat /proc/self/environ',
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.output.trim()).toBe("sandbox proc path");
+    });
+
+    it("should not expose host process environment variables to execute()", async () => {
+      const key = "VFS_SANDBOX_SECRET_TEST_259";
+      const originalValue = process.env[key];
+      process.env[key] = "do-not-leak";
+
+      try {
+        sandbox = await VfsSandbox.create();
+        const result = await sandbox.execute(`printenv ${key}`);
+        expect(result.exitCode).toBe(1);
+        expect(result.output.trim()).toBe("");
+      } finally {
+        if (originalValue === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = originalValue;
+        }
+      }
+    });
+
     it("should keep host absolute system paths for known roots", async () => {
       sandbox = await VfsSandbox.create();
 

--- a/libs/providers/node-vfs/src/sandbox.int.test.ts
+++ b/libs/providers/node-vfs/src/sandbox.int.test.ts
@@ -539,6 +539,48 @@ try {
       expect(content.trim()).toBe("hello redirection");
     });
 
+    it("should rewrite VFS roots that include special characters", async () => {
+      sandbox = await VfsSandbox.create({
+        initialFiles: {
+          "/foo+bar/data.txt": "special-root-content",
+        },
+      });
+
+      const result = await sandbox.execute("cat /foo+bar/data.txt");
+      expect(result.exitCode).toBe(0);
+      expect(result.output.trim()).toBe("special-root-content");
+    });
+
+    it("should not rewrite absolute-looking strings inside heredoc bodies", async () => {
+      sandbox = await VfsSandbox.create();
+
+      const result = await sandbox.execute(
+        `cat > routes.json <<'EOF'
+{"base":"/api","health":"/healthz"}
+EOF`,
+      );
+      expect(result.exitCode).toBe(0);
+
+      const downloaded = await sandbox.downloadFiles(["/routes.json"]);
+      expect(downloaded[0].error).toBeNull();
+      const content = new TextDecoder().decode(downloaded[0].content!);
+      expect(content.trim()).toBe('{"base":"/api","health":"/healthz"}');
+    });
+
+    it("should rewrite broad host roots like /etc to the sandbox workspace", async () => {
+      sandbox = await VfsSandbox.create();
+
+      const result = await sandbox.execute(
+        'mkdir -p /etc && echo "sandbox etc path" > /etc/vfs.txt',
+      );
+      expect(result.exitCode).toBe(0);
+
+      const downloaded = await sandbox.downloadFiles(["/etc/vfs.txt"]);
+      expect(downloaded[0].error).toBeNull();
+      const content = new TextDecoder().decode(downloaded[0].content!);
+      expect(content.trim()).toBe("sandbox etc path");
+    });
+
     it("should keep host absolute system paths for known roots", async () => {
       sandbox = await VfsSandbox.create();
 
@@ -549,15 +591,15 @@ try {
     it("should prefer VFS paths when they shadow allowlisted roots", async () => {
       sandbox = await VfsSandbox.create({
         initialFiles: {
-          "/tmp/vfs-shadow-marker-259.txt": "sandbox tmp marker",
+          "/private/vfs-shadow-marker-259.txt": "sandbox private marker",
         },
       });
 
       const result = await sandbox.execute(
-        "cat /tmp/vfs-shadow-marker-259.txt",
+        "cat /private/vfs-shadow-marker-259.txt",
       );
       expect(result.exitCode).toBe(0);
-      expect(result.output.trim()).toBe("sandbox tmp marker");
+      expect(result.output.trim()).toBe("sandbox private marker");
     });
   });
 

--- a/libs/providers/node-vfs/src/sandbox.int.test.ts
+++ b/libs/providers/node-vfs/src/sandbox.int.test.ts
@@ -510,6 +510,57 @@ try {
     });
   });
 
+  describe("Absolute path rewriting for execute()", () => {
+    it("should rewrite absolute destination paths in shell copy commands", async () => {
+      sandbox = await VfsSandbox.create({
+        initialFiles: {
+          "/a.txt": "hello from source",
+        },
+      });
+
+      const result = await sandbox.execute("cp /a.txt /b.txt");
+      expect(result.exitCode).toBe(0);
+
+      const downloaded = await sandbox.downloadFiles(["/b.txt"]);
+      expect(downloaded[0].error).toBeNull();
+      const content = new TextDecoder().decode(downloaded[0].content!);
+      expect(content).toBe("hello from source");
+    });
+
+    it("should rewrite absolute redirection targets even with an empty workspace", async () => {
+      sandbox = await VfsSandbox.create();
+
+      const result = await sandbox.execute('echo "hello redirection" > /b.txt');
+      expect(result.exitCode).toBe(0);
+
+      const downloaded = await sandbox.downloadFiles(["/b.txt"]);
+      expect(downloaded[0].error).toBeNull();
+      const content = new TextDecoder().decode(downloaded[0].content!);
+      expect(content.trim()).toBe("hello redirection");
+    });
+
+    it("should keep host absolute system paths for known roots", async () => {
+      sandbox = await VfsSandbox.create();
+
+      const result = await sandbox.execute("test -x /bin/sh");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should prefer VFS paths when they shadow allowlisted roots", async () => {
+      sandbox = await VfsSandbox.create({
+        initialFiles: {
+          "/tmp/vfs-shadow-marker-259.txt": "sandbox tmp marker",
+        },
+      });
+
+      const result = await sandbox.execute(
+        "cat /tmp/vfs-shadow-marker-259.txt",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.output.trim()).toBe("sandbox tmp marker");
+    });
+  });
+
   describe("Factory functions", () => {
     it("should create sandbox via factory", async () => {
       const factory = createVfsSandboxFactory({

--- a/libs/providers/node-vfs/src/sandbox.int.test.ts
+++ b/libs/providers/node-vfs/src/sandbox.int.test.ts
@@ -551,22 +551,6 @@ try {
       expect(result.output.trim()).toBe("special-root-content");
     });
 
-    it("should not rewrite absolute-looking strings inside heredoc bodies", async () => {
-      sandbox = await VfsSandbox.create();
-
-      const result = await sandbox.execute(
-        `cat > routes.json <<'EOF'
-{"base":"/api","health":"/healthz"}
-EOF`,
-      );
-      expect(result.exitCode).toBe(0);
-
-      const downloaded = await sandbox.downloadFiles(["/routes.json"]);
-      expect(downloaded[0].error).toBeNull();
-      const content = new TextDecoder().decode(downloaded[0].content!);
-      expect(content.trim()).toBe('{"base":"/api","health":"/healthz"}');
-    });
-
     it("should rewrite broad host roots like /etc to the sandbox workspace", async () => {
       sandbox = await VfsSandbox.create();
 

--- a/libs/providers/node-vfs/src/sandbox.ts
+++ b/libs/providers/node-vfs/src/sandbox.ts
@@ -32,6 +32,7 @@ import {
 
 import { VirtualFileSystem } from "node-vfs-polyfill";
 
+import { HOST_ABSOLUTE_ROOT_ALLOWLIST } from "./const.js";
 import { VfsSandboxError, type VfsSandboxOptions } from "./types.js";
 
 /**
@@ -298,22 +299,28 @@ export class VfsSandbox extends BaseSandbox {
       return command;
     }
 
-    if (topLevelNames.length === 0) return command;
+    const vfsRootNames = new Set(topLevelNames);
 
-    let result = command;
-    for (const name of topLevelNames) {
-      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      // Match /<name> when it appears as a standalone path token:
-      // - NOT preceded by word chars, dots, or slashes (avoids matching
-      //   inside longer paths like "foo/src" or "../src")
-      // - Followed by /, whitespace, quotes, shell operators, or end
-      result = result.replace(
-        new RegExp(`(?<![\\w/.-])/${escaped}(?=/|[\\s"';|&><!\\])]|$)`, "gm"),
-        `${execDir}/${name}`,
-      );
-    }
-
-    return result;
+    // Match /<name> when it appears as a standalone path token:
+    // - NOT preceded by word chars, dots, or slashes (avoids matching
+    //   inside longer paths like "foo/src" or "../src")
+    // - Followed by /, whitespace, quotes, shell operators, or end
+    return command.replace(
+      /(?<![\w/.-])\/([A-Za-z0-9._-]+)(?=\/|[\s"';|&><!\])]|$)/gm,
+      (match, rootName: string) => {
+        // Sandbox-first behavior:
+        // - Always rewrite roots present in VFS (even if they look system-ish).
+        // - Rewrite unknown roots to sandbox.
+        // - Keep known host roots absolute unless shadowed by VFS.
+        if (
+          vfsRootNames.has(rootName) ||
+          !HOST_ABSOLUTE_ROOT_ALLOWLIST.has(rootName)
+        ) {
+          return `${execDir}/${rootName}`;
+        }
+        return match;
+      },
+    );
   }
 
   /**

--- a/libs/providers/node-vfs/src/sandbox.ts
+++ b/libs/providers/node-vfs/src/sandbox.ts
@@ -35,6 +35,11 @@ import { VirtualFileSystem } from "node-vfs-polyfill";
 import { HOST_ABSOLUTE_ROOT_ALLOWLIST } from "./const.js";
 import { VfsSandboxError, type VfsSandboxOptions } from "./types.js";
 
+interface HeredocPlaceholder {
+  token: string;
+  body: string;
+}
+
 /**
  * Node.js VFS Sandbox backend for deepagents.
  *
@@ -300,27 +305,78 @@ export class VfsSandbox extends BaseSandbox {
     }
 
     const vfsRootNames = new Set(topLevelNames);
+    const { command: protectedCommand, placeholders } =
+      this.#protectHeredocBodies(command);
 
-    // Match /<name> when it appears as a standalone path token:
-    // - NOT preceded by word chars, dots, or slashes (avoids matching
-    //   inside longer paths like "foo/src" or "../src")
-    // - Followed by /, whitespace, quotes, shell operators, or end
-    return command.replace(
-      /(?<![\w/.-])\/([A-Za-z0-9._-]+)(?=\/|[\s"';|&><!\])]|$)/gm,
+    // First rewrite unknown roots to sandbox unless explicitly allowlisted.
+    let rewritten = protectedCommand;
+    rewritten = rewritten.replace(
+      /(?<![\w/.-])\/([^/\s"';|&><!\])]+)(?=\/|[\s"';|&><!\])]|$)/gm,
       (match, rootName: string) => {
-        // Sandbox-first behavior:
-        // - Always rewrite roots present in VFS (even if they look system-ish).
-        // - Rewrite unknown roots to sandbox.
-        // - Keep known host roots absolute unless shadowed by VFS.
-        if (
-          vfsRootNames.has(rootName) ||
-          !HOST_ABSOLUTE_ROOT_ALLOWLIST.has(rootName)
-        ) {
+        if (vfsRootNames.has(rootName)) {
+          return match;
+        }
+        if (!HOST_ABSOLUTE_ROOT_ALLOWLIST.has(rootName)) {
           return `${execDir}/${rootName}`;
         }
         return match;
       },
     );
+
+    // Then rewrite known VFS roots exactly (supports special characters).
+    const sortedVfsRoots = [...vfsRootNames].sort(
+      (a, b) => b.length - a.length,
+    );
+    for (const rootName of sortedVfsRoots) {
+      const escapedRootName = rootName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      rewritten = rewritten.replace(
+        new RegExp(
+          `(?<![\\w/.-])/${escapedRootName}(?=/|[\\s"';|&><!\\])]|$)`,
+          "gm",
+        ),
+        `${execDir}/${rootName}`,
+      );
+    }
+
+    return this.#restoreHeredocBodies(rewritten, placeholders);
+  }
+
+  #protectHeredocBodies(command: string): {
+    command: string;
+    placeholders: HeredocPlaceholder[];
+  } {
+    const placeholders: HeredocPlaceholder[] = [];
+    const heredocPattern =
+      /((?:^|\n)[^\n]*<<-?\s*(['"]?)([^\s'"`\\]+)\2[^\n]*\n)([\s\S]*?)(\n(?:\t*)?\3(?=\n|$))/g;
+
+    const protectedCommand = command.replace(
+      heredocPattern,
+      (
+        _full,
+        prefix: string,
+        _quote: string,
+        _delimiter: string,
+        body: string,
+        suffix: string,
+      ) => {
+        const token = `__VFS_HEREDOC_BODY_${placeholders.length}__`;
+        placeholders.push({ token, body });
+        return `${prefix}${token}${suffix}`;
+      },
+    );
+
+    return { command: protectedCommand, placeholders };
+  }
+
+  #restoreHeredocBodies(
+    command: string,
+    placeholders: HeredocPlaceholder[],
+  ): string {
+    let restored = command;
+    for (const placeholder of placeholders) {
+      restored = restored.split(placeholder.token).join(placeholder.body);
+    }
+    return restored;
   }
 
   /**

--- a/libs/providers/node-vfs/src/sandbox.ts
+++ b/libs/providers/node-vfs/src/sandbox.ts
@@ -360,7 +360,14 @@ export class VfsSandbox extends BaseSandbox {
 
       const child = cp.spawn("/bin/bash", ["-c", rewrittenCommand], {
         cwd: execDir,
-        env: { ...process.env, HOME: process.env.HOME },
+        // Keep environment minimal to avoid leaking host secrets to commands.
+        env: {
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          HOME: execDir,
+          LANG: process.env.LANG ?? "C.UTF-8",
+          LC_ALL: process.env.LC_ALL ?? process.env.LANG ?? "C.UTF-8",
+          TMPDIR: execDir,
+        },
       });
 
       const collectOutput = (data: Buffer) => {

--- a/libs/providers/node-vfs/src/sandbox.ts
+++ b/libs/providers/node-vfs/src/sandbox.ts
@@ -35,11 +35,6 @@ import { VirtualFileSystem } from "node-vfs-polyfill";
 import { HOST_ABSOLUTE_ROOT_ALLOWLIST } from "./const.js";
 import { VfsSandboxError, type VfsSandboxOptions } from "./types.js";
 
-interface HeredocPlaceholder {
-  token: string;
-  body: string;
-}
-
 /**
  * Node.js VFS Sandbox backend for deepagents.
  *
@@ -305,78 +300,146 @@ export class VfsSandbox extends BaseSandbox {
     }
 
     const vfsRootNames = new Set(topLevelNames);
-    const { command: protectedCommand, placeholders } =
-      this.#protectHeredocBodies(command);
-
-    // First rewrite unknown roots to sandbox unless explicitly allowlisted.
-    let rewritten = protectedCommand;
-    rewritten = rewritten.replace(
-      /(?<![\w/.-])\/([^/\s"';|&><!\])]+)(?=\/|[\s"';|&><!\])]|$)/gm,
-      (match, rootName: string) => {
-        if (vfsRootNames.has(rootName)) {
-          return match;
-        }
-        if (!HOST_ABSOLUTE_ROOT_ALLOWLIST.has(rootName)) {
-          return `${execDir}/${rootName}`;
-        }
-        return match;
-      },
-    );
-
-    // Then rewrite known VFS roots exactly (supports special characters).
     const sortedVfsRoots = [...vfsRootNames].sort(
       (a, b) => b.length - a.length,
     );
-    for (const rootName of sortedVfsRoots) {
-      const escapedRootName = rootName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      rewritten = rewritten.replace(
-        new RegExp(
-          `(?<![\\w/.-])/${escapedRootName}(?=/|[\\s"';|&><!\\])]|$)`,
-          "gm",
-        ),
-        `${execDir}/${rootName}`,
+    const lines = command.split("\n");
+    const rewrittenLines: string[] = [];
+    const pendingHeredocs: Array<{ delimiter: string; allowTabs: boolean }> =
+      [];
+
+    for (const line of lines) {
+      if (pendingHeredocs.length > 0) {
+        rewrittenLines.push(line);
+
+        const current = pendingHeredocs[0];
+        const candidate = current.allowTabs ? line.replace(/^\t+/, "") : line;
+        if (candidate === current.delimiter) {
+          pendingHeredocs.shift();
+        }
+        continue;
+      }
+
+      let rewrittenLine = line.replace(
+        /(?<![\w/.-])\/([^/\s"';|&><!\])]+)(?=\/|[\s"';|&><!\])]|$)/g,
+        (match, rootName: string) => {
+          if (vfsRootNames.has(rootName)) {
+            return match;
+          }
+          if (!HOST_ABSOLUTE_ROOT_ALLOWLIST.has(rootName)) {
+            return `${execDir}/${rootName}`;
+          }
+          return match;
+        },
       );
+
+      for (const rootName of sortedVfsRoots) {
+        const escapedRootName = rootName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        rewrittenLine = rewrittenLine.replace(
+          new RegExp(
+            `(?<![\\w/.-])/${escapedRootName}(?=/|[\\s"';|&><!\\])]|$)`,
+            "g",
+          ),
+          `${execDir}/${rootName}`,
+        );
+      }
+
+      rewrittenLines.push(rewrittenLine);
+
+      for (const heredoc of this.#extractHeredocDelimiters(line)) {
+        pendingHeredocs.push(heredoc);
+      }
     }
 
-    return this.#restoreHeredocBodies(rewritten, placeholders);
+    return rewrittenLines.join("\n");
   }
 
-  #protectHeredocBodies(command: string): {
-    command: string;
-    placeholders: HeredocPlaceholder[];
-  } {
-    const placeholders: HeredocPlaceholder[] = [];
-    const heredocPattern =
-      /((?:^|\n)[^\n]*<<-?\s*(['"]?)([^\s'"`\\]+)\2[^\n]*\n)([\s\S]*?)(\n(?:\t*)?\3(?=\n|$))/g;
+  #extractHeredocDelimiters(
+    line: string,
+  ): Array<{ delimiter: string; allowTabs: boolean }> {
+    const delimiters: Array<{ delimiter: string; allowTabs: boolean }> = [];
+    let inSingleQuote = false;
+    let inDoubleQuote = false;
+    let escapeNext = false;
 
-    const protectedCommand = command.replace(
-      heredocPattern,
-      (
-        _full,
-        prefix: string,
-        _quote: string,
-        _delimiter: string,
-        body: string,
-        suffix: string,
-      ) => {
-        const token = `__VFS_HEREDOC_BODY_${placeholders.length}__`;
-        placeholders.push({ token, body });
-        return `${prefix}${token}${suffix}`;
-      },
-    );
+    for (let i = 0; i < line.length; i += 1) {
+      const ch = line[i];
 
-    return { command: protectedCommand, placeholders };
-  }
+      if (escapeNext) {
+        escapeNext = false;
+        continue;
+      }
 
-  #restoreHeredocBodies(
-    command: string,
-    placeholders: HeredocPlaceholder[],
-  ): string {
-    let restored = command;
-    for (const placeholder of placeholders) {
-      restored = restored.split(placeholder.token).join(placeholder.body);
+      if (ch === "\\" && !inSingleQuote) {
+        escapeNext = true;
+        continue;
+      }
+
+      if (ch === "'" && !inDoubleQuote) {
+        inSingleQuote = !inSingleQuote;
+        continue;
+      }
+
+      if (ch === '"' && !inSingleQuote) {
+        inDoubleQuote = !inDoubleQuote;
+        continue;
+      }
+
+      if (inSingleQuote || inDoubleQuote) {
+        continue;
+      }
+
+      if (line[i] !== "<" || line[i + 1] !== "<") {
+        continue;
+      }
+
+      let j = i + 2;
+      let allowTabs = false;
+      if (line[j] === "-") {
+        allowTabs = true;
+        j += 1;
+      }
+
+      while (j < line.length && /\s/.test(line[j])) {
+        j += 1;
+      }
+
+      if (j >= line.length) {
+        break;
+      }
+
+      let delimiter = "";
+      const quoteChar = line[j];
+      if (quoteChar === "'" || quoteChar === '"') {
+        j += 1;
+        const start = j;
+        while (j < line.length && line[j] !== quoteChar) {
+          j += 1;
+        }
+        delimiter = line.slice(start, j);
+        if (j < line.length) {
+          j += 1;
+        }
+      } else {
+        const start = j;
+        while (
+          j < line.length &&
+          !/\s/.test(line[j]) &&
+          !";|&<>()".includes(line[j])
+        ) {
+          j += 1;
+        }
+        delimiter = line.slice(start, j);
+      }
+
+      if (delimiter.length > 0) {
+        delimiters.push({ delimiter, allowTabs });
+      }
+
+      i = j - 1;
     }
-    return restored;
+
+    return delimiters;
   }
 
   /**

--- a/libs/providers/node-vfs/src/sandbox.ts
+++ b/libs/providers/node-vfs/src/sandbox.ts
@@ -300,146 +300,35 @@ export class VfsSandbox extends BaseSandbox {
     }
 
     const vfsRootNames = new Set(topLevelNames);
+    let rewritten = command.replace(
+      /(?<![\w/.-])\/([^/\s"';|&><!\])]+)(?=\/|[\s"';|&><!\])]|$)/gm,
+      (match, rootName: string) => {
+        if (vfsRootNames.has(rootName)) {
+          return match;
+        }
+        if (!HOST_ABSOLUTE_ROOT_ALLOWLIST.has(rootName)) {
+          return `${execDir}/${rootName}`;
+        }
+        return match;
+      },
+    );
+
+    // Rewrite known VFS roots exactly (supports special characters).
     const sortedVfsRoots = [...vfsRootNames].sort(
       (a, b) => b.length - a.length,
     );
-    const lines = command.split("\n");
-    const rewrittenLines: string[] = [];
-    const pendingHeredocs: Array<{ delimiter: string; allowTabs: boolean }> =
-      [];
-
-    for (const line of lines) {
-      if (pendingHeredocs.length > 0) {
-        rewrittenLines.push(line);
-
-        const current = pendingHeredocs[0];
-        const candidate = current.allowTabs ? line.replace(/^\t+/, "") : line;
-        if (candidate === current.delimiter) {
-          pendingHeredocs.shift();
-        }
-        continue;
-      }
-
-      let rewrittenLine = line.replace(
-        /(?<![\w/.-])\/([^/\s"';|&><!\])]+)(?=\/|[\s"';|&><!\])]|$)/g,
-        (match, rootName: string) => {
-          if (vfsRootNames.has(rootName)) {
-            return match;
-          }
-          if (!HOST_ABSOLUTE_ROOT_ALLOWLIST.has(rootName)) {
-            return `${execDir}/${rootName}`;
-          }
-          return match;
-        },
+    for (const rootName of sortedVfsRoots) {
+      const escapedRootName = rootName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      rewritten = rewritten.replace(
+        new RegExp(
+          `(?<![\\w/.-])/${escapedRootName}(?=/|[\\s"';|&><!\\])]|$)`,
+          "gm",
+        ),
+        `${execDir}/${rootName}`,
       );
-
-      for (const rootName of sortedVfsRoots) {
-        const escapedRootName = rootName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        rewrittenLine = rewrittenLine.replace(
-          new RegExp(
-            `(?<![\\w/.-])/${escapedRootName}(?=/|[\\s"';|&><!\\])]|$)`,
-            "g",
-          ),
-          `${execDir}/${rootName}`,
-        );
-      }
-
-      rewrittenLines.push(rewrittenLine);
-
-      for (const heredoc of this.#extractHeredocDelimiters(line)) {
-        pendingHeredocs.push(heredoc);
-      }
     }
 
-    return rewrittenLines.join("\n");
-  }
-
-  #extractHeredocDelimiters(
-    line: string,
-  ): Array<{ delimiter: string; allowTabs: boolean }> {
-    const delimiters: Array<{ delimiter: string; allowTabs: boolean }> = [];
-    let inSingleQuote = false;
-    let inDoubleQuote = false;
-    let escapeNext = false;
-
-    for (let i = 0; i < line.length; i += 1) {
-      const ch = line[i];
-
-      if (escapeNext) {
-        escapeNext = false;
-        continue;
-      }
-
-      if (ch === "\\" && !inSingleQuote) {
-        escapeNext = true;
-        continue;
-      }
-
-      if (ch === "'" && !inDoubleQuote) {
-        inSingleQuote = !inSingleQuote;
-        continue;
-      }
-
-      if (ch === '"' && !inSingleQuote) {
-        inDoubleQuote = !inDoubleQuote;
-        continue;
-      }
-
-      if (inSingleQuote || inDoubleQuote) {
-        continue;
-      }
-
-      if (line[i] !== "<" || line[i + 1] !== "<") {
-        continue;
-      }
-
-      let j = i + 2;
-      let allowTabs = false;
-      if (line[j] === "-") {
-        allowTabs = true;
-        j += 1;
-      }
-
-      while (j < line.length && /\s/.test(line[j])) {
-        j += 1;
-      }
-
-      if (j >= line.length) {
-        break;
-      }
-
-      let delimiter = "";
-      const quoteChar = line[j];
-      if (quoteChar === "'" || quoteChar === '"') {
-        j += 1;
-        const start = j;
-        while (j < line.length && line[j] !== quoteChar) {
-          j += 1;
-        }
-        delimiter = line.slice(start, j);
-        if (j < line.length) {
-          j += 1;
-        }
-      } else {
-        const start = j;
-        while (
-          j < line.length &&
-          !/\s/.test(line[j]) &&
-          !";|&<>()".includes(line[j])
-        ) {
-          j += 1;
-        }
-        delimiter = line.slice(start, j);
-      }
-
-      if (delimiter.length > 0) {
-        delimiters.push({ delimiter, allowTabs });
-      }
-
-      i = j - 1;
-    }
-
-    return delimiters;
+    return rewritten;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #259.

This change fixes `@langchain/node-vfs` command execution behavior for absolute paths in `execute()`. The previous implementation only rewrote absolute paths when the top-level path already existed in the VFS root, which caused commands like `cp /a.txt /b.txt` and redirections to `/b.txt` to target host root paths and fail with read-only filesystem errors.

The rewrite behavior is now sandbox-first for workspace paths, while still preserving host system absolute paths for known roots unless those roots are intentionally shadowed by VFS content.

## Changes

### `@langchain/node-vfs`

- Refactored absolute path rewriting in `VfsSandbox#rewriteVfsPaths` to:
  - Rewrite absolute paths whose root exists in VFS.
  - Rewrite unknown absolute roots to the temp execution workspace.
  - Preserve known host system roots through an explicit allowlist unless shadowed by VFS.
- Moved host absolute root allowlist into `src/const.ts` and imported it from `sandbox.ts`.
- Added integration tests for:
  - `cp /a.txt /b.txt` destination rewriting.
  - Absolute redirection targets with an empty workspace.
  - Host absolute path passthrough (`test -x /bin/sh`).
  - VFS precedence when allowlisted roots are shadowed (for example `/tmp/...`).
