### PR TITLE
fix(deepagents): avoid concurrent jumpTo clears

### DIFF
--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -3,15 +3,62 @@ import { createDeepAgent } from "./agent.js";
 import { isAnthropicModel } from "./utils.js";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
 import {
+  AIMessage,
   HumanMessage,
   SystemMessage,
+  ToolMessage,
   type BaseMessage,
 } from "@langchain/core/messages";
 import { MemorySaver, StateSchema } from "@langchain/langgraph";
+import { createMiddleware, toolStrategy } from "langchain";
 import { createFileData } from "./backends/utils.js";
 import { ConfigurationError } from "./errors.js";
 import { assertAllDeepAgentQualities } from "./testing/utils.js";
 import { z } from "zod/v4";
+
+class FakeListToolCallingChatModel extends FakeListChatModel {
+  get profile() {
+    return {
+      toolCalling: true,
+      structuredOutput: true,
+    };
+  }
+
+  bindTools(_tools: unknown[]) {
+    return this;
+  }
+
+  _formatGeneration(response: string) {
+    try {
+      const payload = JSON.parse(response) as {
+        content?: string;
+        tool_calls?: Array<{
+          name: string;
+          args: Record<string, unknown>;
+          id?: string;
+        }>;
+      };
+
+      if (Array.isArray(payload.tool_calls)) {
+        return {
+          message: new AIMessage({
+            content: payload.content ?? "",
+            tool_calls: payload.tool_calls.map((toolCall, index) => ({
+              ...toolCall,
+              id: toolCall.id ?? `call_${index + 1}`,
+              type: "tool_call",
+            })),
+          }),
+          text: payload.content ?? "",
+        };
+      }
+    } catch {
+      // Fall back to plain text responses.
+    }
+
+    return super._formatGeneration(response);
+  }
+}
 
 describe("isAnthropicModel", () => {
   it("should detect claude model strings", () => {
@@ -183,5 +230,57 @@ describe("State schema propagation", () => {
     const channelNames = Object.keys(agent.graph?.channels ?? {});
     expect(channelNames).toContain("foo");
     assertAllDeepAgentQualities(agent);
+  });
+});
+
+describe("Structured output middleware regression", () => {
+  it("does not throw concurrent jumpTo updates during structured output retry with no-op afterModel middleware", async () => {
+    const responseFormat = toolStrategy(z.object({ answer: z.string() }));
+    const toolName = responseFormat[0].name;
+    const model = new FakeListToolCallingChatModel({
+      responses: [
+        JSON.stringify({
+          content: "",
+          tool_calls: [{ name: toolName, args: { wrong: 123 }, id: "call_1" }],
+        }),
+        JSON.stringify({
+          content: "",
+          tool_calls: [
+            { name: toolName, args: { answer: "correct" }, id: "call_2" },
+          ],
+        }),
+      ],
+    });
+
+    const noopAfterModelA = createMiddleware({
+      name: "NoopAfterModelA",
+      afterModel: async () => undefined,
+    });
+    const noopAfterModelB = createMiddleware({
+      name: "NoopAfterModelB",
+      afterModel: async () => undefined,
+    });
+
+    const agent = createDeepAgent({
+      model,
+      tools: [],
+      subagents: [],
+      responseFormat,
+      middleware: [noopAfterModelA, noopAfterModelB],
+    });
+
+    const result = await agent.invoke({
+      messages: [{ role: "user", content: "test" }],
+    });
+
+    expect(result.structuredResponse).toEqual({ answer: "correct" });
+    expect(
+      result.messages.some(
+        (message: BaseMessage) =>
+          ToolMessage.isInstance(message) &&
+          typeof message.content === "string" &&
+          message.content.includes("Failed to parse structured output"),
+      ),
+    ).toBe(true);
   });
 });

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -476,6 +476,17 @@ export function createDeepAgent<
     },
   });
 
+  // LangChain's internal `jumpTo` control channel is cleared by structured
+  // response retries and user afterModel middleware. Multiple clears in the
+  // same graph step are equivalent, so allow one of them instead of throwing
+  // an INVALID_CONCURRENT_GRAPH_UPDATE for `[null, null]`.
+  const jumpToChannel = agent.graph?.channels?.jumpTo as
+    | { guard?: boolean }
+    | undefined;
+  if (jumpToChannel) {
+    jumpToChannel.guard = false;
+  }
+
   /**
    * Combine custom middleware with flattened subagent middleware for complete type inference
    * This ensures InferMiddlewareStates captures state from both sources


### PR DESCRIPTION
## Summary

- allow duplicate clears of LangChain's internal `jumpTo` channel in deep agent graphs
- add a regression test for structured output retry with no-op `afterModel` middleware

Fixes #480

## Testing

- `pnpm --filter deepagents exec vitest run src/agent.test.ts -t "does not throw concurrent jumpTo updates" --typecheck.enabled=false`
- `pnpm --filter deepagents exec vitest run src/agent.test.ts --typecheck.enabled=false`
- `pnpm --filter deepagents exec vitest run --typecheck.enabled=false`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm --filter deepagents build`

Note: `pnpm --filter deepagents typecheck` currently fails on existing `.int.test.ts` imports for `@langchain/sandbox-standard-tests/vitest`, unrelated to this change.
