### PR TITLE
fix(deepagents): add browser and node entrypoints

### DIFF
--- a/.changeset/hunter-deepagents-node-browser-entrypoints-292.md
+++ b/.changeset/hunter-deepagents-node-browser-entrypoints-292.md
@@ -7,3 +7,4 @@ fix(deepagents): add explicit browser and node entrypoints
 - add `deepagents/browser` and `deepagents/node` subpath exports
 - route browser bundlers to the browser-safe bundle via the root `browser` export condition
 - avoid named Node builtin imports in backend utils that can break browser builds
+- document browser guidance to import from `deepagents/browser`

--- a/.changeset/hunter-deepagents-node-browser-entrypoints-292.md
+++ b/.changeset/hunter-deepagents-node-browser-entrypoints-292.md
@@ -1,0 +1,9 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): add explicit browser and node entrypoints
+
+- add `deepagents/browser` and `deepagents/node` subpath exports
+- route browser bundlers to the browser-safe bundle via the root `browser` export condition
+- avoid named Node builtin imports in backend utils that can break browser builds

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -64,6 +64,22 @@ The agent can plan, read/write files, and manage longer tasks with sub-agents an
 > [!TIP]
 > For developing, debugging, and deploying AI agents and LLM applications, see [LangSmith](https://docs.langchain.com/langsmith/home).
 
+## Runtime Entrypoints
+
+`deepagents` now publishes environment-specific entrypoints:
+
+- `deepagents` - default entrypoint. In Node.js it includes the full API. In browser-aware bundlers it resolves to the browser-safe build.
+- `deepagents/browser` - explicit browser-safe entrypoint (no Node-only exports).
+- `deepagents/node` - explicit Node.js entrypoint (includes Node-only exports like `FilesystemBackend` and `LocalShellBackend`).
+
+```typescript
+// Browser-safe usage
+import { createDeepAgent, StateBackend } from "deepagents/browser";
+
+// Explicit Node.js usage
+import { createDeepAgent, FilesystemBackend } from "deepagents/node";
+```
+
 ## Customization
 
 Add tools, swap models, and customize prompts as needed:

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -68,16 +68,19 @@ The agent can plan, read/write files, and manage longer tasks with sub-agents an
 
 `deepagents` now publishes environment-specific entrypoints:
 
-- `deepagents` - default entrypoint. In Node.js it includes the full API. In browser-aware bundlers it resolves to the browser-safe build.
-- `deepagents/browser` - explicit browser-safe entrypoint (no Node-only exports).
-- `deepagents/node` - explicit Node.js entrypoint (includes Node-only exports like `FilesystemBackend` and `LocalShellBackend`).
+- `deepagents` - default Node.js/server entrypoint with the full API.
+- `deepagents/browser` - recommended browser entrypoint (no Node-only exports).
+- `deepagents/node` - optional explicit Node.js entrypoint (same full API as `deepagents`).
 
 ```typescript
 // Browser-safe usage
 import { createDeepAgent, StateBackend } from "deepagents/browser";
 
-// Explicit Node.js usage
-import { createDeepAgent, FilesystemBackend } from "deepagents/node";
+// Node.js usage (recommended)
+import { createDeepAgent, FilesystemBackend } from "deepagents";
+
+// Optional explicit Node.js usage
+// import { createDeepAgent, FilesystemBackend } from "deepagents/node";
 ```
 
 ## Customization

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -66,6 +66,7 @@
   },
   "exports": {
     ".": {
+      "browser": "./dist/browser.js",
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
@@ -73,6 +74,26 @@
       "require": {
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
+      }
+    },
+    "./browser": {
+      "import": {
+        "types": "./dist/browser.d.ts",
+        "default": "./dist/browser.js"
+      },
+      "require": {
+        "types": "./dist/browser.d.cts",
+        "default": "./dist/browser.cjs"
+      }
+    },
+    "./node": {
+      "import": {
+        "types": "./dist/node.d.ts",
+        "default": "./dist/node.js"
+      },
+      "require": {
+        "types": "./dist/node.d.cts",
+        "default": "./dist/node.cjs"
       }
     },
     "./package.json": "./package.json"

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -27,7 +27,7 @@ import {
   createAsyncSubAgentMiddleware,
   isAsyncSubAgent,
 } from "./middleware/index.js";
-import { StateBackend } from "./backends/index.js";
+import { StateBackend } from "./backends/state.js";
 import { ConfigurationError } from "./errors.js";
 import { InteropZodObject } from "@langchain/core/utils/types";
 import { createCacheBreakpointMiddleware } from "./middleware/cache.js";

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -7,7 +7,6 @@
  */
 
 import micromatch from "micromatch";
-import path, { basename } from "path";
 import type {
   AnyBackendProtocol,
   AnySandboxProtocol,
@@ -70,6 +69,18 @@ const MIME_TYPES: Record<string, string> = {
   ".pptx":
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 };
+
+function basename(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const slashIdx = normalized.lastIndexOf("/");
+  return slashIdx === -1 ? normalized : normalized.slice(slashIdx + 1);
+}
+
+function extname(filePath: string): string {
+  const name = basename(filePath);
+  const dotIdx = name.lastIndexOf(".");
+  return dotIdx <= 0 ? "" : name.slice(dotIdx);
+}
 
 /**
  * Sanitize tool_call_id to prevent path traversal and separator issues.
@@ -746,7 +757,7 @@ export function formatGrepMatches(
  * @returns MIME type string (e.g., "image/png", "text/plain")
  */
 export function getMimeType(filePath: string): string {
-  const ext = path.extname(filePath).toLocaleLowerCase();
+  const ext = extname(filePath).toLocaleLowerCase();
   return MIME_TYPES[ext] || "text/plain";
 }
 

--- a/libs/deepagents/src/browser.ts
+++ b/libs/deepagents/src/browser.ts
@@ -1,0 +1,171 @@
+/**
+ * Browser-safe Deep Agents entrypoint.
+ *
+ * Excludes Node.js-only APIs:
+ * - config helpers (`createSettings`, `findProjectRoot`)
+ * - filesystem-backed skills loader (`listSkills`, `parseSkillMetadata`)
+ * - agent-memory middleware (`createAgentMemoryMiddleware`)
+ * - Node-specific backends (`FilesystemBackend`, `LocalShellBackend`)
+ */
+
+export { createDeepAgent } from "./agent.js";
+export { ConfigurationError, type ConfigurationErrorCode } from "./errors.js";
+
+// Export harness profiles
+export {
+  type HarnessProfile,
+  type HarnessProfileOptions,
+  type HarnessProfileConfigData,
+  type GeneralPurposeSubagentConfig,
+  createHarnessProfile,
+  serializeProfile,
+  parseHarnessProfileConfig,
+  registerHarnessProfile,
+  getHarnessProfile,
+  harnessProfileConfigSchema,
+  generalPurposeSubagentConfigSchema,
+  EMPTY_HARNESS_PROFILE,
+  REQUIRED_MIDDLEWARE_NAMES,
+} from "./profiles/index.js";
+
+export { createSubagentTransformer } from "./stream.js";
+export type { DeepAgentRunStream, SubagentRunStream } from "./stream.js";
+export type {
+  AnySubAgent,
+  CreateDeepAgentParams,
+  MergedDeepAgentState,
+  // DeepAgent type bag and helper types
+  DeepAgent,
+  DeepAgentTypeConfig,
+  DefaultDeepAgentTypeConfig,
+  ResolveDeepAgentTypeConfig,
+  InferDeepAgentType,
+  InferDeepAgentSubagents,
+  InferSubagentByName,
+  InferSubagentReactAgentType,
+  // Subagent middleware extraction types
+  ExtractSubAgentMiddleware,
+  FlattenSubAgentMiddleware,
+  InferSubAgentMiddlewareStates,
+  // Response format type utilities
+  SupportedResponseFormat,
+  InferStructuredResponse,
+} from "./types.js";
+
+// Export permissions
+export {
+  type FilesystemPermission,
+  type FilesystemOperation,
+  type PermissionMode,
+} from "./permissions/index.js";
+
+// Export middleware (matches Python's interface)
+export {
+  createFilesystemMiddleware,
+  createSubAgentMiddleware,
+  createPatchToolCallsMiddleware,
+  createSummarizationMiddleware,
+  computeSummarizationDefaults,
+  createMemoryMiddleware,
+  createAsyncSubAgentMiddleware,
+  isAsyncSubAgent,
+  // Skills middleware - matches Python's SkillsMiddleware interface
+  createSkillsMiddleware,
+  type SkillsMiddlewareOptions,
+  type SkillMetadata,
+  // Skills constants
+  MAX_SKILL_FILE_SIZE,
+  MAX_SKILL_NAME_LENGTH,
+  MAX_SKILL_DESCRIPTION_LENGTH,
+  // Subagent constants for building custom configurations
+  GENERAL_PURPOSE_SUBAGENT,
+  DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
+  DEFAULT_SUBAGENT_PROMPT,
+  TASK_SYSTEM_PROMPT,
+  // Completion callback middleware for async subagents
+  createCompletionCallbackMiddleware,
+  type CompletionCallbackOptions,
+  // Other middleware types
+  type FilesystemMiddlewareOptions,
+  type SubAgentMiddlewareOptions,
+  type MemoryMiddlewareOptions,
+  type SubAgent,
+  type CompiledSubAgent,
+  type AsyncSubAgentMiddlewareOptions,
+  type AsyncSubAgent,
+  type AsyncTask,
+  type AsyncTaskStatus,
+} from "./middleware/index.js";
+
+// Export shared state values (similar to LangGraph's messagesValue pattern)
+export { filesValue } from "./values.js";
+
+// Export browser-safe backends
+export type {
+  AnyBackendProtocol,
+  BackendProtocol,
+  BackendProtocolV1,
+  BackendProtocolV2,
+  BackendFactory,
+  BackendRuntime,
+  FileData,
+  FileInfo,
+  GrepMatch,
+  ReadResult,
+  ReadRawResult,
+  GrepResult,
+  LsResult,
+  GlobResult,
+  WriteResult,
+  EditResult,
+  StateAndStore,
+  // Sandbox execution types
+  ExecuteResponse,
+  FileOperationError,
+  FileDownloadResponse,
+  FileUploadResponse,
+  SandboxBackendProtocol,
+  SandboxBackendProtocolV1,
+  SandboxBackendProtocolV2,
+  MaybePromise,
+  // Sandbox provider types
+  SandboxInfo,
+  SandboxListResponse,
+  SandboxListOptions,
+  SandboxGetOrCreateOptions,
+  SandboxDeleteOptions,
+  // Sandbox error types
+  SandboxErrorCode,
+} from "./backends/protocol.js";
+
+export {
+  isSandboxBackend,
+  isSandboxProtocol,
+  SandboxError,
+  resolveBackend,
+} from "./backends/protocol.js";
+
+export { StateBackend } from "./backends/state.js";
+export {
+  StoreBackend,
+  type StoreBackendContext,
+  type StoreBackendNamespaceFactory,
+  type StoreBackendOptions,
+} from "./backends/store.js";
+export { CompositeBackend } from "./backends/composite.js";
+export { ContextHubBackend } from "./backends/context-hub.js";
+export { BaseSandbox } from "./backends/sandbox.js";
+export {
+  LangSmithSandbox,
+  type LangSmithSandboxOptions,
+  type LangSmithSandboxCreateOptions,
+} from "./backends/langsmith.js";
+export type {
+  Snapshot as LangSmithSnapshot,
+  CaptureSnapshotOptions as LangSmithCaptureSnapshotOptions,
+  StartSandboxOptions as LangSmithStartSandboxOptions,
+} from "langsmith/experimental/sandbox";
+export {
+  adaptBackendProtocol,
+  adaptSandboxProtocol,
+} from "./backends/utils.js";

--- a/libs/deepagents/src/node.ts
+++ b/libs/deepagents/src/node.ts
@@ -1,0 +1,6 @@
+/**
+ * Node.js entrypoint for Deep Agents.
+ *
+ * Includes all exports, including Node.js-only APIs.
+ */
+export * from "./index.js";

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -22,7 +22,7 @@ import type {
   BaseStore,
 } from "@langchain/langgraph-checkpoint";
 
-import type { AnyBackendProtocol } from "./backends/index.js";
+import type { AnyBackendProtocol } from "./backends/protocol.js";
 import type { AsyncSubAgent, SubAgent } from "./middleware/index.js";
 import type { InteropZodObject } from "@langchain/core/utils/types";
 import type { AnnotationRoot, StreamTransformer } from "@langchain/langgraph";

--- a/libs/deepagents/tsdown.config.ts
+++ b/libs/deepagents/tsdown.config.ts
@@ -6,7 +6,7 @@ const external = (id: string) =>
 
 export default defineConfig([
   {
-    entry: ["./src/index.ts"],
+    entry: ["./src/index.ts", "./src/browser.ts", "./src/node.ts"],
     format: ["esm"],
     dts: true,
     clean: true,
@@ -16,7 +16,7 @@ export default defineConfig([
     external,
   },
   {
-    entry: ["./src/index.ts"],
+    entry: ["./src/index.ts", "./src/browser.ts", "./src/node.ts"],
     format: ["cjs"],
     dts: true,
     clean: true,


### PR DESCRIPTION
## Summary

Fixes #292, #543

This updates `deepagents` packaging to split environment-specific exports and avoid browser build failures caused by Node-only imports in the default bundle. Browser consumers now have an explicit `deepagents/browser` entrypoint, while Node consumers can keep using `deepagents` (or optionally `deepagents/node`) for the full runtime API.

## Changes

### `deepagents` package exports and entrypoints

- Added `src/browser.ts` as a browser-safe public barrel that excludes Node-only APIs.
- Added `src/node.ts` as an explicit Node entrypoint that re-exports the full API.
- Updated `package.json` exports to:
  - route the root `browser` condition to `./dist/browser.js`
  - expose `./browser` and `./node` subpath exports (ESM + CJS + types).
- Updated `tsdown` config to build `index`, `browser`, and `node` outputs.

### Runtime import graph hardening

- Updated `createDeepAgent` to import `StateBackend` directly from `backends/state` so it no longer pulls in the full Node-oriented backends barrel.
- Updated `types.ts` to import `AnyBackendProtocol` from `backends/protocol` instead of `backends/index`.
- Removed named Node builtin path imports from `backends/utils.ts` by replacing `path.basename`/`path.extname` with local helpers.

### Documentation and release notes

- Added a README section documenting import guidance: browser apps should use `deepagents/browser`, and Node apps can continue to use `deepagents`.
- Added a patch changeset for `deepagents` describing the entrypoint and packaging fix.
