### PR TITLE
feat(deepagents): Add support for stateSchema to createDeepAgent()

### DIFF
--- a/libs/deepagents/src/agent.test-d.ts
+++ b/libs/deepagents/src/agent.test-d.ts
@@ -18,7 +18,7 @@ import {
   toolStrategy,
   providerStrategy,
 } from "langchain";
-import { Annotation, StateSchema } from "@langchain/langgraph";
+import { StateSchema } from "@langchain/langgraph";
 import { z } from "zod/v4";
 import { createDeepAgent } from "./agent.js";
 import type {
@@ -345,12 +345,16 @@ describe("createDeepAgent types", () => {
       expectTypeOf(result.research).toEqualTypeOf<string>();
     });
 
-    it("accepts the full StateDefinitionInit union", () => {
-      createDeepAgent({ stateSchema: new StateSchema({ a: z.string() }) });
-      createDeepAgent({ stateSchema: z.object({ b: z.string() }) });
-      createDeepAgent({
-        stateSchema: Annotation.Root({ c: Annotation<string> }),
-      });
+    it("accepts the two schema forms applied at runtime", async () => {
+      const fromStateSchema = await createDeepAgent({
+        stateSchema: new StateSchema({ a: z.string() }),
+      }).invoke({ messages: [] });
+      expectTypeOf(fromStateSchema.a).toEqualTypeOf<string>();
+
+      const fromZod = await createDeepAgent({
+        stateSchema: z.object({ b: z.string().default("") }),
+      }).invoke({ messages: [] });
+      expectTypeOf(fromZod.b).toEqualTypeOf<string>();
     });
   });
 });

--- a/libs/deepagents/src/agent.test-d.ts
+++ b/libs/deepagents/src/agent.test-d.ts
@@ -18,6 +18,7 @@ import {
   toolStrategy,
   providerStrategy,
 } from "langchain";
+import { Annotation, StateSchema } from "@langchain/langgraph";
 import { z } from "zod/v4";
 import { createDeepAgent } from "./agent.js";
 import type {
@@ -316,6 +317,40 @@ describe("createDeepAgent types", () => {
       expectTypeOf(result.structuredResponse).toEqualTypeOf<
         z.infer<typeof schema1> | z.infer<typeof schema2>
       >();
+    });
+  });
+
+  describe("stateSchema parameter", () => {
+    it("should expose StateSchema fields on the invoke result, typed", async () => {
+      const agent = createDeepAgent({
+        stateSchema: new StateSchema({
+          author: z.string(),
+        }),
+      });
+      const result = await agent.invoke({ messages: [] });
+
+      expectTypeOf(result).toHaveProperty("author");
+      expectTypeOf(result.author).toEqualTypeOf<string>();
+      expectTypeOf(result.author).not.toBeAny();
+    });
+
+    it("should merge stateSchema fields with middleware-derived state", async () => {
+      const agent = createDeepAgent({
+        middleware: [ResearchMiddleware],
+        stateSchema: new StateSchema({ author: z.string() }),
+      });
+      const result = await agent.invoke({ messages: [] });
+
+      expectTypeOf(result.author).toEqualTypeOf<string>();
+      expectTypeOf(result.research).toEqualTypeOf<string>();
+    });
+
+    it("accepts the full StateDefinitionInit union", () => {
+      createDeepAgent({ stateSchema: new StateSchema({ a: z.string() }) });
+      createDeepAgent({ stateSchema: z.object({ b: z.string() }) });
+      createDeepAgent({
+        stateSchema: Annotation.Root({ c: Annotation<string> }),
+      });
     });
   });
 });

--- a/libs/deepagents/src/agent.test-d.ts
+++ b/libs/deepagents/src/agent.test-d.ts
@@ -334,6 +334,17 @@ describe("createDeepAgent types", () => {
       expectTypeOf(result.author).not.toBeAny();
     });
 
+    it("should expose zod object schema fields on the invoke result, typed", async () => {
+      const agent = createDeepAgent({
+        stateSchema: z.object({ author: z.string().default("") }),
+      });
+      const result = await agent.invoke({ messages: [] });
+
+      expectTypeOf(result).toHaveProperty("author");
+      expectTypeOf(result.author).toEqualTypeOf<string>();
+      expectTypeOf(result.author).not.toBeAny();
+    });
+
     it("should merge stateSchema fields with middleware-derived state", async () => {
       const agent = createDeepAgent({
         middleware: [ResearchMiddleware],
@@ -343,18 +354,6 @@ describe("createDeepAgent types", () => {
 
       expectTypeOf(result.author).toEqualTypeOf<string>();
       expectTypeOf(result.research).toEqualTypeOf<string>();
-    });
-
-    it("accepts the two schema forms applied at runtime", async () => {
-      const fromStateSchema = await createDeepAgent({
-        stateSchema: new StateSchema({ a: z.string() }),
-      }).invoke({ messages: [] });
-      expectTypeOf(fromStateSchema.a).toEqualTypeOf<string>();
-
-      const fromZod = await createDeepAgent({
-        stateSchema: z.object({ b: z.string().default("") }),
-      }).invoke({ messages: [] });
-      expectTypeOf(fromZod.b).toEqualTypeOf<string>();
     });
   });
 });

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -7,9 +7,11 @@ import {
   SystemMessage,
   type BaseMessage,
 } from "@langchain/core/messages";
-import { MemorySaver } from "@langchain/langgraph";
+import { MemorySaver, StateSchema } from "@langchain/langgraph";
 import { createFileData } from "./backends/utils.js";
 import { ConfigurationError } from "./errors.js";
+import { assertAllDeepAgentQualities } from "./testing/utils.js";
+import { z } from "zod/v4";
 
 describe("isAnthropicModel", () => {
   it("should detect claude model strings", () => {
@@ -167,5 +169,19 @@ describe("Built-in tool name collision detection", () => {
     expect(() =>
       createDeepAgent({ model, tools: [makeTool("my_custom_tool")] }),
     ).not.toThrow();
+  });
+});
+
+describe("State schema propagation", () => {
+  it("should add StateSchema channels to the compiled graph + ensure built-in channels", () => {
+    const stateSchema = new StateSchema({
+      foo: z.string().default("foo"),
+    });
+    const model = new FakeListChatModel({ responses: ["Done"] });
+    const agent = createDeepAgent({ model, stateSchema });
+
+    const channelNames = Object.keys(agent.graph?.channels ?? {});
+    expect(channelNames).toContain("foo");
+    assertAllDeepAgentQualities(agent);
   });
 });

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -52,10 +52,7 @@ import { createSubagentTransformer } from "./stream.js";
  */
 import type * as _messages from "@langchain/core/messages";
 import type * as _langgraph from "@langchain/langgraph";
-import type {
-  StateDefinitionInit,
-  StreamTransformer,
-} from "@langchain/langgraph";
+import type { AnyStateSchema, StreamTransformer } from "@langchain/langgraph";
 import {
   resolveHarnessProfile,
   applyProfilePrompt,
@@ -150,7 +147,8 @@ export function createDeepAgent<
   const TStreamTransformers extends ReadonlyArray<
     () => StreamTransformer<any>
   > = readonly [],
-  TStateSchema extends StateDefinitionInit | undefined = undefined,
+  TStateSchema extends AnyStateSchema | InteropZodObject | undefined =
+    undefined,
 >(
   params: CreateDeepAgentParams<
     TResponse,

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -52,7 +52,10 @@ import { createSubagentTransformer } from "./stream.js";
  */
 import type * as _messages from "@langchain/core/messages";
 import type * as _langgraph from "@langchain/langgraph";
-import type { StreamTransformer } from "@langchain/langgraph";
+import type {
+  StateDefinitionInit,
+  StreamTransformer,
+} from "@langchain/langgraph";
 import {
   resolveHarnessProfile,
   applyProfilePrompt,
@@ -123,7 +126,7 @@ const BUILTIN_TOOL_NAMES: ReadonlySet<string> = new Set([
  *
  * @example
  * ```typescript
- * // Middleware with custom state
+ * // Custom state from middleware and/or the agent stateSchema param — both are merged
  * const ResearchMiddleware = createMiddleware({
  *   name: "ResearchMiddleware",
  *   stateSchema: z.object({ research: z.string().default("") }),
@@ -131,10 +134,11 @@ const BUILTIN_TOOL_NAMES: ReadonlySet<string> = new Set([
  *
  * const agent = createDeepAgent({
  *   middleware: [ResearchMiddleware],
+ *   stateSchema: z.object({ author: z.string().default("Me") }),
  * });
  *
  * const result = await agent.invoke({ messages: [...] });
- * // result.research is properly typed as string
+ * // result.research and result.author are properly typed as strings
  * ```
  */
 export function createDeepAgent<
@@ -146,6 +150,7 @@ export function createDeepAgent<
   const TStreamTransformers extends ReadonlyArray<
     () => StreamTransformer<any>
   > = readonly [],
+  TStateSchema extends StateDefinitionInit | undefined = undefined,
 >(
   params: CreateDeepAgentParams<
     TResponse,
@@ -153,20 +158,23 @@ export function createDeepAgent<
     TMiddleware,
     TSubagents,
     TTools,
-    TStreamTransformers
+    TStreamTransformers,
+    TStateSchema
   > = {} as CreateDeepAgentParams<
     TResponse,
     ContextSchema,
     TMiddleware,
     TSubagents,
     TTools,
-    TStreamTransformers
+    TStreamTransformers,
+    TStateSchema
   >,
 ) {
   const {
     model = "anthropic:claude-sonnet-4-6",
     tools = [],
     systemPrompt,
+    stateSchema,
     middleware: customMiddleware = [],
     subagents = [],
     responseFormat,
@@ -449,6 +457,7 @@ export function createDeepAgent<
   const agent = createAgent({
     model,
     systemPrompt: finalSystemPrompt,
+    stateSchema,
     tools: effectiveTools,
     middleware,
     ...(responseFormat !== null && { responseFormat }),
@@ -481,7 +490,7 @@ export function createDeepAgent<
   /**
    * Return as DeepAgent with proper DeepAgentTypeConfig
    * - Response: InferStructuredResponse<TResponse> (unwraps ToolStrategy<T>/ProviderStrategy<T> → T)
-   * - State: undefined (state comes from middleware)
+   * - State: User-provided stateSchema, merged with middleware-derived state downstream
    * - Context: ContextSchema
    * - Middleware: AllMiddleware (built-in + custom + subagent middleware for state inference)
    * - Tools: TTools
@@ -491,7 +500,7 @@ export function createDeepAgent<
   return agent as unknown as DeepAgent<
     DeepAgentTypeConfig<
       InferStructuredResponse<TResponse>,
-      undefined,
+      TStateSchema,
       ContextSchema,
       AllMiddleware,
       TTools,

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -498,6 +498,7 @@ export type InferSubagentReactAgentType<
  * @typeParam TSubagents - The subagents array type for extracting subagent middleware states
  * @typeParam TTools - The tools array type
  * @typeParam TStreamTransformers - Custom stream transformer factories
+ * @typeParam TStateSchema - The custom state schema type
  */
 export interface CreateDeepAgentParams<
   TResponse extends SupportedResponseFormat = SupportedResponseFormat,

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -27,6 +27,7 @@ import type { AsyncSubAgent, SubAgent } from "./middleware/index.js";
 import type { InteropZodObject } from "@langchain/core/utils/types";
 import type {
   AnnotationRoot,
+  AnyStateSchema,
   StateDefinitionInit,
   StreamTransformer,
 } from "@langchain/langgraph";
@@ -510,7 +511,8 @@ export interface CreateDeepAgentParams<
   )[],
   TStreamTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
     readonly [],
-  TStateSchema extends StateDefinitionInit | undefined = undefined,
+  TStateSchema extends AnyStateSchema | InteropZodObject | undefined =
+    undefined,
 > {
   /** The model to use (model name string or LanguageModelLike instance). Defaults to claude-sonnet-4-5-20250929 */
   model?: BaseLanguageModel | string;

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -25,7 +25,11 @@ import type {
 import type { AnyBackendProtocol } from "./backends/index.js";
 import type { AsyncSubAgent, SubAgent } from "./middleware/index.js";
 import type { InteropZodObject } from "@langchain/core/utils/types";
-import type { AnnotationRoot, StreamTransformer } from "@langchain/langgraph";
+import type {
+  AnnotationRoot,
+  StateDefinitionInit,
+  StreamTransformer,
+} from "@langchain/langgraph";
 import type { CompiledSubAgent } from "./middleware/subagents.js";
 import type {
   ASYNC_TASK_TOOL_NAMES,
@@ -199,9 +203,8 @@ export interface DeepAgentTypeConfig<
   TResponse extends Record<string, any> | ResponseFormatUndefined =
     | Record<string, any>
     | ResponseFormatUndefined,
-  TState extends AnyAnnotationRoot | InteropZodObject | undefined =
-    | AnyAnnotationRoot
-    | InteropZodObject
+  TState extends StateDefinitionInit | undefined =
+    | StateDefinitionInit
     | undefined,
   TContext extends AnyAnnotationRoot | InteropZodObject =
     | AnyAnnotationRoot
@@ -507,6 +510,7 @@ export interface CreateDeepAgentParams<
   )[],
   TStreamTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
     readonly [],
+  TStateSchema extends StateDefinitionInit | undefined = undefined,
 > {
   /** The model to use (model name string or LanguageModelLike instance). Defaults to claude-sonnet-4-5-20250929 */
   model?: BaseLanguageModel | string;
@@ -514,6 +518,34 @@ export interface CreateDeepAgentParams<
   tools?: TTools | StructuredTool[];
   /** Custom system prompt for the agent. This will be combined with the base agent prompt */
   systemPrompt?: string | SystemMessage;
+  /**
+   * Optional schema for custom agent state. Allows you to define custom state properties
+   * beyond built-in `messages`, `todos`, and `files`. These properties can be accessed
+   * in hooks, middleware, and throughout the agent's execution.
+   *
+   * Unlike `contextSchema` the state is persisted between agent invocations when using a
+   * checkpointer, making it suitable for maintaining conversation history, user preferences,
+   * or any other data that should persist across multiple interactions.
+   *
+   * @example
+   * ```ts
+   * import { StateSchema } from "@langchain/langgraph";
+   * import { z } from "zod";
+   *
+   * const agent = createDeepAgent({
+   *   stateSchema: new StateSchema({
+   *     author: z.string().default("unknown"),
+   *   }),
+   * });
+   *
+   * const result = await agent.invoke({
+   *   messages: [{ role: "user", content: "Take a note" }],
+   *   author: "Me",
+   * });
+   * // result.author is typed `string`
+   * ```
+   */
+  stateSchema?: TStateSchema;
   /** Custom middleware to apply after standard middleware */
   middleware?: TMiddleware;
   /**


### PR DESCRIPTION
## Summary
Adds support for `stateSchema` to `createDeepAgent()` as well as accompanying tests. Example:

```
const stateSchema = new StateSchema({
  foo: z.string().default("foo"),
});
const agent = createDeepAgent({ model, stateSchema });
// agent.graph.channels includes attribute foo
```

### Callouts
**Opted against compile/runtime check for stateSchema keys**
There is a strong argument here to add a compile-time or runtime check to ensure uniqueness of `stateSchema` keys to guard against the first-writer-wins behavior of channel merging. [There is already a runtime tool name check](https://github.com/langchain-ai/deepagentsjs/blob/c524561ad0c4b13075b0d0999236f09bf5f6cb89/libs/deepagents/src/agent.ts#L185). However the topic of how channel merging is handled, I think, deserves a fast follow to ensure that consumers of this API are properly educated (rather than just throwing in this key concept into a single docstring). **Action item here is that I would love to treat this as a fast follow, and chat about if/how we're educating consumers about this concept.**

**Protocol re. changesets**
Happy to run changeset to bump minor version. What is the protocol here?
