### PR TITLE
fix(deepagents): replace same-name middleware in createDeepAgent

### DIFF
--- a/.changeset/hunter-middleware-replace-by-name.md
+++ b/.changeset/hunter-middleware-replace-by-name.md
@@ -1,0 +1,8 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): replace same-name middleware in createDeepAgent instead of appending duplicates
+
+- Merge root and declarative subagent middleware by name so custom middleware can override built-ins in place.
+- Reuse the shared profile merge helper and add agent tests covering replacement and ordering.

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { createDeepAgent } from "./agent.js";
 import { isAnthropicModel } from "./utils.js";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
@@ -10,6 +10,33 @@ import {
 import { MemorySaver } from "@langchain/langgraph";
 import { createFileData } from "./backends/utils.js";
 import { ConfigurationError } from "./errors.js";
+import { createMiddleware } from "langchain";
+import type { AgentMiddleware } from "langchain";
+
+const { createAgentMock, createSubAgentMiddlewareMock } = vi.hoisted(() => ({
+  createAgentMock: vi.fn(),
+  createSubAgentMiddlewareMock: vi.fn(),
+}));
+
+vi.mock("langchain", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("langchain")>();
+  createAgentMock.mockImplementation(actual.createAgent as any);
+  return {
+    ...actual,
+    createAgent: createAgentMock,
+  };
+});
+
+vi.mock("./middleware/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./middleware/index.js")>();
+  createSubAgentMiddlewareMock.mockImplementation(
+    actual.createSubAgentMiddleware,
+  );
+  return {
+    ...actual,
+    createSubAgentMiddleware: createSubAgentMiddlewareMock,
+  };
+});
 
 describe("isAnthropicModel", () => {
   it("should detect claude model strings", () => {
@@ -167,5 +194,115 @@ describe("Built-in tool name collision detection", () => {
     expect(() =>
       createDeepAgent({ model, tools: [makeTool("my_custom_tool")] }),
     ).not.toThrow();
+  });
+});
+
+describe("createDeepAgent middleware replacement", () => {
+  beforeEach(() => {
+    createAgentMock.mockClear();
+    createSubAgentMiddlewareMock.mockClear();
+  });
+
+  it("replaces root middleware by name in place instead of appending", () => {
+    createAgentMock.mockImplementationOnce(
+      () =>
+        ({
+          withConfig: vi.fn().mockReturnValue({
+            graph: { nodes: { tools: { bound: { tools: [] } } } },
+          }),
+        }) as any,
+    );
+
+    const replacementSummarization = createMiddleware({
+      name: "SummarizationMiddleware",
+    });
+    const customTail = createMiddleware({
+      name: "CustomTailMiddleware",
+    });
+
+    createDeepAgent({
+      model: "openai:gpt-5",
+      middleware: [replacementSummarization, customTail],
+    });
+
+    const createAgentCall = createAgentMock.mock.calls.at(-1);
+    expect(createAgentCall).toBeDefined();
+    const middleware = (
+      createAgentCall![0] as {
+        middleware: AgentMiddleware[];
+      }
+    ).middleware;
+    const names = middleware.map((m: AgentMiddleware) => m.name);
+
+    expect(
+      names.filter((n: string) => n === "SummarizationMiddleware"),
+    ).toHaveLength(1);
+
+    const summarizationIdx = names.indexOf("SummarizationMiddleware");
+    const patchIdx = names.indexOf("patchToolCallsMiddleware");
+    const customIdx = names.indexOf("CustomTailMiddleware");
+
+    expect(summarizationIdx).toBeGreaterThanOrEqual(0);
+    expect(patchIdx).toBeGreaterThanOrEqual(0);
+    expect(customIdx).toBeGreaterThanOrEqual(0);
+    expect(summarizationIdx).toBeLessThan(patchIdx);
+    expect(customIdx).toBeGreaterThan(patchIdx);
+  });
+
+  it("applies same-name replacement for declarative subagent middleware", () => {
+    createAgentMock.mockImplementationOnce(
+      () =>
+        ({
+          withConfig: vi.fn().mockReturnValue({
+            graph: { nodes: { tools: { bound: { tools: [] } } } },
+          }),
+        }) as any,
+    );
+
+    const replacementSummarization = createMiddleware({
+      name: "SummarizationMiddleware",
+    });
+    const customTail = createMiddleware({
+      name: "SubagentCustomTailMiddleware",
+    });
+
+    createDeepAgent({
+      model: "openai:gpt-5",
+      subagents: [
+        {
+          name: "specialist",
+          description: "Specialist agent",
+          systemPrompt: "Handle specialist tasks.",
+          middleware: [replacementSummarization, customTail],
+        },
+      ],
+    });
+
+    const createSubAgentCall = createSubAgentMiddlewareMock.mock.calls.at(-1);
+    expect(createSubAgentCall).toBeDefined();
+    const { subagents } = createSubAgentCall![0] as {
+      subagents: Array<{ name: string; middleware?: AgentMiddleware[] }>;
+    };
+    const specialist = subagents.find(
+      (s: { name: string }) => s.name === "specialist",
+    );
+    expect(specialist).toBeDefined();
+
+    const names = (specialist!.middleware ?? []).map(
+      (m: AgentMiddleware) => m.name,
+    );
+    expect(
+      names.filter((n: string) => n === "SummarizationMiddleware"),
+    ).toHaveLength(1);
+
+    const summarizationIdx = names.indexOf("SummarizationMiddleware");
+    const patchIdx = names.indexOf("patchToolCallsMiddleware");
+    const customIdx = names.indexOf("SubagentCustomTailMiddleware");
+
+    expect(summarizationIdx).toBeGreaterThanOrEqual(0);
+    expect(patchIdx).toBeGreaterThanOrEqual(0);
+    expect(customIdx).toBeGreaterThanOrEqual(0);
+    expect(summarizationIdx).toBeLessThan(patchIdx);
+    expect(customIdx).toBeGreaterThan(patchIdx);
   });
 });

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -58,6 +58,7 @@ import {
   applyProfilePrompt,
   resolveMiddleware,
 } from "./profiles/index.js";
+import { mergeMiddleware } from "./profiles/harness/merge.js";
 import {
   isAnthropicModel,
   getModelProvider,
@@ -238,7 +239,7 @@ export function createDeepAgent<
     // Middleware for custom subagents (does NOT include skills from main agent).
     // Uses createSummarizationMiddleware (deepagents version) with backend support
     // and auto-computed defaults from model profile.
-    const subagentMiddleware = [
+    const subagentBaseMiddleware = [
       // Provides todo list management capabilities for tracking tasks.
       todoListMiddleware(),
       // Enables filesystem operations and optional long-term memory storage.
@@ -256,8 +257,14 @@ export function createDeepAgent<
       ...(input.skills != null && input.skills.length > 0
         ? [createSkillsMiddleware({ backend, sources: input.skills })]
         : []),
-      // Appends custom middleware from the subagent spec.
-      ...(input.middleware ?? []),
+    ];
+    const subagentMiddleware = [
+      ...resolveMiddleware(
+        mergeMiddleware(
+          subagentBaseMiddleware,
+          (input.middleware ?? []) as AgentMiddleware[],
+        ),
+      ),
       // Adds Anthropic cache controls when supported by the model.
       ...cacheMiddleware,
     ];
@@ -350,20 +357,25 @@ export function createDeepAgent<
   // Runtime middleware array: combine built-in + optional middleware.
   // Note: The full type is handled separately via AllMiddleware.
   const middleware = [
-    // Built-in middleware with deterministic ordering.
-    todoMiddleware,
-    // Optional root-level skills.
-    ...skillsMiddleware,
-    fsMiddleware,
-    subagentMiddleware,
-    summarizationMiddleware,
-    patchToolCallsMiddleware,
-    // Optional async subagent bridge.
-    ...(asyncSubAgents.length > 0
-      ? [createAsyncSubAgentMiddleware({ asyncSubAgents })]
-      : []),
-    // User-provided middleware.
-    ...customMiddleware,
+    ...resolveMiddleware(
+      mergeMiddleware(
+        [
+          // Built-in middleware with deterministic ordering.
+          todoMiddleware,
+          // Optional root-level skills.
+          ...skillsMiddleware,
+          fsMiddleware,
+          subagentMiddleware,
+          summarizationMiddleware,
+          patchToolCallsMiddleware,
+          // Optional async subagent bridge.
+          ...(asyncSubAgents.length > 0
+            ? [createAsyncSubAgentMiddleware({ asyncSubAgents })]
+            : []),
+        ],
+        customMiddleware as unknown as AgentMiddleware[],
+      ),
+    ),
     // Optional Anthropic cache controls.
     ...cacheMiddleware,
     // Optional memory support.

--- a/libs/deepagents/src/profiles/harness/merge.ts
+++ b/libs/deepagents/src/profiles/harness/merge.ts
@@ -14,7 +14,7 @@ import { createHarnessProfile } from "./create.js";
  *
  * Returns a factory to ensure fresh resolution on each call.
  */
-function mergeMiddleware(
+export function mergeMiddleware(
   base: AgentMiddleware[] | (() => AgentMiddleware[]),
   override: AgentMiddleware[] | (() => AgentMiddleware[]),
 ): (() => AgentMiddleware[]) | AgentMiddleware[] {


### PR DESCRIPTION
## Summary

`createDeepAgent` now merges user-provided middleware into the assembled middleware stack by `.name`, replacing matching entries in place instead of appending duplicates. This gives users a direct path to override built-in middleware configuration (such as summarization) without introducing duplicate triggers. The same replacement behavior now applies to declarative subagent middleware stacks.

## Changes

### `libs/deepagents/src/agent.ts`

- Reused shared middleware merge semantics when composing the root middleware stack, so matching middleware names replace existing entries at their current position.
- Applied the same merge-by-name behavior to declarative subagent middleware assembly before cache middleware is appended.
- Preserved existing stack ordering guarantees while preventing duplicate named middleware.

### `libs/deepagents/src/profiles/harness/merge.ts`

- Exported `mergeMiddleware` so the same merge-by-name logic can be reused by `createDeepAgent`.

### `libs/deepagents/src/agent.test.ts`

- Added coverage for root middleware replacement by name and declarative subagent middleware replacement by name.
- Asserted both de-duplication (`SummarizationMiddleware` appears once) and ordering behavior.

### `.changeset/hunter-middleware-replace-by-name.md`

- Added a patch changeset for `deepagents` describing the middleware replacement behavior.
