### PR TITLE
ci(infra): pin actions/checkout to commit SHA in release workflow

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
The `build` job in the CLI release workflow referenced `actions/checkout@v6` by tag while every other action across the repo's workflows is pinned to a full commit SHA. Pinning it closes the one remaining mutable-tag reference so CI can't silently pull a re-tagged action.

## Changes
- Pin `actions/checkout` in the `cli-release.yml` `build` job to `8e8c483…90e8` (`v6.0.1`) — the same SHA used by the repo's other checkout steps.