### PR TITLE
chore(quickjs): remove configurable concurrency and add subagents option with true default

### DIFF
--- a/.changeset/rare-candies-drop.md
+++ b/.changeset/rare-candies-drop.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+chore(quickjs): remove configurable concurrency and add subagents option with true default

--- a/libs/providers/quickjs/src/index.ts
+++ b/libs/providers/quickjs/src/index.ts
@@ -33,7 +33,6 @@ export {
   DEFAULT_MAX_STACK_SIZE,
   DEFAULT_EXECUTION_TIMEOUT,
   DEFAULT_MAX_PTC_CALLS,
-  DEFAULT_MAX_SUBAGENT_CONCURRENCY,
 } from "./session.js";
 
 export { formatReplResult, toCamelCase } from "./utils.js";

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -363,8 +363,12 @@ export function createCodeInterpreterMiddleware(
     maxResultChars = DEFAULT_MAX_RESULTS_CHARS,
     toolName = DEFAULT_TOOL_NAME,
     captureConsole = true,
-    maxSubagentConcurrency = DEFAULT_MAX_SUBAGENT_CONCURRENCY,
+    subagents = true,
   } = options;
+
+  const maxSubagentConcurrency = subagents
+    ? DEFAULT_MAX_SUBAGENT_CONCURRENCY
+    : 0;
 
   if (maxPtcCalls !== null && maxPtcCalls !== undefined && maxPtcCalls < 1) {
     throw new Error("`maxPtcCalls` must be >= 1 or null");

--- a/libs/providers/quickjs/src/types.ts
+++ b/libs/providers/quickjs/src/types.ts
@@ -78,15 +78,17 @@ export interface CodeInterpreterMiddlewareOptions {
   captureConsole?: boolean;
 
   /**
-   * Maximum concurrent `subagent()` calls from the REPL.
+   * Expose the built-in `task()` global for subagent orchestration.
    *
-   * When subagent specs are available in configurable, a built-in
-   * `subagent()` global is installed in the REPL with this concurrency cap.
-   * Set to `0` to disable the subagent primitive entirely.
+   * When `true` (default) and subagent specs are available, a `task()`
+   * global is installed in the REPL that dispatches subagents
+   * programmatically with a fixed concurrency cap of 32.
+   * Set to `false` to require subagent dispatch through the normal
+   * `task` tool path.
    *
-   * @default 32
+   * @default true
    */
-  maxSubagentConcurrency?: number;
+  subagents?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Summary

This PR remove the configurable concurrency option from code interpreter middleware options and adds a subagents option that is true by default