### PR TITLE
feat(deepagents): implement default middleware systemprompt override

### DIFF
--- a/libs/deepagents/src/agent.test-d.ts
+++ b/libs/deepagents/src/agent.test-d.ts
@@ -93,6 +93,23 @@ describe("createDeepAgent types", () => {
     });
   });
 
+  it("should allow default middleware system prompt overrides", () => {
+    createDeepAgent({
+      middlewareSystemPrompts: {
+        todoList: "Use todos sparingly.",
+        filesystem: "Use filesystem tools carefully.",
+        subagent: "Delegate independent work.",
+        asyncSubagent: "Launch async work only when requested.",
+      },
+    });
+
+    createDeepAgent({
+      middlewareSystemPrompts: {
+        subagent: null,
+      },
+    });
+  });
+
   describe("MergedDeepAgentState helper type", () => {
     it("should correctly merge middleware states", () => {
       type TestMiddleware = readonly [

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -123,6 +123,56 @@ describe("System prompt cache control breakpoints", () => {
   });
 });
 
+describe("Middleware system prompt overrides", () => {
+  function getSystemMessageFromSpy(
+    invokeSpy: ReturnType<typeof vi.spyOn>,
+  ): BaseMessage | undefined {
+    const lastCall = invokeSpy.mock.calls[invokeSpy.mock.calls.length - 1];
+    const messages = lastCall?.[0] as BaseMessage[] | undefined;
+    if (!messages) return undefined;
+    return messages.find(SystemMessage.isInstance);
+  }
+
+  it("applies custom prompts to default middleware", async () => {
+    const invokeSpy = vi.spyOn(FakeListChatModel.prototype, "invoke");
+    const model = new FakeListChatModel({ responses: ["Done"] });
+
+    const agent = createDeepAgent({
+      model,
+      subagents: [
+        {
+          name: "async-researcher",
+          description: "Researches asynchronously",
+          graphId: "research_graph",
+        },
+      ],
+      middlewareSystemPrompts: {
+        todoList: "CUSTOM TODO PROMPT",
+        filesystem: "CUSTOM FILESYSTEM PROMPT",
+        subagent: "CUSTOM SUBAGENT PROMPT",
+        asyncSubagent: "CUSTOM ASYNC SUBAGENT PROMPT",
+      },
+    });
+
+    await agent.invoke({ messages: [new HumanMessage("Hello")] });
+
+    const systemMessage = getSystemMessageFromSpy(invokeSpy);
+    expect(systemMessage).toBeDefined();
+    const systemText = systemMessage!.text;
+
+    expect(systemText).toContain("CUSTOM TODO PROMPT");
+    expect(systemText).toContain("CUSTOM FILESYSTEM PROMPT");
+    expect(systemText).toContain("CUSTOM SUBAGENT PROMPT");
+    expect(systemText).toContain("CUSTOM ASYNC SUBAGENT PROMPT");
+    expect(systemText).not.toContain("## `write_todos`");
+    expect(systemText).not.toContain("## Filesystem Tools");
+    expect(systemText).not.toContain("## `task` (subagent spawner)");
+    expect(systemText).not.toContain("## Async subagents");
+
+    invokeSpy.mockRestore();
+  });
+});
+
 describe("Built-in tool name collision detection", () => {
   const model = new FakeListChatModel({ responses: ["Done"] });
 

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -173,6 +173,7 @@ export function createDeepAgent<
     model = "anthropic:claude-sonnet-4-6",
     tools = [],
     systemPrompt,
+    middlewareSystemPrompts,
     stateSchema,
     middleware: customMiddleware = [],
     subagents = [],
@@ -247,11 +248,14 @@ export function createDeepAgent<
     // and auto-computed defaults from model profile.
     const subagentMiddleware = [
       // Provides todo list management capabilities for tracking tasks.
-      todoListMiddleware(),
+      todoListMiddleware({
+        systemPrompt: middlewareSystemPrompts?.todoList,
+      }),
       // Enables filesystem operations and optional long-term memory storage.
       createFilesystemMiddleware({
         backend,
         permissions: effectivePermissions,
+        systemPrompt: middlewareSystemPrompts?.filesystem,
       }),
       // Automatically summarizes conversation history when token limits are approached.
       // Uses createSummarizationMiddleware (deepagents version) with backend support
@@ -327,9 +331,15 @@ export function createDeepAgent<
   // Optional middleware (skills, memory, HITL, async) are appended at runtime.
   const builtInMiddleware = [
     // Provides todo list management capabilities for tracking tasks.
-    todoListMiddleware(),
+    todoListMiddleware({
+      systemPrompt: middlewareSystemPrompts?.todoList,
+    }),
     // Enables filesystem operations and optional long-term memory storage.
-    createFilesystemMiddleware({ backend, permissions }),
+    createFilesystemMiddleware({
+      backend,
+      permissions,
+      systemPrompt: middlewareSystemPrompts?.filesystem,
+    }),
     // Enables delegation to specialized subagents for complex tasks.
     createSubAgentMiddleware({
       defaultModel: model,
@@ -337,6 +347,7 @@ export function createDeepAgent<
       defaultInterruptOn: interruptOn,
       subagents: inlineSubagents,
       generalPurposeAgent: false,
+      systemPrompt: middlewareSystemPrompts?.subagent,
     }),
     // Automatically summarizes conversation history when token limits are approached.
     // Uses createSummarizationMiddleware (deepagents version) with backend support
@@ -367,7 +378,12 @@ export function createDeepAgent<
     patchToolCallsMiddleware,
     // Optional async subagent bridge.
     ...(asyncSubAgents.length > 0
-      ? [createAsyncSubAgentMiddleware({ asyncSubAgents })]
+      ? [
+          createAsyncSubAgentMiddleware({
+            asyncSubAgents,
+            systemPrompt: middlewareSystemPrompts?.asyncSubagent,
+          }),
+        ]
       : []),
     // User-provided middleware.
     ...customMiddleware,

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -30,6 +30,7 @@ export type { DeepAgentRunStream, SubagentRunStream } from "./stream.js";
 export type {
   AnySubAgent,
   CreateDeepAgentParams,
+  DeepAgentMiddlewareSystemPrompts,
   MergedDeepAgentState,
   // DeepAgent type bag and helper types
   DeepAgent,

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -145,6 +145,20 @@ export type MergedDeepAgentState<
 export type SupportedResponseFormat = ResponseFormat | TypedToolStrategy<any>;
 
 /**
+ * Overrides for system prompts injected by createDeepAgent's default middleware.
+ */
+export interface DeepAgentMiddlewareSystemPrompts {
+  /** Prompt injected by the built-in todo list middleware. */
+  todoList?: string;
+  /** Prompt injected by the built-in filesystem middleware. */
+  filesystem?: string;
+  /** Prompt injected by the built-in subagent task middleware. Set to `null` to disable it. */
+  subagent?: string | null;
+  /** Prompt injected by the built-in async subagent middleware. */
+  asyncSubagent?: string;
+}
+
+/**
  * Utility type to extract the parsed response type from a ResponseFormat strategy.
  *
  * Maps `ToolStrategy<T>`, `ProviderStrategy<T>`, and `TypedToolStrategy<T>` to `T`
@@ -521,6 +535,8 @@ export interface CreateDeepAgentParams<
   tools?: TTools | StructuredTool[];
   /** Custom system prompt for the agent. This will be combined with the base agent prompt */
   systemPrompt?: string | SystemMessage;
+  /** Overrides for system prompts injected by createDeepAgent's default middleware. */
+  middlewareSystemPrompts?: DeepAgentMiddlewareSystemPrompts;
   /**
    * Optional schema for custom agent state. Allows you to define custom state properties
    * beyond built-in `messages`, `todos`, and `files`. These properties can be accessed


### PR DESCRIPTION
## Summary

Adds a `middlewareSystemPrompts` option to `createDeepAgent` so callers can override system prompts injected by the built-in middleware stack.

Supported overrides:

- `todoList`
- `filesystem`
- `subagent`
- `asyncSubagent`

The new `DeepAgentMiddlewareSystemPrompts` interface is exported from the package entrypoint for consumers who want to type config objects directly.

## Changes

- Adds `middlewareSystemPrompts?: DeepAgentMiddlewareSystemPrompts` to `CreateDeepAgentParams`.
- Wires prompt overrides into the built-in root middleware stack.
- Applies the same todo/filesystem prompt overrides to normalized subagent middleware.
- Supports disabling the subagent task prompt with `subagent: null`, matching existing `createSubAgentMiddleware` behavior.
- Adds runtime coverage that verifies custom middleware prompts replace the defaults.
- Adds a type test confirming the new param is accepted by `createDeepAgent`.

## Validation

- `pnpm --dir libs/deepagents exec vitest run src/agent.test.ts --config vitest.config.ts --typecheck.enabled=false`
- Editor diagnostics pass for the edited files.