### PR TITLE
fix(deepagents): count tokens once per model call in summarization middleware

### DIFF
--- a/.changeset/summarization-count-tokens-once.md
+++ b/.changeset/summarization-count-tokens-once.md
@@ -1,0 +1,10 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): count tokens once per model call in summarization middleware
+
+`createSummarizationMiddleware` counted tokens twice on every model call—once
+inside `truncateArgs` and again for the should-summarize check—even when
+nothing was truncated or summarized. Count once and pass the total into
+`truncateArgs`; recount only when truncation actually modifies messages.

--- a/libs/deepagents/src/middleware/summarization.test.ts
+++ b/libs/deepagents/src/middleware/summarization.test.ts
@@ -14,6 +14,20 @@ import type {
 } from "../backends/protocol.js";
 import { createMockBackend } from "./test.js";
 
+const mockCountTokensApproximately = vi.hoisted(() => vi.fn());
+
+vi.mock("langchain", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("langchain")>();
+  mockCountTokensApproximately.mockImplementation(
+    actual.countTokensApproximately,
+  );
+
+  return {
+    ...actual,
+    countTokensApproximately: mockCountTokensApproximately,
+  };
+});
+
 // Mock the initChatModel function from langchain/chat_models/universal
 vi.mock("langchain/chat_models/universal", () => {
   return {
@@ -462,6 +476,31 @@ describe("createSummarizationMiddleware", () => {
   });
 
   describe("argument truncation", () => {
+    it("should count tokens once when nothing is truncated or summarized", async () => {
+      const middleware = createSummarizationMiddleware({
+        model: "gpt-4o-mini",
+        backend: createMockBackend(),
+        trigger: { type: "messages", value: 10 },
+        truncateArgsSettings: {
+          trigger: { type: "tokens", value: 1_000_000 },
+          keep: { type: "messages", value: 1 },
+        },
+      });
+
+      const messages = [
+        new HumanMessage({ content: "Hello" }),
+        new AIMessage({ content: "Hi there!" }),
+      ];
+
+      const { result, capturedRequest } = await callWrapModelCall(middleware, {
+        messages,
+      });
+
+      expect(AIMessage.isInstance(result)).toBe(true);
+      expect(capturedRequest?.messages).toEqual(messages);
+      expect(mockCountTokensApproximately).toHaveBeenCalledTimes(1);
+    });
+
     it("should truncate large tool call arguments", async () => {
       const mockBackend = createMockBackend();
       const middleware = createSummarizationMiddleware({

--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -758,8 +758,10 @@ export function createSummarizationMiddleware(
     maxInputTokens?: number,
     systemMessage?: SystemMessage | unknown,
     tools?: (ServerTool | ClientTool)[] | unknown[],
+    options?: { totalTokens?: number },
   ): { messages: BaseMessage[]; modified: boolean } {
-    const totalTokens = countTotalTokens(messages, systemMessage, tools);
+    const totalTokens =
+      options?.totalTokens ?? countTotalTokens(messages, systemMessage, tools);
     if (!shouldTruncateArgs(messages, totalTokens, maxInputTokens)) {
       return { messages, modified: false };
     }
@@ -1205,30 +1207,39 @@ export function createSummarizationMiddleware(
       const maxInputTokens = getMaxInputTokens(resolvedModel);
       applyModelDefaults(resolvedModel);
 
+      const totalTokens = countTotalTokens(
+        effectiveMessages,
+        request.systemMessage,
+        request.tools,
+      );
+
       /**
        * Step 1: Truncate args if configured
        */
-      const { messages: truncatedMessages } = truncateArgs(
-        effectiveMessages,
-        maxInputTokens,
-        request.systemMessage,
-        request.tools,
-      );
+      const { messages: truncatedMessages, modified: truncateModified } =
+        truncateArgs(
+          effectiveMessages,
+          maxInputTokens,
+          request.systemMessage,
+          request.tools,
+          { totalTokens },
+        );
 
       /**
        * Step 2: Check if summarization should happen.
-       * Count tokens including system message and tools to match what's
-       * actually sent to the model (matching Python implementation).
+       * Recount only if truncation changed messages.
        */
-      const totalTokens = countTotalTokens(
-        truncatedMessages,
-        request.systemMessage,
-        request.tools,
-      );
+      const tokensForSummary = truncateModified
+        ? countTotalTokens(
+            truncatedMessages,
+            request.systemMessage,
+            request.tools,
+          )
+        : totalTokens;
 
       const shouldDoSummarization = shouldSummarize(
         truncatedMessages,
-        totalTokens,
+        tokensForSummary,
         maxInputTokens,
       );
 
@@ -1248,8 +1259,8 @@ export function createSummarizationMiddleware(
             throw err;
           }
 
-          if (maxInputTokens && totalTokens > 0) {
-            const observedRatio = maxInputTokens / totalTokens;
+          if (maxInputTokens && tokensForSummary > 0) {
+            const observedRatio = maxInputTokens / tokensForSummary;
             if (observedRatio > tokenEstimationMultiplier) {
               tokenEstimationMultiplier = observedRatio * 1.1;
             }


### PR DESCRIPTION
## Summary
- Port [langchain-ai/deepagents#3877](https://github.com/langchain-ai/deepagents/pull/3877): `createSummarizationMiddleware` now counts tokens once per model call instead of twice on the common pass-through path.
- Pass the precomputed total into `truncateArgs` via an optional `totalTokens` parameter; recount only when truncation modifies messages.
- Add a regression test asserting `countTokensApproximately` runs exactly once when nothing is truncated or summarized.
