### PR TITLE
feat(deepagents): add interrupt mode to filesystem permissions

### DIFF
--- a/.changeset/fs-permissions-interrupt-mode.md
+++ b/.changeset/fs-permissions-interrupt-mode.md
@@ -1,0 +1,9 @@
+---
+"deepagents": minor
+---
+
+feat(deepagents): add interrupt mode to filesystem permissions
+
+Filesystem permission rules now support `mode: "interrupt"`, pausing matching tool calls for human approval via `HumanInTheLoopMiddleware` instead of denying or running silently. `createDeepAgent` auto-installs HITL when interrupt rules are present and merges fs-derived `interruptOn` configs with user overrides (user wins per tool name). Scope-aware `when` predicates fire only when calls intersect protected paths, including hardening for pathless bulk tools and current-dir aliases.
+
+Port of langchain-ai/deepagents#3505. Requires `langchain@1.4.5-dev-1781048185730` (or later with `when` predicate support).

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -38,11 +38,11 @@
   },
   "homepage": "https://github.com/langchain-ai/deepagentsjs#readme",
   "dependencies": {
-    "@langchain/core": "^1.1.44",
+    "@langchain/core": "1.1.49-dev-1781048185730",
     "@langchain/langgraph": "^1.3.0",
     "@langchain/langgraph-sdk": "^1.9.1",
     "fast-glob": "^3.3.3",
-    "langchain": "^1.4.0",
+    "langchain": "1.4.5-dev-1781048185730",
     "micromatch": "^4.0.8",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -47,6 +47,10 @@ import type {
   SupportedResponseFormat,
 } from "./types.js";
 import { createSubagentTransformer } from "./stream.js";
+import {
+  buildInterruptOnFromPermissions,
+  mergeFsInterruptOn,
+} from "./middleware/fs-interrupt.js";
 
 /**
  * required for type inference
@@ -239,8 +243,17 @@ export function createDeepAgent<
    * Only the general-purpose subagent inherits the main agent's skills.
    * If a custom subagent needs skills, it must specify its own `skills` array.
    */
+  const mainInterruptOn = mergeFsInterruptOn(
+    buildInterruptOnFromPermissions(permissions),
+    interruptOn,
+  );
+
   const normalizeSubagentSpec = (input: SubAgent): SubAgent => {
     const effectivePermissions = input.permissions ?? permissions;
+    const subagentInterruptOn = mergeFsInterruptOn(
+      buildInterruptOnFromPermissions(effectivePermissions),
+      input.interruptOn ?? interruptOn,
+    );
 
     // Middleware for custom subagents (does NOT include skills from main agent).
     // Uses createSummarizationMiddleware (deepagents version) with backend support
@@ -272,6 +285,7 @@ export function createDeepAgent<
       ...input,
       tools: input.tools ?? [],
       middleware: subagentMiddleware,
+      ...(subagentInterruptOn != null && { interruptOn: subagentInterruptOn }),
     };
   };
 
@@ -334,7 +348,7 @@ export function createDeepAgent<
     createSubAgentMiddleware({
       defaultModel: model,
       defaultTools: effectiveTools,
-      defaultInterruptOn: interruptOn,
+      defaultInterruptOn: mainInterruptOn ?? null,
       subagents: inlineSubagents,
       generalPurposeAgent: false,
     }),
@@ -383,8 +397,10 @@ export function createDeepAgent<
           }),
         ]
       : []),
-    // Optional human-in-the-loop tool interrupts.
-    ...(interruptOn ? [humanInTheLoopMiddleware({ interruptOn })] : []),
+    // Optional human-in-the-loop tool interrupts (user config + fs interrupt rules).
+    ...(mainInterruptOn
+      ? [humanInTheLoopMiddleware({ interruptOn: mainInterruptOn })]
+      : []),
   ];
 
   // Apply profile middleware additions. Inserted before cache middleware

--- a/libs/deepagents/src/middleware/fs-interrupt.test.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.test.ts
@@ -77,7 +77,9 @@ describe("decidePathAccess interrupt mode", () => {
     const rules: FilesystemPermission[] = [
       { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
     ];
-    expect(decidePathAccess(rules, "write", "/secrets/x.txt")).toBe("interrupt");
+    expect(decidePathAccess(rules, "write", "/secrets/x.txt")).toBe(
+      "interrupt",
+    );
     expect(decidePathAccess(rules, "write", "/workspace/x.txt")).toBe("allow");
   });
 
@@ -145,7 +147,12 @@ describe("bulk when predicate", () => {
       { operations: ["read"], paths: ["/secrets/**"], mode: "deny" },
       { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
     ];
-    const denyWhen = makeFsWhenPredicate(denyFirstRules, "read", "path", "bulk");
+    const denyWhen = makeFsWhenPredicate(
+      denyFirstRules,
+      "read",
+      "path",
+      "bulk",
+    );
 
     expect(denyWhen(fakeReq({ path: "/secrets" }))).toBe(false);
     expect(denyWhen(fakeReq({ path: "/secrets/sub" }))).toBe(false);
@@ -165,12 +172,12 @@ describe("glob bulk pattern predicate", () => {
     ];
     const carvedWhen = buildInterruptOnFromPermissions(carvedRules).glob.when!;
 
-    expect(
-      carvedWhen(fakeReq({ pattern: "*.txt", path: "/public" })),
-    ).toBe(false);
-    expect(
-      carvedWhen(fakeReq({ pattern: "*.txt", path: "/workspace" })),
-    ).toBe(true);
+    expect(carvedWhen(fakeReq({ pattern: "*.txt", path: "/public" }))).toBe(
+      false,
+    );
+    expect(carvedWhen(fakeReq({ pattern: "*.txt", path: "/workspace" }))).toBe(
+      true,
+    );
   });
 
   it.each([

--- a/libs/deepagents/src/middleware/fs-interrupt.test.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.test.ts
@@ -126,6 +126,30 @@ describe("bulk when predicate", () => {
   ])("%j -> %s", (args, expected) => {
     expect(when(fakeReq(args))).toBe(expected);
   });
+
+  it("honors first-match-wins allow carve-outs for bulk calls", () => {
+    const carvedRules: FilesystemPermission[] = [
+      { operations: ["read"], paths: ["/public/**"] },
+      { operations: ["read"], paths: ["/**"], mode: "interrupt" },
+    ];
+    const carvedWhen = makeFsWhenPredicate(carvedRules, "read", "path", "bulk");
+
+    expect(carvedWhen(fakeReq({ path: "/public" }))).toBe(false);
+    expect(carvedWhen(fakeReq({ path: "/public/sub" }))).toBe(false);
+    expect(carvedWhen(fakeReq({ path: "/" }))).toBe(true);
+    expect(carvedWhen(fakeReq({ path: "/workspace" }))).toBe(true);
+  });
+
+  it("does not interrupt bulk calls when deny wins first-match", () => {
+    const denyFirstRules: FilesystemPermission[] = [
+      { operations: ["read"], paths: ["/secrets/**"], mode: "deny" },
+      { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+    ];
+    const denyWhen = makeFsWhenPredicate(denyFirstRules, "read", "path", "bulk");
+
+    expect(denyWhen(fakeReq({ path: "/secrets" }))).toBe(false);
+    expect(denyWhen(fakeReq({ path: "/secrets/sub" }))).toBe(false);
+  });
 });
 
 describe("glob bulk pattern predicate", () => {
@@ -133,6 +157,21 @@ describe("glob bulk pattern predicate", () => {
     { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
   ];
   const when = buildInterruptOnFromPermissions(rules).glob.when!;
+
+  it("honors allow carve-outs when glob path is scoped", () => {
+    const carvedRules: FilesystemPermission[] = [
+      { operations: ["read"], paths: ["/public/**"] },
+      { operations: ["read"], paths: ["/**"], mode: "interrupt" },
+    ];
+    const carvedWhen = buildInterruptOnFromPermissions(carvedRules).glob.when!;
+
+    expect(
+      carvedWhen(fakeReq({ pattern: "*.txt", path: "/public" })),
+    ).toBe(false);
+    expect(
+      carvedWhen(fakeReq({ pattern: "*.txt", path: "/workspace" })),
+    ).toBe(true);
+  });
 
   it.each([
     [{ pattern: "/secrets/**", path: "/workspace" }, true],

--- a/libs/deepagents/src/middleware/fs-interrupt.test.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.test.ts
@@ -3,13 +3,11 @@ import type { ToolCallRequest } from "langchain";
 import {
   buildInterruptOnFromPermissions,
   mergeFsInterruptOn,
-  _testExports,
+  makeFsWhenPredicate,
 } from "./fs-interrupt.js";
 import { decidePathAccess } from "../permissions/enforce.js";
 import { globAnchor, pathsOverlap } from "../permissions/path-utils.js";
 import type { FilesystemPermission } from "../permissions/types.js";
-
-const { makeFsWhenPredicate } = _testExports;
 
 function fakeReq(args: Record<string, unknown>): ToolCallRequest {
   return {

--- a/libs/deepagents/src/middleware/fs-interrupt.test.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import type { ToolCallRequest } from "langchain";
+import {
+  buildInterruptOnFromPermissions,
+  mergeFsInterruptOn,
+  _testExports,
+} from "./fs-interrupt.js";
+import { decidePathAccess } from "../permissions/enforce.js";
+import { globAnchor, pathsOverlap } from "../permissions/path-utils.js";
+import type { FilesystemPermission } from "../permissions/types.js";
+
+const { makeFsWhenPredicate } = _testExports;
+
+function fakeReq(args: Record<string, unknown>): ToolCallRequest {
+  return {
+    toolCall: { id: "1", name: "test", args },
+  } as ToolCallRequest;
+}
+
+describe("buildInterruptOnFromPermissions", () => {
+  it("returns empty when no rules", () => {
+    expect(buildInterruptOnFromPermissions([])).toEqual({});
+  });
+
+  it("returns empty when no interrupt rules", () => {
+    const rules: FilesystemPermission[] = [
+      { operations: ["write"], paths: ["/secrets/**"], mode: "deny" },
+    ];
+    expect(buildInterruptOnFromPermissions(rules)).toEqual({});
+  });
+
+  it("registers only tools whose op could interrupt", () => {
+    const rules: FilesystemPermission[] = [
+      { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+    ];
+    expect(Object.keys(buildInterruptOnFromPermissions(rules)).sort()).toEqual([
+      "edit_file",
+      "write_file",
+    ]);
+  });
+
+  it("registers read tools for read interrupt", () => {
+    const rules: FilesystemPermission[] = [
+      { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+    ];
+    expect(Object.keys(buildInterruptOnFromPermissions(rules)).sort()).toEqual([
+      "glob",
+      "grep",
+      "ls",
+      "read_file",
+    ]);
+  });
+});
+
+describe("mergeFsInterruptOn", () => {
+  it("returns undefined when both inputs are empty", () => {
+    expect(mergeFsInterruptOn({}, undefined)).toBeUndefined();
+    expect(mergeFsInterruptOn({}, {})).toBeUndefined();
+  });
+
+  it("user interruptOn overrides fs-generated config per tool name", () => {
+    const fsConfig = buildInterruptOnFromPermissions([
+      { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+    ]);
+    const merged = mergeFsInterruptOn(fsConfig, {
+      write_file: { allowedDecisions: ["approve", "reject"] },
+    });
+    expect(merged?.write_file).toEqual({
+      allowedDecisions: ["approve", "reject"],
+    });
+    expect(merged?.edit_file).toBeDefined();
+  });
+});
+
+describe("decidePathAccess interrupt mode", () => {
+  it("returns interrupt for a matching interrupt rule", () => {
+    const rules: FilesystemPermission[] = [
+      { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+    ];
+    expect(decidePathAccess(rules, "write", "/secrets/x.txt")).toBe("interrupt");
+    expect(decidePathAccess(rules, "write", "/workspace/x.txt")).toBe("allow");
+  });
+
+  it("first-match-wins: deny before interrupt", () => {
+    const rules: FilesystemPermission[] = [
+      { operations: ["write"], paths: ["/secrets/**"], mode: "deny" },
+      { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+    ];
+    expect(decidePathAccess(rules, "write", "/secrets/x.txt")).toBe("deny");
+  });
+});
+
+describe("exact when predicate", () => {
+  const rules: FilesystemPermission[] = [
+    { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+  ];
+  const when = makeFsWhenPredicate(rules, "write", "file_path", "exact");
+
+  it.each([
+    ["/secrets/key.pem", true],
+    ["/workspace/x.txt", false],
+  ])("file_path=%s -> %s", (filePath, expected) => {
+    expect(when(fakeReq({ file_path: filePath }))).toBe(expected);
+  });
+});
+
+describe("bulk when predicate", () => {
+  const rules: FilesystemPermission[] = [
+    { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+  ];
+  const when = makeFsWhenPredicate(rules, "read", "path", "bulk");
+
+  it.each([
+    [{ path: undefined }, true],
+    [{}, true],
+    [{ path: "." }, true],
+    [{ path: "" }, true],
+    [{ path: "./" }, true],
+    [{ path: "/." }, true],
+    [{ path: "/" }, true],
+    [{ path: "/secrets" }, true],
+    [{ path: "/secrets/sub" }, true],
+    [{ path: "/workspace" }, false],
+    [{ path: "/secret" }, false],
+    [{ path: "/secrets/../etc/passwd" }, false],
+  ])("%j -> %s", (args, expected) => {
+    expect(when(fakeReq(args))).toBe(expected);
+  });
+});
+
+describe("glob bulk pattern predicate", () => {
+  const rules: FilesystemPermission[] = [
+    { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+  ];
+  const when = buildInterruptOnFromPermissions(rules).glob.when!;
+
+  it.each([
+    [{ pattern: "/secrets/**", path: "/workspace" }, true],
+    [{ pattern: "/secrets/sub/*.txt", path: "/workspace" }, true],
+    [{ pattern: "/**/key.pem", path: "/workspace" }, true],
+    [{ pattern: "/workspace/**", path: "/workspace" }, false],
+    [{ pattern: "../secrets/*", path: "/workspace" }, true],
+    [{ pattern: "../../etc/*", path: "/workspace/sub" }, true],
+    [{ pattern: "*.txt", path: "/workspace" }, false],
+    [{ pattern: "*.txt", path: "/secrets" }, true],
+  ])("%j -> %s", (args, expected) => {
+    expect(when(fakeReq(args))).toBe(expected);
+  });
+});
+
+describe("globAnchor", () => {
+  it.each([
+    ["/secrets/**", "/secrets"],
+    ["/a/*/b", "/a"],
+    ["/secrets/key.pem", "/secrets/key.pem"],
+    ["/*/foo", "/"],
+    ["/**/secrets", "/"],
+  ])("globAnchor(%s) -> %s", (pattern, expected) => {
+    expect(globAnchor(pattern)).toBe(expected);
+  });
+});
+
+describe("pathsOverlap", () => {
+  it.each([
+    ["/a/b", "/a/b", true],
+    ["/a/b/c", "/a/b", true],
+    ["/a", "/a/b", true],
+    ["/", "/anywhere", true],
+    ["/anywhere", "/", true],
+    ["/secret", "/secrets", false],
+    ["/secrets", "/secret", false],
+    ["/workspace", "/secrets", false],
+  ])("pathsOverlap(%s, %s) -> %s", (a, b, expected) => {
+    expect(pathsOverlap(a, b)).toBe(expected);
+  });
+});

--- a/libs/deepagents/src/middleware/fs-interrupt.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.ts
@@ -1,0 +1,207 @@
+/**
+ * Glue between `FilesystemPermission` rules and `HumanInTheLoopMiddleware`.
+ *
+ * `FilesystemMiddleware` enforces deny rules and filters denied results only.
+ * Graph assembly calls `buildInterruptOnFromPermissions` to turn filesystem
+ * permissions into an `interruptOn` mapping with scope-aware `when` predicates.
+ */
+
+import type { InterruptOnConfig, ToolCallRequest } from "langchain";
+import { validateFilePath } from "../backends/utils.js";
+import { decidePathAccess } from "../permissions/enforce.js";
+import type {
+  FilesystemOperation,
+  FilesystemPermission,
+} from "../permissions/types.js";
+import {
+  globAnchor,
+  pathsOverlap,
+  toPosixPath,
+} from "../permissions/path-utils.js";
+
+type ToolScope = "exact" | "bulk";
+
+const FS_TOOL_PATH_ARGS: Record<
+  string,
+  readonly [FilesystemOperation, string, ToolScope, string | null]
+> = {
+  ls: ["read", "path", "bulk", null],
+  read_file: ["read", "file_path", "exact", null],
+  write_file: ["write", "file_path", "exact", null],
+  edit_file: ["write", "file_path", "exact", null],
+  glob: ["read", "path", "bulk", "pattern"],
+  grep: ["read", "path", "bulk", null],
+};
+
+const FULL_HITL_DECISIONS = ["approve", "edit", "reject"] as const;
+
+function makeExactWhenPredicate(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+  pathArgName: string,
+): (request: ToolCallRequest) => boolean {
+  return (request) => {
+    const rawPath = request.toolCall.args?.[pathArgName];
+    if (typeof rawPath !== "string") {
+      return false;
+    }
+
+    try {
+      const normalized = validateFilePath(rawPath);
+      return decidePathAccess(rules, operation, normalized) === "interrupt";
+    } catch {
+      return false;
+    }
+  };
+}
+
+function bulkPatternFires(
+  rawPattern: string,
+  interruptAnchors: readonly string[],
+): boolean {
+  const posixPattern = toPosixPath(rawPattern);
+  if (posixPattern.startsWith("/")) {
+    const anchor = globAnchor(rawPattern);
+    return interruptAnchors.some((ruleAnchor) =>
+      pathsOverlap(anchor, ruleAnchor),
+    );
+  }
+
+  return posixPattern.split("/").includes("..");
+}
+
+function makeBulkWhenPredicate(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+  pathArgName: string,
+  patternArgName: string | null,
+): (request: ToolCallRequest) => boolean {
+  const interruptAnchors = rules.flatMap((rule) =>
+    rule.mode === "interrupt" && rule.operations.includes(operation)
+      ? rule.paths.map((pattern) => globAnchor(pattern))
+      : [],
+  );
+
+  return (request) => {
+    if (interruptAnchors.length === 0) {
+      return false;
+    }
+
+    const args = request.toolCall.args ?? {};
+    const rawPath = args[pathArgName];
+    if (rawPath == null) {
+      return true;
+    }
+    if (typeof rawPath !== "string") {
+      return false;
+    }
+
+    let normalized: string;
+    try {
+      normalized = validateFilePath(rawPath);
+    } catch {
+      return false;
+    }
+
+    if (normalized === "/.") {
+      normalized = "/";
+    }
+
+    if (
+      interruptAnchors.some((anchor) => pathsOverlap(normalized, anchor))
+    ) {
+      return true;
+    }
+
+    if (patternArgName != null) {
+      const rawPattern = args[patternArgName];
+      if (
+        typeof rawPattern === "string" &&
+        bulkPatternFires(rawPattern, interruptAnchors)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+}
+
+function makeFsWhenPredicate(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+  pathArgName: string,
+  scope: ToolScope,
+  patternArgName: string | null = null,
+): (request: ToolCallRequest) => boolean {
+  if (scope === "exact") {
+    return makeExactWhenPredicate(rules, operation, pathArgName);
+  }
+
+  return makeBulkWhenPredicate(
+    rules,
+    operation,
+    pathArgName,
+    patternArgName,
+  );
+}
+
+/**
+ * Generate `interruptOn` configs from interrupt-mode filesystem permissions.
+ */
+export function buildInterruptOnFromPermissions(
+  rules: readonly FilesystemPermission[],
+): Record<string, InterruptOnConfig> {
+  if (!rules.some((rule) => rule.mode === "interrupt")) {
+    return {};
+  }
+
+  const result: Record<string, InterruptOnConfig> = {};
+  for (const [toolName, [operation, pathArg, scope, patternArg]] of Object.entries(
+    FS_TOOL_PATH_ARGS,
+  )) {
+    if (
+      !rules.some(
+        (rule) => rule.mode === "interrupt" && rule.operations.includes(operation),
+      )
+    ) {
+      continue;
+    }
+
+    result[toolName] = {
+      allowedDecisions: [...FULL_HITL_DECISIONS],
+      when: makeFsWhenPredicate(rules, operation, pathArg, scope, patternArg),
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Merge fs-permission-derived configs with user-supplied `interruptOn`.
+ *
+ * User-supplied entries override generated ones per tool name. Returns
+ * `undefined` when both inputs are empty so callers can skip HITL middleware.
+ */
+export function mergeFsInterruptOn(
+  fsInterruptOn: Record<string, InterruptOnConfig>,
+  userInterruptOn?: Record<string, boolean | InterruptOnConfig> | null,
+): Record<string, boolean | InterruptOnConfig> | undefined {
+  if (
+    Object.keys(fsInterruptOn).length === 0 &&
+    (!userInterruptOn || Object.keys(userInterruptOn).length === 0)
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...fsInterruptOn,
+    ...(userInterruptOn ?? {}),
+  };
+}
+
+/** @internal Exported for unit tests. */
+export const _testExports = {
+  makeFsWhenPredicate,
+  FS_TOOL_PATH_ARGS,
+};

--- a/libs/deepagents/src/middleware/fs-interrupt.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.ts
@@ -8,7 +8,7 @@
 
 import type { InterruptOnConfig, ToolCallRequest } from "langchain";
 import { validateFilePath } from "../backends/utils.js";
-import { decidePathAccess } from "../permissions/enforce.js";
+import { decidePathAccess, globMatch } from "../permissions/enforce.js";
 import type {
   FilesystemOperation,
   FilesystemPermission,
@@ -55,19 +55,105 @@ function makeExactWhenPredicate(
   };
 }
 
-function bulkPatternFires(
+/**
+ * Build a probe path inside `callPath`'s subtree that could match `rulePattern`.
+ *
+ * Used with `decidePathAccess` so bulk interrupts honor first-match-wins.
+ */
+function representativeProbePath(callPath: string, rulePattern: string): string {
+  const anchor = globAnchor(rulePattern);
+  const call = callPath.replace(/\/+$/, "") || "/";
+
+  if (call === "/") {
+    if (rulePattern.includes("**")) {
+      return anchor === "/" ? "/__hitl_probe__" : `${anchor}/__hitl_probe__`;
+    }
+    return anchor;
+  }
+
+  const childProbe = `${call}/__hitl_probe__`;
+  if (globMatch(childProbe, rulePattern)) {
+    return childProbe;
+  }
+  if (globMatch(call, rulePattern)) {
+    return call;
+  }
+
+  if (pathsOverlap(call, anchor)) {
+    if (rulePattern.includes("**")) {
+      const base =
+        call === anchor || anchor.startsWith(`${call}/`) ? anchor : call;
+      return base === "/" ? "/__hitl_probe__" : `${base}/__hitl_probe__`;
+    }
+    return anchor;
+  }
+
+  return anchor === "/" ? "/__hitl_probe__" : `${anchor}/__hitl_probe__`;
+}
+
+/**
+ * Return true when a bulk call rooted at `callPath` could surface paths that
+ * resolve to interrupt under first-match-wins rule ordering.
+ */
+function bulkSubtreeCouldInterrupt(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+  callPath: string,
+): boolean {
+  for (const rule of rules) {
+    if (rule.mode !== "interrupt" || !rule.operations.includes(operation)) {
+      continue;
+    }
+
+    for (const pattern of rule.paths) {
+      const anchor = globAnchor(pattern);
+      if (!pathsOverlap(callPath, anchor)) {
+        continue;
+      }
+
+      const probePath = representativeProbePath(callPath, pattern);
+      if (decidePathAccess(rules, operation, probePath) === "interrupt") {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function bulkPatternCouldInterrupt(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+  normalizedPath: string,
   rawPattern: string,
-  interruptAnchors: readonly string[],
 ): boolean {
   const posixPattern = toPosixPath(rawPattern);
   if (posixPattern.startsWith("/")) {
-    const anchor = globAnchor(rawPattern);
-    return interruptAnchors.some((ruleAnchor) =>
-      pathsOverlap(anchor, ruleAnchor),
+    return bulkSubtreeCouldInterrupt(
+      rules,
+      operation,
+      globAnchor(rawPattern),
     );
   }
 
-  return posixPattern.split("/").includes("..");
+  if (posixPattern.split("/").includes("..")) {
+    return rules.some(
+      (rule) =>
+        rule.mode === "interrupt" && rule.operations.includes(operation),
+    );
+  }
+
+  return bulkSubtreeCouldInterrupt(rules, operation, normalizedPath);
+}
+
+function hasInterruptRules(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+): boolean {
+  return rules.some(
+    (rule) =>
+      rule.mode === "interrupt" && rule.operations.includes(operation),
+  );
 }
 
 function makeBulkWhenPredicate(
@@ -76,21 +162,15 @@ function makeBulkWhenPredicate(
   pathArgName: string,
   patternArgName: string | null,
 ): (request: ToolCallRequest) => boolean {
-  const interruptAnchors = rules.flatMap((rule) =>
-    rule.mode === "interrupt" && rule.operations.includes(operation)
-      ? rule.paths.map((pattern) => globAnchor(pattern))
-      : [],
-  );
-
   return (request) => {
-    if (interruptAnchors.length === 0) {
+    if (!hasInterruptRules(rules, operation)) {
       return false;
     }
 
     const args = request.toolCall.args ?? {};
     const rawPath = args[pathArgName];
     if (rawPath == null) {
-      return true;
+      return bulkSubtreeCouldInterrupt(rules, operation, "/");
     }
     if (typeof rawPath !== "string") {
       return false;
@@ -107,9 +187,7 @@ function makeBulkWhenPredicate(
       normalized = "/";
     }
 
-    if (
-      interruptAnchors.some((anchor) => pathsOverlap(normalized, anchor))
-    ) {
+    if (bulkSubtreeCouldInterrupt(rules, operation, normalized)) {
       return true;
     }
 
@@ -117,7 +195,7 @@ function makeBulkWhenPredicate(
       const rawPattern = args[patternArgName];
       if (
         typeof rawPattern === "string" &&
-        bulkPatternFires(rawPattern, interruptAnchors)
+        bulkPatternCouldInterrupt(rules, operation, normalized, rawPattern)
       ) {
         return true;
       }
@@ -203,5 +281,6 @@ export function mergeFsInterruptOn(
 /** @internal Exported for unit tests. */
 export const _testExports = {
   makeFsWhenPredicate,
+  bulkSubtreeCouldInterrupt,
   FS_TOOL_PATH_ARGS,
 };

--- a/libs/deepagents/src/middleware/fs-interrupt.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.ts
@@ -61,7 +61,10 @@ function makeExactWhenPredicate(
  *
  * Used with `decidePathAccess` so bulk interrupts honor first-match-wins.
  */
-function representativeProbePath(callPath: string, rulePattern: string): string {
+function representativeProbePath(
+  callPath: string,
+  rulePattern: string,
+): string {
   const anchor = globAnchor(rulePattern);
   const call = stripTrailingSlashes(callPath) || "/";
 
@@ -130,11 +133,7 @@ function bulkPatternCouldInterrupt(
 ): boolean {
   const posixPattern = toPosixPath(rawPattern);
   if (posixPattern.startsWith("/")) {
-    return bulkSubtreeCouldInterrupt(
-      rules,
-      operation,
-      globAnchor(rawPattern),
-    );
+    return bulkSubtreeCouldInterrupt(rules, operation, globAnchor(rawPattern));
   }
 
   if (posixPattern.split("/").includes("..")) {
@@ -152,8 +151,7 @@ function hasInterruptRules(
   operation: FilesystemOperation,
 ): boolean {
   return rules.some(
-    (rule) =>
-      rule.mode === "interrupt" && rule.operations.includes(operation),
+    (rule) => rule.mode === "interrupt" && rule.operations.includes(operation),
   );
 }
 
@@ -217,12 +215,7 @@ function makeFsWhenPredicate(
     return makeExactWhenPredicate(rules, operation, pathArgName);
   }
 
-  return makeBulkWhenPredicate(
-    rules,
-    operation,
-    pathArgName,
-    patternArgName,
-  );
+  return makeBulkWhenPredicate(rules, operation, pathArgName, patternArgName);
 }
 
 /**
@@ -236,12 +229,14 @@ export function buildInterruptOnFromPermissions(
   }
 
   const result: Record<string, InterruptOnConfig> = {};
-  for (const [toolName, [operation, pathArg, scope, patternArg]] of Object.entries(
-    FS_TOOL_PATH_ARGS,
-  )) {
+  for (const [
+    toolName,
+    [operation, pathArg, scope, patternArg],
+  ] of Object.entries(FS_TOOL_PATH_ARGS)) {
     if (
       !rules.some(
-        (rule) => rule.mode === "interrupt" && rule.operations.includes(operation),
+        (rule) =>
+          rule.mode === "interrupt" && rule.operations.includes(operation),
       )
     ) {
       continue;

--- a/libs/deepagents/src/middleware/fs-interrupt.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.ts
@@ -16,6 +16,7 @@ import type {
 import {
   globAnchor,
   pathsOverlap,
+  stripTrailingSlashes,
   toPosixPath,
 } from "../permissions/path-utils.js";
 
@@ -62,7 +63,7 @@ function makeExactWhenPredicate(
  */
 function representativeProbePath(callPath: string, rulePattern: string): string {
   const anchor = globAnchor(rulePattern);
-  const call = callPath.replace(/\/+$/, "") || "/";
+  const call = stripTrailingSlashes(callPath) || "/";
 
   if (call === "/") {
     if (rulePattern.includes("**")) {

--- a/libs/deepagents/src/middleware/fs-interrupt.ts
+++ b/libs/deepagents/src/middleware/fs-interrupt.ts
@@ -204,7 +204,7 @@ function makeBulkWhenPredicate(
   };
 }
 
-function makeFsWhenPredicate(
+export function makeFsWhenPredicate(
   rules: readonly FilesystemPermission[],
   operation: FilesystemOperation,
   pathArgName: string,
@@ -273,10 +273,3 @@ export function mergeFsInterruptOn(
     ...(userInterruptOn ?? {}),
   };
 }
-
-/** @internal Exported for unit tests. */
-export const _testExports = {
-  makeFsWhenPredicate,
-  bulkSubtreeCouldInterrupt,
-  FS_TOOL_PATH_ARGS,
-};

--- a/libs/deepagents/src/middleware/fs.permissions.test.ts
+++ b/libs/deepagents/src/middleware/fs.permissions.test.ts
@@ -44,6 +44,12 @@ const denyWrite = (paths: string[]) => ({
   mode: "deny" as const,
 });
 
+const interruptRead = (paths: string[]) => ({
+  operations: ["read"] as const,
+  paths,
+  mode: "interrupt" as const,
+});
+
 describe("fs tool permissions", () => {
   describe("no permissions configured", () => {
     it("all tools operate normally when permissions is empty", async () => {
@@ -301,6 +307,24 @@ describe("fs tool permissions", () => {
 
       const result = await getTool(middleware, "ls").invoke({ path: "/" });
       expect(result).toMatch(/no files found/i);
+    });
+
+    it("does not post-filter interrupt-mode paths from results", async () => {
+      const backend = createMockBackend();
+      backend.ls = vi.fn().mockResolvedValue({
+        files: [
+          { path: "/secret/a.txt", is_dir: false },
+          { path: "/public/b.txt", is_dir: false },
+        ],
+      });
+      const middleware = createFilesystemMiddleware({
+        backend,
+        permissions: [interruptRead(["/secret/**"])],
+      });
+
+      const result = await getTool(middleware, "ls").invoke({ path: "/" });
+      expect(result).toContain("/secret/a.txt");
+      expect(result).toContain("/public/b.txt");
     });
   });
 

--- a/libs/deepagents/src/permissions/enforce.ts
+++ b/libs/deepagents/src/permissions/enforce.ts
@@ -69,7 +69,7 @@ export function globMatch(path: string, pattern: string): boolean {
  *
  * First-match-wins; permissive default.
  *
- * @returns `"allow"` if the operation is permitted, `"deny"` otherwise.
+ * @returns The matched rule's mode, or `"allow"` when no rule matches.
  */
 export function decidePathAccess(
   rules: readonly FilesystemPermission[],

--- a/libs/deepagents/src/permissions/path-utils.test.ts
+++ b/libs/deepagents/src/permissions/path-utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { globAnchor, pathsOverlap, toPosixPath } from "./path-utils.js";
+
+describe("toPosixPath", () => {
+  it("normalizes backslashes", () => {
+    expect(toPosixPath("C:\\workspace\\file")).toBe("C:/workspace/file");
+  });
+});
+
+describe("globAnchor", () => {
+  it("returns longest wildcard-free prefix", () => {
+    expect(globAnchor("/foo/bar/**")).toBe("/foo/bar");
+  });
+});
+
+describe("pathsOverlap", () => {
+  it("treats root as overlapping everything", () => {
+    expect(pathsOverlap("/", "/secrets")).toBe(true);
+  });
+});

--- a/libs/deepagents/src/permissions/path-utils.test.ts
+++ b/libs/deepagents/src/permissions/path-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { globAnchor, pathsOverlap, toPosixPath } from "./path-utils.js";
+import {
+  globAnchor,
+  pathsOverlap,
+  stripTrailingSlashes,
+  toPosixPath,
+} from "./path-utils.js";
 
 describe("toPosixPath", () => {
   it("normalizes backslashes", () => {
@@ -16,5 +21,17 @@ describe("globAnchor", () => {
 describe("pathsOverlap", () => {
   it("treats root as overlapping everything", () => {
     expect(pathsOverlap("/", "/secrets")).toBe(true);
+  });
+});
+
+describe("stripTrailingSlashes", () => {
+  it("removes trailing slashes", () => {
+    expect(stripTrailingSlashes("/foo/bar/")).toBe("/foo/bar");
+    expect(stripTrailingSlashes("/")).toBe("");
+  });
+
+  it("handles long runs of trailing slashes in linear time", () => {
+    const path = `/foo${"/".repeat(10_000)}`;
+    expect(stripTrailingSlashes(path)).toBe("/foo");
   });
 });

--- a/libs/deepagents/src/permissions/path-utils.ts
+++ b/libs/deepagents/src/permissions/path-utils.ts
@@ -7,6 +7,15 @@ export function toPosixPath(path: string): string {
   return path.replace(/\\/g, "/");
 }
 
+/** Strip trailing `/` characters in O(n) time without regex backtracking. */
+export function stripTrailingSlashes(path: string): string {
+  let end = path.length;
+  while (end > 0 && path[end - 1] === "/") {
+    end--;
+  }
+  return end === path.length ? path : path.slice(0, end);
+}
+
 /**
  * Return the longest leading directory of `pattern` with no wildcards.
  *
@@ -34,7 +43,7 @@ export function globAnchor(pattern: string): string {
 }
 
 function pathComponents(path: string): string[] {
-  const trimmed = toPosixPath(path).replace(/\/+$/, "");
+  const trimmed = stripTrailingSlashes(toPosixPath(path));
   if (!trimmed || trimmed === "/") {
     return [];
   }

--- a/libs/deepagents/src/permissions/path-utils.ts
+++ b/libs/deepagents/src/permissions/path-utils.ts
@@ -1,0 +1,66 @@
+const GLOB_WILDCARD_CHARS = new Set(["*", "?", "[", "{"]);
+
+/**
+ * Normalize backslash separators to forward slashes for POSIX path logic.
+ */
+export function toPosixPath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+/**
+ * Return the longest leading directory of `pattern` with no wildcards.
+ *
+ * For `/secrets/**` returns `/secrets`; for patterns with a leading globstar
+ * falls back to `/`.
+ */
+export function globAnchor(pattern: string): string {
+  const parts = toPosixPath(pattern)
+    .split("/")
+    .filter((part) => part.length > 0);
+
+  const safe: string[] = [];
+  for (const part of parts) {
+    if ([...part].some((char) => GLOB_WILDCARD_CHARS.has(char))) {
+      break;
+    }
+    safe.push(part);
+  }
+
+  if (safe.length === 0) {
+    return "/";
+  }
+
+  return `/${safe.join("/")}`;
+}
+
+function pathComponents(path: string): string[] {
+  const trimmed = toPosixPath(path).replace(/\/+$/, "");
+  if (!trimmed || trimmed === "/") {
+    return [];
+  }
+
+  return trimmed.split("/").filter((part) => part.length > 0);
+}
+
+/**
+ * Return true when the subtree at `callPath` intersects `ruleAnchor`.
+ *
+ * Component-wise prefix check: `/secret` does not overlap `/secrets`.
+ * Root `/` overlaps everything.
+ */
+export function pathsOverlap(callPath: string, ruleAnchor: string): boolean {
+  const a = pathComponents(callPath);
+  const b = pathComponents(ruleAnchor);
+
+  if (a.length === 0 || b.length === 0) {
+    return true;
+  }
+
+  const aKey = a.join("/");
+  const bKey = b.join("/");
+  if (aKey === bKey) {
+    return true;
+  }
+
+  return aKey.startsWith(`${bKey}/`) || bKey.startsWith(`${aKey}/`);
+}

--- a/libs/deepagents/src/permissions/types.ts
+++ b/libs/deepagents/src/permissions/types.ts
@@ -4,9 +4,9 @@
 export type FilesystemOperation = "read" | "write";
 
 /**
- * Whether a matched rule permits or blocks the operation.
+ * Whether a matched rule permits, blocks, or pauses the operation for approval.
  */
-export type PermissionMode = "allow" | "deny";
+export type PermissionMode = "allow" | "deny" | "interrupt";
 
 /**
  * A single filesystem permission rule.
@@ -34,7 +34,13 @@ export interface FilesystemPermission {
   paths: string[];
 
   /**
-   * Whether matching paths are permitted or blocked. Defaults to `"allow"`.
+   * Whether matching paths are permitted, blocked, or paused for human approval.
+   *
+   * - `"allow"` (default): operation proceeds normally.
+   * - `"deny"`: operation is rejected with a permission error.
+   * - `"interrupt"`: matching tool calls pause for human approval via
+   *   `HumanInTheLoopMiddleware` (auto-installed when any interrupt-mode
+   *   rule is present).
    */
   mode?: PermissionMode;
 }

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -625,6 +625,11 @@ export interface CreateDeepAgentParams<
    * and `grep`. Subagents inherit these rules unless they specify their own
    * `permissions` field.
    *
+   * Use `mode: "interrupt"` to pause matching tool calls for human approval.
+   * `HumanInTheLoopMiddleware` is auto-installed when any interrupt-mode rule
+   * is present, and generated `interruptOn` entries are merged with the
+   * `interruptOn` argument (user-supplied entries win per tool name).
+   *
    * @example
    * ```ts
    * createDeepAgent({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,13 +62,13 @@ importers:
         version: link:../../internal/eval-harness
       '@langchain/langgraph':
         specifier: ^1.2.9
-        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       deepagents:
         specifier: workspace:*
         version: link:../../libs/deepagents
       langchain:
         specifier: ^1.3.1
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
+        version: 1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
       langsmith:
         specifier: ^0.7.4
         version: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -149,13 +149,13 @@ importers:
         version: link:../../internal/eval-harness
       '@langchain/langgraph':
         specifier: ^1.2.9
-        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       deepagents:
         specifier: workspace:*
         version: link:../../libs/deepagents
       langchain:
         specifier: ^1.3.1
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
+        version: 1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
       langsmith:
         specifier: ^0.7.4
         version: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -191,7 +191,7 @@ importers:
         version: link:../../internal/eval-harness
       '@langchain/langgraph':
         specifier: ^1.2.9
-        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       deepagents:
         specifier: workspace:*
         version: link:../../libs/deepagents
@@ -209,7 +209,7 @@ importers:
         version: link:../../internal/eval-harness
       '@langchain/langgraph':
         specifier: ^1.2.9
-        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       deepagents:
         specifier: workspace:*
         version: link:../../libs/deepagents
@@ -264,7 +264,7 @@ importers:
         version: link:../../libs/deepagents
       langchain:
         specifier: ^1.3.1
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
+        version: 1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       langsmith:
         specifier: ^0.7.4
         version: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -282,7 +282,7 @@ importers:
         version: link:../../internal/eval-harness
       '@langchain/langgraph':
         specifier: ^1.2.9
-        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       deepagents:
         specifier: workspace:*
         version: link:../../libs/deepagents
@@ -303,7 +303,7 @@ importers:
         version: link:../../libs/deepagents
       langchain:
         specifier: ^1.3.1
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
+        version: 1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       langsmith:
         specifier: ^0.7.4
         version: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -339,7 +339,7 @@ importers:
         version: link:../../libs/deepagents
       langchain:
         specifier: ^1.3.1
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
+        version: 1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       langsmith:
         specifier: ^0.7.4
         version: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -360,7 +360,7 @@ importers:
         version: link:../../libs/deepagents
       langchain:
         specifier: ^1.3.1
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
+        version: 1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       langsmith:
         specifier: ^0.7.4
         version: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -487,7 +487,7 @@ importers:
     dependencies:
       '@langchain/langgraph-sdk':
         specifier: ^1.8.0
-        version: 1.9.15(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.9.15(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -606,20 +606,20 @@ importers:
   libs/deepagents:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
-        version: 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+        specifier: 1.1.49-dev-1781048185730
+        version: 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/langgraph':
         specifier: ^1.3.0
-        version: 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       '@langchain/langgraph-sdk':
         specifier: ^1.9.1
-        version: 1.9.15(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.9.15(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
       langchain:
-        specifier: ^1.4.0
-        version: 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
+        specifier: 1.4.5-dev-1781048185730
+        version: 1.4.5-dev-1781048185730(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0)
       langsmith:
         specifier: ^0.7.1
         version: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -635,19 +635,19 @@ importers:
     devDependencies:
       '@langchain/anthropic':
         specifier: ^1.3.26
-        version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        version: 1.4.0(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/langgraph-checkpoint':
         specifier: ^1.0.2
-        version: 1.0.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        version: 1.0.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/openai':
         specifier: ^1.4.1
-        version: 1.4.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
+        version: 1.4.7(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
       '@langchain/sandbox-standard-tests':
         specifier: workspace:*
         version: link:../standard-tests
       '@langchain/tavily':
         specifier: ^1.2.0
-        version: 1.2.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        version: 1.2.0(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@tsconfig/recommended':
         specifier: ^1.0.13
         version: 1.0.13
@@ -1472,6 +1472,10 @@ packages:
 
   '@langchain/core@1.1.48':
     resolution: {integrity: sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==}
+    engines: {node: '>=20'}
+
+  '@langchain/core@1.1.49-dev-1781048185730':
+    resolution: {integrity: sha512-a0Au9qwt40Rp0Pwr/8bAhR7zSLpi/GiBqVn8iHbJ6DfbIRR2DrYIe0DWlQm9EP1jZCrg9Dx+krxSuej3LqOrwQ==}
     engines: {node: '>=20'}
 
   '@langchain/langgraph-checkpoint@1.0.4':
@@ -3126,6 +3130,12 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.1.48
+
+  langchain@1.4.5-dev-1781048185730:
+    resolution: {integrity: sha512-gaFG4ZEStm60b6MUld+yYNeaKL1pWfjHXrPbE8PUyI5IIqJlYU88G4E+vvr6FHThqqc/ySh27DHOsq/jrxAkdg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.49-dev-1781048185730
 
   langsmith@0.7.1:
     resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
@@ -4839,7 +4849,29 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       zod: 4.4.3
 
+  '@langchain/anthropic@1.4.0(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+    dependencies:
+      '@anthropic-ai/sdk': 0.95.2(zod@4.4.3)
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      zod: 4.4.3
+
   '@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -4860,9 +4892,35 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       uuid: 14.0.0
 
+  '@langchain/langgraph-checkpoint@1.0.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      uuid: 14.0.0
+
   '@langchain/langgraph-sdk@1.9.15(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/protocol': 0.0.16
+      '@types/json-schema': 7.0.15
+      p-queue: 9.3.0
+      p-retry: 7.1.1
+      uuid: 14.0.0
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@langchain/langgraph-sdk@1.9.15(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/protocol': 0.0.16
+      '@types/json-schema': 7.0.15
+      p-queue: 9.3.0
+      p-retry: 7.1.1
+      uuid: 14.0.0
+
+  '@langchain/langgraph-sdk@1.9.15(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/protocol': 0.0.16
       '@types/json-schema': 7.0.15
       p-queue: 9.3.0
@@ -4887,9 +4945,48 @@ snapshots:
       - svelte
       - vue
 
+  '@langchain/langgraph@1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/langgraph-sdk': 1.9.15(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@langchain/protocol': 0.0.16
+      '@standard-schema/spec': 1.1.0
+      uuid: 14.0.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@langchain/langgraph@1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/langgraph-sdk': 1.9.15(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/protocol': 0.0.16
+      '@standard-schema/spec': 1.1.0
+      uuid: 14.0.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+
   '@langchain/openai@1.4.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      js-tiktoken: 1.0.21
+      openai: 6.42.0(ws@8.20.0)(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/openai@1.4.7(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       js-tiktoken: 1.0.21
       openai: 6.42.0(ws@8.20.0)(zod@4.4.3)
       zod: 4.4.3
@@ -4901,6 +4998,11 @@ snapshots:
   '@langchain/tavily@1.2.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      zod: 4.4.3
+
+  '@langchain/tavily@1.2.0(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       zod: 4.4.3
 
   '@manypkg/find-root@1.1.0':
@@ -6276,6 +6378,63 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/langgraph': 1.3.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      langsmith: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  langchain@1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0):
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      langsmith: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  langchain@1.4.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0):
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      langsmith: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  langchain@1.4.5-dev-1781048185730(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.20.0):
+    dependencies:
+      '@langchain/core': 1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.49-dev-1781048185730(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       langsmith: 0.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.42.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       zod: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Add `mode: "interrupt"` to `FilesystemPermission`, pausing matching filesystem tool calls for human approval instead of denying or running silently.
- Auto-install `HumanInTheLoopMiddleware` in `createDeepAgent` when any interrupt-mode permission rule exists; merge fs-derived `interruptOn` with user `interruptOn` (user wins per tool name) on the main agent, GP subagent, and declarative subagents.
- Introduce scope-aware `when` predicates in `middleware/fs-interrupt.ts` so interrupts fire only when calls intersect protected paths—literal match for exact tools (`read_file`, `write_file`, `edit_file`) and subtree overlap for bulk tools (`ls`, `glob`, `grep`), including fixes for pathless calls, current-dir aliases (`.`, `""`, `./`), and absolute `**` glob patterns.
- Bump `langchain` and `@langchain/core` to `1.4.5-dev-1781048185730` / `1.1.49-dev-1781048185730` for `when` predicate support (JS HITL uses approve / edit / reject; no Python `respond` decision yet).
