### PR TITLE
chore(deepagents): clarify LocalShellBackend virtualMode behavior

### DIFF
--- a/libs/deepagents/src/backends/local-shell.test.ts
+++ b/libs/deepagents/src/backends/local-shell.test.ts
@@ -362,6 +362,29 @@ describe("LocalShellBackend", () => {
   });
 
   describe("virtual mode", () => {
+    it("should preserve absolute path behavior when virtualMode is false", async () => {
+      const outsidePath = path.join(
+        os.tmpdir(),
+        `deepagents-local-shell-legacy-${Date.now()}.txt`,
+      );
+
+      try {
+        const backend = new LocalShellBackend({
+          rootDir: tmpDir,
+          virtualMode: false,
+        });
+
+        const writeResult = await backend.write(outsidePath, "legacy mode");
+        expect(writeResult.error).toBeUndefined();
+        expect(fsSync.existsSync(outsidePath)).toBe(true);
+        expect(
+          fsSync.existsSync(path.join(tmpDir, path.basename(outsidePath))),
+        ).toBe(false);
+      } finally {
+        await fs.rm(outsidePath, { force: true });
+      }
+    });
+
     it("should restrict filesystem paths but not shell commands", async () => {
       const backend = new LocalShellBackend({
         rootDir: tmpDir,

--- a/libs/deepagents/src/backends/local-shell.ts
+++ b/libs/deepagents/src/backends/local-shell.ts
@@ -32,6 +32,8 @@ import { SandboxError } from "./protocol.js";
 export interface LocalShellBackendOptions {
   /**
    * Working directory for both filesystem operations and shell commands.
+   * When set with `virtualMode: false` (default), absolute paths and `..` can
+   * bypass rootDir for filesystem operations.
    * @defaultValue `process.cwd()`
    */
   rootDir?: string;
@@ -39,6 +41,7 @@ export interface LocalShellBackendOptions {
   /**
    * Enable virtual path mode for filesystem operations.
    * When true, treats rootDir as a virtual root filesystem.
+   * When false (default), preserves legacy path behavior.
    * Does NOT restrict shell commands.
    * @defaultValue `false`
    */
@@ -112,6 +115,7 @@ export interface LocalShellBackendOptions {
  * // Create backend with explicit environment
  * const backend = new LocalShellBackend({
  *   rootDir: "/home/user/project",
+ *   virtualMode: true,
  *   env: { PATH: "/usr/bin:/bin" },
  * });
  *
@@ -127,6 +131,7 @@ export interface LocalShellBackendOptions {
  * // Inherit all environment variables
  * const backend2 = new LocalShellBackend({
  *   rootDir: "/home/user/project",
+ *   virtualMode: true,
  *   inheritEnv: true,
  * });
  * ```


### PR DESCRIPTION
## Summary

Fixes #544.

Clarifies `LocalShellBackend` path semantics without introducing a breaking default change. This keeps legacy behavior intact while making the bounded-workspace setup explicit in docs and examples.

## Changes

### deepagents (`LocalShellBackend`)

- Clarified `LocalShellBackendOptions` docs to explicitly note that `rootDir` does not bound filesystem paths when `virtualMode` is `false`.
- Updated `LocalShellBackend` examples to use `virtualMode: true` when bounded path semantics are intended.
- Added unit coverage to assert legacy behavior is preserved: with `virtualMode: false`, absolute writes can resolve outside `rootDir`.
