### PR TITLE
chore(deepagents): expose `createSubAgent`

### DIFF
--- a/.changeset/eager-badgers-greet.md
+++ b/.changeset/eager-badgers-greet.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+chore(deepagents): expose createSubAgent

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -31,7 +31,7 @@ import { createDeepAgent } from "../agent.js";
 import { createSkillsMiddleware } from "./skills.js";
 import { createFileData } from "../backends/utils.js";
 import { createMockBackend } from "./test.js";
-import { createSubAgent, type SubAgent } from "./subagents.js";
+import { createSubAgent } from "./subagents.js";
 
 const createAgentMock = vi.mocked(createAgent);
 
@@ -1030,14 +1030,13 @@ describe("createSubAgent", () => {
   });
 
   it("compiles a declarative spec into a runnable via createAgent", () => {
-    const spec: SubAgent = {
+    createSubAgent({
       name: "worker",
       description: "Does work",
       systemPrompt: "Work on the task.",
+      model: fakeModel,
       tools: [getWeather],
-    };
-
-    createSubAgent(spec, { defaultModel: fakeModel });
+    });
 
     expect(createAgentMock).toHaveBeenCalledOnce();
     const call = createAgentMock.mock.calls[0][0];
@@ -1047,68 +1046,54 @@ describe("createSubAgent", () => {
     expect(call.name).toBe("worker");
   });
 
-  it("uses spec model over default when provided", () => {
-    const specModel = new FakeListChatModel({ responses: ["hello"] });
-    const spec: SubAgent = {
-      name: "worker",
-      description: "Does work",
-      systemPrompt: "Work.",
-      model: specModel,
-    };
-
-    createSubAgent(spec, { defaultModel: fakeModel });
-
-    const call = createAgentMock.mock.calls[0][0];
-    expect(call.model).toBe(specModel);
+  it("throws when model is missing", () => {
+    expect(() =>
+      createSubAgent({
+        name: "worker",
+        description: "Does work",
+        systemPrompt: "Work.",
+        tools: [getWeather],
+      }),
+    ).toThrow("SubAgent 'worker' must specify 'model'");
   });
 
-  it("falls back to defaultTools when spec omits tools", () => {
-    const spec: SubAgent = {
-      name: "worker",
-      description: "Does work",
-      systemPrompt: "Work.",
-    };
-
-    createSubAgent(spec, {
-      defaultModel: fakeModel,
-      defaultTools: [getWeather],
-    });
-
-    const call = createAgentMock.mock.calls[0][0];
-    expect(call.tools).toEqual([getWeather]);
+  it("throws when tools is missing", () => {
+    expect(() =>
+      createSubAgent({
+        name: "worker",
+        description: "Does work",
+        systemPrompt: "Work.",
+        model: fakeModel,
+      }),
+    ).toThrow("SubAgent 'worker' must specify 'tools'");
   });
 
-  it("prepends defaultMiddleware before spec middleware", () => {
-    const baseMiddleware = { name: "base" } as unknown as AgentMiddleware;
+  it("passes middleware through to createAgent", () => {
     const customMiddleware = { name: "custom" } as unknown as AgentMiddleware;
 
-    const spec: SubAgent = {
+    createSubAgent({
       name: "worker",
       description: "Does work",
       systemPrompt: "Work.",
+      model: fakeModel,
+      tools: [getWeather],
       middleware: [customMiddleware],
-    };
-
-    createSubAgent(spec, {
-      defaultModel: fakeModel,
-      defaultMiddleware: [baseMiddleware],
     });
 
     const call = createAgentMock.mock.calls[0][0];
     const middleware = call.middleware as AgentMiddleware[];
-    expect(middleware[0]).toBe(baseMiddleware);
-    expect(middleware[1]).toBe(customMiddleware);
+    expect(middleware[0]).toBe(customMiddleware);
   });
 
   it("appends humanInTheLoopMiddleware when interruptOn is specified", () => {
-    const spec: SubAgent = {
+    createSubAgent({
       name: "worker",
       description: "Does work",
       systemPrompt: "Work.",
+      model: fakeModel,
+      tools: [getWeather],
       interruptOn: { get_weather: true },
-    };
-
-    createSubAgent(spec, { defaultModel: fakeModel });
+    });
 
     const call = createAgentMock.mock.calls[0][0];
     const middleware = call.middleware as AgentMiddleware[];
@@ -1116,46 +1101,30 @@ describe("createSubAgent", () => {
     expect(middleware[0]).toHaveProperty("name");
   });
 
-  it("falls back to defaultInterruptOn when spec omits interruptOn", () => {
-    const spec: SubAgent = {
-      name: "worker",
-      description: "Does work",
-      systemPrompt: "Work.",
-    };
-
-    createSubAgent(spec, {
-      defaultModel: fakeModel,
-      defaultInterruptOn: { get_weather: true },
-    });
-
-    const call = createAgentMock.mock.calls[0][0];
-    const middleware = call.middleware as AgentMiddleware[];
-    expect(middleware.length).toBe(1);
-  });
-
   it("forwards responseFormat when specified", () => {
     const schema = z.object({ answer: z.string() });
-    const spec: SubAgent = {
+
+    createSubAgent({
       name: "worker",
       description: "Does work",
       systemPrompt: "Work.",
+      model: fakeModel,
+      tools: [getWeather],
       responseFormat: schema,
-    };
-
-    createSubAgent(spec, { defaultModel: fakeModel });
+    });
 
     const call = createAgentMock.mock.calls[0][0];
     expect(call.responseFormat).toBe(schema);
   });
 
   it("does not set responseFormat when not specified", () => {
-    const spec: SubAgent = {
+    createSubAgent({
       name: "worker",
       description: "Does work",
       systemPrompt: "Work.",
-    };
-
-    createSubAgent(spec, { defaultModel: fakeModel });
+      model: fakeModel,
+      tools: [],
+    });
 
     const call = createAgentMock.mock.calls[0][0];
     expect(call.responseFormat).toBeUndefined();

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("langchain", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createAgent: vi.fn(actual.createAgent as (...args: unknown[]) => unknown),
+  };
+});
+
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
-import { createAgent, tool } from "langchain";
+import { createAgent, tool, type AgentMiddleware } from "langchain";
 import {
   AIMessage,
   BaseMessage,
@@ -22,6 +31,9 @@ import { createDeepAgent } from "../agent.js";
 import { createSkillsMiddleware } from "./skills.js";
 import { createFileData } from "../backends/utils.js";
 import { createMockBackend } from "./test.js";
+import { createSubAgent, type SubAgent } from "./subagents.js";
+
+const createAgentMock = vi.mocked(createAgent);
 
 /**
  * Helper to get all system prompts from model invoke spy calls.
@@ -1001,5 +1013,151 @@ describe("lc_agent_name propagation for subagents", () => {
     );
 
     expect(capturedSubagentAgentName).toBe("worker");
+  });
+});
+
+describe("createSubAgent", () => {
+  const fakeModel = new FakeListChatModel({ responses: ["hello"] });
+
+  const getWeather = tool(async () => "sunny", {
+    name: "get_weather",
+    description: "Get the weather in a city",
+    schema: z.object({ city: z.string() }),
+  });
+
+  beforeEach(() => {
+    createAgentMock.mockClear();
+  });
+
+  it("compiles a declarative spec into a runnable via createAgent", () => {
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work on the task.",
+      tools: [getWeather],
+    };
+
+    createSubAgent(spec, { defaultModel: fakeModel });
+
+    expect(createAgentMock).toHaveBeenCalledOnce();
+    const call = createAgentMock.mock.calls[0][0];
+    expect(call.model).toBe(fakeModel);
+    expect(call.systemPrompt).toBe("Work on the task.");
+    expect(call.tools).toEqual([getWeather]);
+    expect(call.name).toBe("worker");
+  });
+
+  it("uses spec model over default when provided", () => {
+    const specModel = new FakeListChatModel({ responses: ["hello"] });
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work.",
+      model: specModel,
+    };
+
+    createSubAgent(spec, { defaultModel: fakeModel });
+
+    const call = createAgentMock.mock.calls[0][0];
+    expect(call.model).toBe(specModel);
+  });
+
+  it("falls back to defaultTools when spec omits tools", () => {
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work.",
+    };
+
+    createSubAgent(spec, {
+      defaultModel: fakeModel,
+      defaultTools: [getWeather],
+    });
+
+    const call = createAgentMock.mock.calls[0][0];
+    expect(call.tools).toEqual([getWeather]);
+  });
+
+  it("prepends defaultMiddleware before spec middleware", () => {
+    const baseMiddleware = { name: "base" } as unknown as AgentMiddleware;
+    const customMiddleware = { name: "custom" } as unknown as AgentMiddleware;
+
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work.",
+      middleware: [customMiddleware],
+    };
+
+    createSubAgent(spec, {
+      defaultModel: fakeModel,
+      defaultMiddleware: [baseMiddleware],
+    });
+
+    const call = createAgentMock.mock.calls[0][0];
+    const middleware = call.middleware as AgentMiddleware[];
+    expect(middleware[0]).toBe(baseMiddleware);
+    expect(middleware[1]).toBe(customMiddleware);
+  });
+
+  it("appends humanInTheLoopMiddleware when interruptOn is specified", () => {
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work.",
+      interruptOn: { get_weather: true },
+    };
+
+    createSubAgent(spec, { defaultModel: fakeModel });
+
+    const call = createAgentMock.mock.calls[0][0];
+    const middleware = call.middleware as AgentMiddleware[];
+    expect(middleware.length).toBe(1);
+    expect(middleware[0]).toHaveProperty("name");
+  });
+
+  it("falls back to defaultInterruptOn when spec omits interruptOn", () => {
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work.",
+    };
+
+    createSubAgent(spec, {
+      defaultModel: fakeModel,
+      defaultInterruptOn: { get_weather: true },
+    });
+
+    const call = createAgentMock.mock.calls[0][0];
+    const middleware = call.middleware as AgentMiddleware[];
+    expect(middleware.length).toBe(1);
+  });
+
+  it("forwards responseFormat when specified", () => {
+    const schema = z.object({ answer: z.string() });
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work.",
+      responseFormat: schema,
+    };
+
+    createSubAgent(spec, { defaultModel: fakeModel });
+
+    const call = createAgentMock.mock.calls[0][0];
+    expect(call.responseFormat).toBe(schema);
+  });
+
+  it("does not set responseFormat when not specified", () => {
+    const spec: SubAgent = {
+      name: "worker",
+      description: "Does work",
+      systemPrompt: "Work.",
+    };
+
+    createSubAgent(spec, { defaultModel: fakeModel });
+
+    const call = createAgentMock.mock.calls[0][0];
+    expect(call.responseFormat).toBeUndefined();
   });
 });

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -472,6 +472,74 @@ function returnCommandWithStateUpdate(
 }
 
 /**
+ * Options for creating a subagent from a declarative spec.
+ */
+export interface CreateSubAgentOptions {
+  /**
+   * Fallback model when the spec omits `model`.
+   */
+  defaultModel: LanguageModelLike | string;
+
+  /**
+   * Fallback tools when the spec omits `tools`.
+   */
+  defaultTools?: StructuredTool[];
+
+  /**
+   * Base middleware prepended to the spec's own middleware.
+   */
+  defaultMiddleware?: AgentMiddleware[];
+
+  /**
+   * Fallback interrupt-on config when the spec omits `interruptOn`.
+   */
+  defaultInterruptOn?: Record<string, boolean | InterruptOnConfig> | null;
+}
+
+/**
+ * Create a runnable agent from a declarative `SubAgent` spec.
+ *
+ * This is the shared entrypoint for compiling a `SubAgent` into a
+ * `ReactAgent`. Pre-compiled `CompiledSubAgent` runnables bypass this
+ * function entirely.
+ *
+ * @param spec - Declarative subagent specification.
+ * @param options - Default model, tools, middleware, and interrupt-on config.
+ * @returns A compiled `ReactAgent` ready for task-tool invocation.
+ */
+export function createSubAgent(
+  spec: SubAgent,
+  options: CreateSubAgentOptions,
+): ReactAgent {
+  const {
+    defaultModel,
+    defaultTools = [],
+    defaultMiddleware = [],
+    defaultInterruptOn = null,
+  } = options;
+
+  const middleware: AgentMiddleware[] = spec.middleware
+    ? [...defaultMiddleware, ...spec.middleware]
+    : [...defaultMiddleware];
+
+  const interruptOn = spec.interruptOn || defaultInterruptOn;
+  if (interruptOn) {
+    middleware.push(humanInTheLoopMiddleware({ interruptOn }));
+  }
+
+  return createAgent({
+    model: spec.model ?? defaultModel,
+    systemPrompt: spec.systemPrompt,
+    tools: spec.tools ?? defaultTools,
+    middleware,
+    name: spec.name,
+    ...(spec.responseFormat != null && {
+      responseFormat: spec.responseFormat,
+    }),
+  });
+}
+
+/**
  * Create subagent instances from specifications
  */
 function getSubagents(options: {
@@ -536,23 +604,11 @@ function getSubagents(options: {
     if ("runnable" in agentParams) {
       agents[agentParams.name] = agentParams.runnable;
     } else {
-      const middleware = agentParams.middleware
-        ? [...defaultSubagentMiddleware, ...agentParams.middleware]
-        : [...defaultSubagentMiddleware];
-
-      const interruptOn = agentParams.interruptOn || defaultInterruptOn;
-      if (interruptOn)
-        middleware.push(humanInTheLoopMiddleware({ interruptOn }));
-
-      agents[agentParams.name] = createAgent({
-        model: agentParams.model ?? defaultModel,
-        systemPrompt: agentParams.systemPrompt,
-        tools: agentParams.tools ?? defaultTools,
-        middleware,
-        name: agentParams.name,
-        ...(agentParams.responseFormat != null && {
-          responseFormat: agentParams.responseFormat,
-        }),
+      agents[agentParams.name] = createSubAgent(agentParams, {
+        defaultModel,
+        defaultTools,
+        defaultMiddleware: defaultSubagentMiddleware,
+        defaultInterruptOn,
       });
     }
   }

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -472,65 +472,38 @@ function returnCommandWithStateUpdate(
 }
 
 /**
- * Options for creating a subagent from a declarative spec.
- */
-export interface CreateSubAgentOptions {
-  /**
-   * Fallback model when the spec omits `model`.
-   */
-  defaultModel: LanguageModelLike | string;
-
-  /**
-   * Fallback tools when the spec omits `tools`.
-   */
-  defaultTools?: StructuredTool[];
-
-  /**
-   * Base middleware prepended to the spec's own middleware.
-   */
-  defaultMiddleware?: AgentMiddleware[];
-
-  /**
-   * Fallback interrupt-on config when the spec omits `interruptOn`.
-   */
-  defaultInterruptOn?: Record<string, boolean | InterruptOnConfig> | null;
-}
-
-/**
  * Create a runnable agent from a declarative `SubAgent` spec.
  *
  * This is the shared entrypoint for compiling a `SubAgent` into a
  * `ReactAgent`. Pre-compiled `CompiledSubAgent` runnables bypass this
  * function entirely.
  *
- * @param spec - Declarative subagent specification.
- * @param options - Default model, tools, middleware, and interrupt-on config.
+ * The spec must have `model` and `tools` set — the caller is responsible
+ * for coalescing any defaults before calling this function.
+ *
+ * @param spec - Declarative subagent specification. Must specify `model` and `tools`.
  * @returns A compiled `ReactAgent` ready for task-tool invocation.
  */
-export function createSubAgent(
-  spec: SubAgent,
-  options: CreateSubAgentOptions,
-): ReactAgent {
-  const {
-    defaultModel,
-    defaultTools = [],
-    defaultMiddleware = [],
-    defaultInterruptOn = null,
-  } = options;
+export function createSubAgent(spec: SubAgent): ReactAgent {
+  if (!spec.model) {
+    throw new Error(`SubAgent '${spec.name}' must specify 'model'`);
+  }
+  if (!spec.tools) {
+    throw new Error(`SubAgent '${spec.name}' must specify 'tools'`);
+  }
 
-  const middleware: AgentMiddleware[] = spec.middleware
-    ? [...defaultMiddleware, ...spec.middleware]
-    : [...defaultMiddleware];
+  const middleware: AgentMiddleware[] = [...(spec.middleware ?? [])];
 
-  const interruptOn = spec.interruptOn || defaultInterruptOn;
-  if (interruptOn) {
-    middleware.push(humanInTheLoopMiddleware({ interruptOn }));
+  if (spec.interruptOn) {
+    middleware.push(
+      humanInTheLoopMiddleware({ interruptOn: spec.interruptOn }),
+    );
   }
 
   return createAgent({
-    model: spec.model ?? defaultModel,
+    model: spec.model,
     systemPrompt: spec.systemPrompt,
-    tools: spec.tools ?? defaultTools,
+    tools: spec.tools,
     middleware,
     name: spec.name,
     ...(spec.responseFormat != null && {
@@ -604,11 +577,15 @@ function getSubagents(options: {
     if ("runnable" in agentParams) {
       agents[agentParams.name] = agentParams.runnable;
     } else {
-      agents[agentParams.name] = createSubAgent(agentParams, {
-        defaultModel,
-        defaultTools,
-        defaultMiddleware: defaultSubagentMiddleware,
-        defaultInterruptOn,
+      agents[agentParams.name] = createSubAgent({
+        ...agentParams,
+        model: agentParams.model ?? defaultModel,
+        tools: agentParams.tools ?? defaultTools,
+        middleware: [
+          ...defaultSubagentMiddleware,
+          ...(agentParams.middleware ?? []),
+        ],
+        interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       });
     }
   }


### PR DESCRIPTION
### Summary

Exposes `createSubAgent` as a dedicated function which allows us to reuse the inner subagent factory outside of the middleware (e.g. using it as the single source of truth for defining subagents in quickjs).

Port of similar implementation from https://github.com/langchain-ai/deepagents/pull/3846