### PR TITLE
fix(deepagents): scope composite route search fanout by path

### DIFF
--- a/.changeset/hunter-composite-route-search-scope.md
+++ b/.changeset/hunter-composite-route-search-scope.md
@@ -2,7 +2,7 @@
 "deepagents": patch
 ---
 
-fix(backends): scope CompositeBackend grep/glob route fanout by search path
+fix: scope CompositeBackend grep/glob route fanout by search path
 
 CompositeBackend now limits fallback route fanout to routes mounted under the requested search path, instead of querying all routed backends unconditionally.
 

--- a/.changeset/hunter-composite-route-search-scope.md
+++ b/.changeset/hunter-composite-route-search-scope.md
@@ -1,0 +1,9 @@
+---
+"deepagents": patch
+---
+
+fix(backends): scope CompositeBackend grep/glob route fanout by search path
+
+CompositeBackend now limits fallback route fanout to routes mounted under the requested search path, instead of querying all routed backends unconditionally.
+
+This avoids unrelated routed backend calls (and side-effect errors) for scoped searches like `path="/workspace"`, while preserving full fanout behavior at root (`path="/"`).

--- a/libs/deepagents/src/backends/composite.test.ts
+++ b/libs/deepagents/src/backends/composite.test.ts
@@ -332,6 +332,81 @@ describe("CompositeBackend", () => {
     expect(archPaths).not.toContain("/archive/2023/log.txt");
   });
 
+  it("grep should only fan out to routed backends mounted under the search path", async () => {
+    const { state, runtime } = makeConfig();
+
+    const memoriesBackend = new StoreBackend(runtime);
+    const skillsBackend = new StoreBackend(runtime);
+    const composite = new CompositeBackend(new StateBackend(runtime), {
+      "/workspace/memories/": memoriesBackend,
+      "/skills/": skillsBackend,
+    });
+
+    const outsideSpy = vi
+      .spyOn(skillsBackend, "grep")
+      .mockResolvedValue({ error: "OUTSIDE_ROUTE_CALLED" });
+    const insideSpy = vi.spyOn(memoriesBackend, "grep");
+
+    const defaultWrite = await composite.write("/workspace/index.ts", "index");
+    expect(defaultWrite.error).toBeUndefined();
+    if (defaultWrite.filesUpdate) {
+      Object.assign(state.files, defaultWrite.filesUpdate);
+    }
+
+    const routedWrite = await composite.write(
+      "/workspace/memories/note.md",
+      "index memory",
+    );
+    expect(routedWrite.error).toBeUndefined();
+
+    const result = await composite.grep("index", "/workspace", "**/*");
+    expect(result.error).toBeUndefined();
+
+    const paths = new Set((result.matches || []).map((m) => m.path));
+    expect(paths).toContain("/workspace/index.ts");
+    expect(paths).toContain("/workspace/memories/note.md");
+    expect(outsideSpy).not.toHaveBeenCalled();
+    expect(insideSpy).toHaveBeenCalledWith("index", "/", "**/*");
+  });
+
+  it("glob should only fan out to routed backends mounted under the search path", async () => {
+    const { state, runtime } = makeConfig();
+
+    const memoriesBackend = new StoreBackend(runtime);
+    const skillsBackend = new StoreBackend(runtime);
+    const composite = new CompositeBackend(new StateBackend(runtime), {
+      "/workspace/memories/": memoriesBackend,
+      "/skills/": skillsBackend,
+    });
+
+    const outsideSpy = vi.spyOn(skillsBackend, "glob").mockResolvedValue({
+      files: [{ path: "/outside.txt" }],
+    });
+    const insideSpy = vi.spyOn(memoriesBackend, "glob");
+
+    const defaultWrite = await composite.write("/workspace/index.ts", "index");
+    expect(defaultWrite.error).toBeUndefined();
+    if (defaultWrite.filesUpdate) {
+      Object.assign(state.files, defaultWrite.filesUpdate);
+    }
+
+    const routedWrite = await composite.write(
+      "/workspace/memories/note.md",
+      "index memory",
+    );
+    expect(routedWrite.error).toBeUndefined();
+
+    const result = await composite.glob("**/*", "/workspace");
+    expect(result.error).toBeUndefined();
+
+    const paths = new Set((result.files || []).map((f) => f.path));
+    expect(paths).toContain("/workspace/index.ts");
+    expect(paths).toContain("/workspace/memories/note.md");
+    expect(paths).not.toContain("/skills/outside.txt");
+    expect(outsideSpy).not.toHaveBeenCalled();
+    expect(insideSpy).toHaveBeenCalledWith("**/*", "/");
+  });
+
   it("should return ReadRawResult from readRaw across backends", async () => {
     const { state, runtime } = makeConfig();
 

--- a/libs/deepagents/src/backends/composite.ts
+++ b/libs/deepagents/src/backends/composite.ts
@@ -107,6 +107,37 @@ export class CompositeBackend implements BackendProtocolV2 {
   }
 
   /**
+   * Returns true when `path` points at `routePrefix` or its descendants.
+   */
+  private isPathWithinRoute(path: string, routePrefix: string): boolean {
+    const normalizedRoute = routePrefix.endsWith("/")
+      ? routePrefix
+      : `${routePrefix}/`;
+    const routeRoot = normalizedRoute.slice(0, -1);
+    return path === routeRoot || path.startsWith(normalizedRoute);
+  }
+
+  /**
+   * Returns true when `routePrefix` is inside `path` (or equal to it).
+   *
+   * Examples:
+   * - path `/` includes all routes
+   * - path `/workspace` includes route `/workspace/memories/`
+   * - path `/workspace` excludes route `/skills/`
+   */
+  private isRouteUnderPath(routePrefix: string, path: string): boolean {
+    if (path === "/") {
+      return true;
+    }
+
+    const normalizedPath = path.endsWith("/") ? path : `${path}/`;
+    const normalizedRoute = routePrefix.endsWith("/")
+      ? routePrefix
+      : `${routePrefix}/`;
+    return normalizedRoute.startsWith(normalizedPath);
+  }
+
+  /**
    * List files and directories in the specified directory (non-recursive).
    *
    * @param path - Absolute path to directory
@@ -116,7 +147,7 @@ export class CompositeBackend implements BackendProtocolV2 {
   async ls(path: string): Promise<LsResult> {
     // Check if path matches a specific route
     for (const [routePrefix, backend] of this.sortedRoutes) {
-      if (path.startsWith(routePrefix.replace(/\/$/, ""))) {
+      if (this.isPathWithinRoute(path, routePrefix)) {
         // Query only the matching routed backend
         const suffix = path.substring(routePrefix.length);
         const searchPath = suffix ? "/" + suffix : "/";
@@ -200,14 +231,16 @@ export class CompositeBackend implements BackendProtocolV2 {
    */
   async grep(
     pattern: string,
-    path: string = "/",
+    path: string | null = "/",
     glob: string | null = null,
   ): Promise<GrepResult> {
+    const searchPath = path || "/";
+
     // If path targets a specific route, search only that backend
     for (const [routePrefix, backend] of this.sortedRoutes) {
-      if (path.startsWith(routePrefix.replace(/\/$/, ""))) {
-        const searchPath = path.substring(routePrefix.length - 1);
-        const raw = await backend.grep(pattern, searchPath || "/", glob);
+      if (this.isPathWithinRoute(searchPath, routePrefix)) {
+        const routeSearchPath = searchPath.substring(routePrefix.length - 1);
+        const raw = await backend.grep(pattern, routeSearchPath || "/", glob);
 
         if (raw.error) {
           return raw;
@@ -222,9 +255,9 @@ export class CompositeBackend implements BackendProtocolV2 {
       }
     }
 
-    // Otherwise, search default and all routed backends and merge
+    // Otherwise, search default and routed backends mounted inside this path
     const allMatches: GrepMatch[] = [];
-    const rawDefault = await this.default.grep(pattern, path, glob);
+    const rawDefault = await this.default.grep(pattern, searchPath, glob);
 
     if (rawDefault.error) {
       return rawDefault;
@@ -232,8 +265,12 @@ export class CompositeBackend implements BackendProtocolV2 {
 
     allMatches.push(...(rawDefault.matches || []));
 
-    // Search all routes
+    // Search only routes that are descendants of the requested path
     for (const [routePrefix, backend] of Object.entries(this.routes)) {
+      if (!this.isRouteUnderPath(routePrefix, searchPath)) {
+        continue;
+      }
+
       const raw = await backend.grep(pattern, "/", glob);
 
       if (raw.error) {
@@ -259,7 +296,7 @@ export class CompositeBackend implements BackendProtocolV2 {
 
     // Route based on path, not pattern
     for (const [routePrefix, backend] of this.sortedRoutes) {
-      if (path.startsWith(routePrefix.replace(/\/$/, ""))) {
+      if (this.isPathWithinRoute(path, routePrefix)) {
         const searchPath = path.substring(routePrefix.length - 1);
         const result = await backend.glob(pattern, searchPath || "/");
 
@@ -276,7 +313,7 @@ export class CompositeBackend implements BackendProtocolV2 {
       }
     }
 
-    // Path doesn't match any specific route - search default backend AND all routed backends
+    // Path doesn't match any specific route - search default and route descendants
     const defaultResult = await this.default.glob(pattern, path);
     if (defaultResult.error) {
       return defaultResult;
@@ -284,6 +321,10 @@ export class CompositeBackend implements BackendProtocolV2 {
     results.push(...(defaultResult.files || []));
 
     for (const [routePrefix, backend] of Object.entries(this.routes)) {
+      if (!this.isRouteUnderPath(routePrefix, path)) {
+        continue;
+      }
+
       const result = await backend.glob(pattern, "/");
       if (result.error) {
         continue; // Skip backends that error


### PR DESCRIPTION
## Summary

Fixes #241.

This updates `CompositeBackend` search routing so scoped `grep`/`glob` requests only fan out to routed backends mounted under the requested path. Previously, non-route paths (for example `/workspace`) still queried all routes, which could trigger unrelated backend errors.

## Changes

### `libs/deepagents/src/backends/composite.ts`

- Added route/path helper predicates to distinguish:
  - when a search path is inside a route,
  - when a route is a descendant of the requested search path.
- Updated `grep` fallback behavior to query the default backend plus only descendant routes (instead of unconditional all-route fanout).
- Updated `glob` fallback behavior to use the same descendant-route filtering.
- Normalized `grep` path handling to accept `null` and treat it as root (`/`).
- Reused the same route-matching helper in `ls` for consistent prefix matching semantics.

### `libs/deepagents/src/backends/composite.test.ts`

- Added regression test to ensure `grep("...", "/workspace")` does not call unrelated routes (for example `/skills/`) while still searching relevant descendant routes.
- Added regression test for equivalent `glob` behavior.
