### PR TITLE
feat: add interrupt mode to FilesystemPermission

### DIFF
--- a/.changeset/fs-permission-interrupt-mode.md
+++ b/.changeset/fs-permission-interrupt-mode.md
@@ -1,0 +1,13 @@
+---
+"deepagents": minor
+---
+
+Add `interrupt` mode to `FilesystemPermission`
+
+Filesystem permission rules now accept `mode: "interrupt"`, which pauses a
+matching filesystem tool call for human approval before it runs — the
+path-scoped counterpart to `interruptOn`. Exact-path tools (`read_file`,
+`write_file`, `edit_file`) interrupt only when the target path matches a rule;
+bulk tools (`ls`, `glob`, `grep`) interrupt whenever their search subtree could
+overlap a rule's anchor. It reuses the same interrupt request/response shape as
+`humanInTheLoopMiddleware`, so resuming works identically.

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -17,6 +17,7 @@ import type {
 
 import {
   createFilesystemMiddleware,
+  createFilesystemInterruptMiddleware,
   createSubAgentMiddleware,
   createPatchToolCallsMiddleware,
   createSummarizationMiddleware,
@@ -29,6 +30,7 @@ import {
   isAsyncSubAgent,
 } from "./middleware/index.js";
 import { StateBackend } from "./backends/state.js";
+import { hasInterruptPermission } from "./permissions/index.js";
 import { ConfigurationError } from "./errors.js";
 import { InteropZodObject } from "@langchain/core/utils/types";
 import { createCacheBreakpointMiddleware } from "./middleware/cache.js";
@@ -253,6 +255,16 @@ export function createDeepAgent<
         backend,
         permissions: effectivePermissions,
       }),
+      // Path-gated filesystem permission interrupts for the subagent. Tools
+      // already covered by the subagent's interruptOn are excluded.
+      ...(hasInterruptPermission(effectivePermissions)
+        ? [
+            createFilesystemInterruptMiddleware({
+              permissions: effectivePermissions,
+              excludeTools: Object.keys(input.interruptOn ?? interruptOn ?? {}),
+            }),
+          ]
+        : []),
       // Automatically summarizes conversation history when token limits are approached.
       // Uses createSummarizationMiddleware (deepagents version) with backend support
       // and auto-computed defaults from model profile.
@@ -380,6 +392,16 @@ export function createDeepAgent<
             backend,
             sources: memory,
             addCacheControl: anthropicModel,
+          }),
+        ]
+      : []),
+    // Optional path-gated filesystem permission interrupts. Tools already
+    // covered by `interruptOn` are excluded so the user-supplied config wins.
+    ...(hasInterruptPermission(permissions)
+      ? [
+          createFilesystemInterruptMiddleware({
+            permissions,
+            excludeTools: interruptOn ? Object.keys(interruptOn) : [],
           }),
         ]
       : []),

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -67,6 +67,8 @@ export {
 // Export middleware (matches Python's interface)
 export {
   createFilesystemMiddleware,
+  createFilesystemInterruptMiddleware,
+  type FilesystemInterruptMiddlewareOptions,
   createSubAgentMiddleware,
   createPatchToolCallsMiddleware,
   createSummarizationMiddleware,

--- a/libs/deepagents/src/middleware/fs_interrupt.test.ts
+++ b/libs/deepagents/src/middleware/fs_interrupt.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { MemorySaver, Command } from "@langchain/langgraph";
+import { FakeListChatModel } from "@langchain/core/utils/testing";
+import { AIMessage } from "@langchain/core/messages";
+import type { HITLRequest } from "langchain";
+
+import { createDeepAgent } from "../agent.js";
+import type { FilesystemPermission } from "../permissions/types.js";
+
+function readFileModel(filePath: string): FakeListChatModel {
+  return new FakeListChatModel({
+    responses: [
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          { id: "call_1", name: "read_file", args: { file_path: filePath } },
+        ],
+      }) as unknown as string,
+      "Done",
+      "Done",
+    ],
+  });
+}
+
+const INTERRUPT_READ: FilesystemPermission[] = [
+  { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+];
+
+describe("createFilesystemInterruptMiddleware (via createDeepAgent)", () => {
+  it("interrupts read_file when the path matches an interrupt rule", async () => {
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model: readFileModel("/secrets/key.txt"),
+      permissions: INTERRUPT_READ,
+      checkpointer,
+    });
+
+    const config = { configurable: { thread_id: crypto.randomUUID() } };
+    const result = await agent.invoke(
+      { messages: [{ role: "user", content: "read the secret" }] },
+      config,
+    );
+
+    expect(result.__interrupt__).toBeDefined();
+    const request = result.__interrupt__?.[0].value as HITLRequest;
+    expect(request.actionRequests.some((ar) => ar.name === "read_file")).toBe(
+      true,
+    );
+  });
+
+  it("does not interrupt read_file for an unrelated path", async () => {
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model: readFileModel("/workspace/notes.txt"),
+      permissions: INTERRUPT_READ,
+      checkpointer,
+    });
+
+    const config = { configurable: { thread_id: crypto.randomUUID() } };
+    const result = await agent.invoke(
+      { messages: [{ role: "user", content: "read my notes" }] },
+      config,
+    );
+
+    expect(result.__interrupt__).toBeUndefined();
+  });
+
+  it("does not interrupt when there are no interrupt-mode rules", async () => {
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model: readFileModel("/workspace/notes.txt"),
+      permissions: [
+        { operations: ["read"], paths: ["/secrets/**"], mode: "deny" },
+      ],
+      checkpointer,
+    });
+
+    const config = { configurable: { thread_id: crypto.randomUUID() } };
+    const result = await agent.invoke(
+      { messages: [{ role: "user", content: "read my notes" }] },
+      config,
+    );
+
+    expect(result.__interrupt__).toBeUndefined();
+  });
+
+  it("resumes execution after the operation is approved", async () => {
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model: readFileModel("/secrets/key.txt"),
+      permissions: INTERRUPT_READ,
+      checkpointer,
+    });
+
+    const config = { configurable: { thread_id: crypto.randomUUID() } };
+    await agent.invoke(
+      { messages: [{ role: "user", content: "read the secret" }] },
+      config,
+    );
+
+    const resumed = await agent.invoke(
+      new Command({ resume: { decisions: [{ type: "approve" }] } }),
+      config,
+    );
+
+    expect(resumed.__interrupt__).toBeUndefined();
+  });
+});

--- a/libs/deepagents/src/middleware/fs_interrupt.ts
+++ b/libs/deepagents/src/middleware/fs_interrupt.ts
@@ -1,0 +1,222 @@
+import { createMiddleware } from "langchain";
+import { AIMessage, ToolMessage } from "@langchain/core/messages";
+import type { ToolCall } from "@langchain/core/messages/tool";
+import { interrupt } from "@langchain/langgraph";
+import {
+  buildFsInterruptPredicates,
+  hasInterruptPermission,
+} from "../permissions/interrupt.js";
+import type { FilesystemPermission } from "../permissions/types.js";
+
+const ALLOWED_DECISIONS = ["approve", "edit", "reject"] as const;
+
+interface ApproveDecision {
+  type: "approve";
+}
+interface EditDecision {
+  type: "edit";
+  editedAction: { name: string; args: Record<string, unknown> };
+}
+interface RejectDecision {
+  type: "reject";
+  message?: string;
+}
+type Decision = ApproveDecision | EditDecision | RejectDecision;
+
+/**
+ * Options for {@link createFilesystemInterruptMiddleware}.
+ */
+export interface FilesystemInterruptMiddlewareOptions {
+  /** Filesystem permission rules; only `interrupt`-mode rules have an effect. */
+  permissions: FilesystemPermission[];
+  /**
+   * Tool names already handled elsewhere (e.g. via `interruptOn`). These are
+   * skipped so the user-supplied human-in-the-loop configuration wins.
+   */
+  excludeTools?: Iterable<string>;
+  /** Prefix used when describing an approval request. */
+  descriptionPrefix?: string;
+}
+
+function processDecision(
+  decision: Decision,
+  toolCall: ToolCall,
+): { revisedToolCall: ToolCall | null; toolMessage: ToolMessage | null } {
+  if (decision.type === "approve") {
+    return { revisedToolCall: toolCall, toolMessage: null };
+  }
+  if (decision.type === "edit") {
+    const editedAction = decision.editedAction;
+    if (!editedAction || typeof editedAction.name !== "string") {
+      throw new Error(
+        `Invalid edited action for tool "${toolCall.name}": name must be a string`,
+      );
+    }
+    if (!editedAction.args || typeof editedAction.args !== "object") {
+      throw new Error(
+        `Invalid edited action for tool "${toolCall.name}": args must be an object`,
+      );
+    }
+    return {
+      revisedToolCall: {
+        type: "tool_call",
+        name: editedAction.name,
+        args: editedAction.args,
+        id: toolCall.id,
+      },
+      toolMessage: null,
+    };
+  }
+  if (decision.type === "reject") {
+    if (
+      decision.message !== undefined &&
+      typeof decision.message !== "string"
+    ) {
+      throw new Error(
+        `Tool call response for "${toolCall.name}" must be a string, got ${typeof decision.message}`,
+      );
+    }
+    return {
+      revisedToolCall: toolCall,
+      toolMessage: new ToolMessage({
+        content:
+          decision.message ??
+          `User rejected the tool call for \`${toolCall.name}\` with id ${toolCall.id}`,
+        name: toolCall.name,
+        tool_call_id: toolCall.id ?? "",
+        status: "error",
+      }),
+    };
+  }
+  throw new Error(
+    `Unexpected human decision: ${JSON.stringify(decision)}. Decision type ` +
+      `'${(decision as Decision).type}' is not allowed for tool '${toolCall.name}'.`,
+  );
+}
+
+/**
+ * Pause filesystem tool calls for human approval when they match an
+ * `interrupt`-mode {@link FilesystemPermission} rule.
+ *
+ * This is the deepagents counterpart to gating `interruptOn` by path: a single
+ * tool (e.g. `read_file`) only pauses when its target path matches a rule,
+ * rather than on every call. It uses the same interrupt request/response shape
+ * as `humanInTheLoopMiddleware`, so resuming works identically — resume with a
+ * `HITLResponse` (`{ decisions: [...] }`).
+ *
+ * Bulk tools (`ls`/`glob`/`grep`) pause whenever their search subtree could
+ * overlap an interrupt-mode rule's anchor. Returns a no-op middleware when no
+ * `interrupt`-mode rules apply.
+ */
+export function createFilesystemInterruptMiddleware(
+  options: FilesystemInterruptMiddlewareOptions,
+) {
+  const { permissions, descriptionPrefix } = options;
+  const predicates = buildFsInterruptPredicates(
+    permissions,
+    new Set(options.excludeTools ?? []),
+  );
+  const prefix = descriptionPrefix ?? "Filesystem operation requires approval";
+
+  return createMiddleware({
+    name: "FilesystemInterruptMiddleware",
+    afterModel: {
+      canJumpTo: ["model"],
+      hook: async (state: { messages: unknown[] }) => {
+        if (Object.keys(predicates).length === 0) {
+          return undefined;
+        }
+        const messages = state.messages;
+        if (!messages.length) {
+          return undefined;
+        }
+        const lastMessage = [...messages]
+          .reverse()
+          .find((m) => AIMessage.isInstance(m)) as AIMessage | undefined;
+        if (!lastMessage || !lastMessage.tool_calls?.length) {
+          return undefined;
+        }
+
+        const interruptToolCalls: ToolCall[] = [];
+        const autoApprovedToolCalls: ToolCall[] = [];
+        for (const toolCall of lastMessage.tool_calls) {
+          const predicate = predicates[toolCall.name];
+          if (predicate && predicate(toolCall.args ?? {})) {
+            interruptToolCalls.push(toolCall);
+          } else {
+            autoApprovedToolCalls.push(toolCall);
+          }
+        }
+
+        if (interruptToolCalls.length === 0) {
+          return undefined;
+        }
+
+        const actionRequests = interruptToolCalls.map((toolCall) => ({
+          name: toolCall.name,
+          args: toolCall.args,
+          description: `${prefix}\n\nTool: ${toolCall.name}\nArgs: ${JSON.stringify(
+            toolCall.args,
+            null,
+            2,
+          )}`,
+        }));
+        const reviewConfigs = interruptToolCalls.map((toolCall) => ({
+          actionName: toolCall.name,
+          allowedDecisions: [...ALLOWED_DECISIONS],
+        }));
+
+        const response = (await interrupt({
+          actionRequests,
+          reviewConfigs,
+        })) as { decisions?: Decision[] };
+        const decisions = response?.decisions;
+
+        if (!decisions || !Array.isArray(decisions)) {
+          throw new Error(
+            "Invalid HITLResponse: decisions must be a non-empty array",
+          );
+        }
+        if (decisions.length !== interruptToolCalls.length) {
+          throw new Error(
+            `Number of human decisions (${decisions.length}) does not match ` +
+              `number of hanging tool calls (${interruptToolCalls.length}).`,
+          );
+        }
+
+        const revisedToolCalls: ToolCall[] = [...autoApprovedToolCalls];
+        const artificialToolMessages: ToolMessage[] = [];
+        const hasRejectedToolCalls = decisions.some(
+          (decision) => decision.type === "reject",
+        );
+
+        for (let i = 0; i < decisions.length; i += 1) {
+          const decision = decisions[i];
+          const toolCall = interruptToolCalls[i];
+          const { revisedToolCall, toolMessage } = processDecision(
+            decision,
+            toolCall,
+          );
+          if (
+            revisedToolCall &&
+            (!hasRejectedToolCalls || decision.type === "reject")
+          ) {
+            revisedToolCalls.push(revisedToolCall);
+          }
+          if (toolMessage) {
+            artificialToolMessages.push(toolMessage);
+          }
+        }
+
+        lastMessage.tool_calls = revisedToolCalls;
+        const jumpTo = hasRejectedToolCalls ? ("model" as const) : undefined;
+        return {
+          messages: [lastMessage, ...artificialToolMessages],
+          jumpTo,
+        };
+      },
+    },
+  });
+}
+
+export { hasInterruptPermission };

--- a/libs/deepagents/src/middleware/index.ts
+++ b/libs/deepagents/src/middleware/index.ts
@@ -8,6 +8,10 @@ export {
   createContentPreview,
 } from "./fs.js";
 export {
+  createFilesystemInterruptMiddleware,
+  type FilesystemInterruptMiddlewareOptions,
+} from "./fs_interrupt.js";
+export {
   createSubAgentMiddleware,
   type SubAgentMiddlewareOptions,
   type SubAgent,

--- a/libs/deepagents/src/permissions/enforce.ts
+++ b/libs/deepagents/src/permissions/enforce.ts
@@ -69,7 +69,8 @@ export function globMatch(path: string, pattern: string): boolean {
  *
  * First-match-wins; permissive default.
  *
- * @returns `"allow"` if the operation is permitted, `"deny"` otherwise.
+ * @returns the matched rule's mode (`"allow"`, `"deny"`, or `"interrupt"`),
+ * or `"allow"` when no rule matches.
  */
 export function decidePathAccess(
   rules: readonly FilesystemPermission[],

--- a/libs/deepagents/src/permissions/index.ts
+++ b/libs/deepagents/src/permissions/index.ts
@@ -10,3 +10,10 @@ export {
   decidePathAccess,
   validatePermissionPaths,
 } from "./enforce.js";
+
+export {
+  buildFsInterruptPredicates,
+  hasInterruptPermission,
+  globAnchor,
+  pathsOverlap,
+} from "./interrupt.js";

--- a/libs/deepagents/src/permissions/interrupt.test.ts
+++ b/libs/deepagents/src/permissions/interrupt.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFsInterruptPredicates,
+  globAnchor,
+  pathsOverlap,
+  hasInterruptPermission,
+} from "./interrupt.js";
+import type { FilesystemPermission } from "./types.js";
+
+function predicate(
+  rules: FilesystemPermission[],
+  tool: string,
+  excludeTools: string[] = [],
+) {
+  const predicates = buildFsInterruptPredicates(rules, new Set(excludeTools));
+  return predicates[tool];
+}
+
+describe("globAnchor", () => {
+  it("returns the literal leading directory", () => {
+    expect(globAnchor("/secrets/**")).toBe("/secrets");
+    expect(globAnchor("/a/*/b")).toBe("/a");
+    expect(globAnchor("/secrets/sub/*.txt")).toBe("/secrets/sub");
+  });
+
+  it("falls back to root for wildcards at or near the root", () => {
+    expect(globAnchor("/**/secrets")).toBe("/");
+    expect(globAnchor("/*/foo")).toBe("/");
+    expect(globAnchor("*.txt")).toBe("/");
+  });
+});
+
+describe("pathsOverlap", () => {
+  it("matches when one subtree contains the other", () => {
+    expect(pathsOverlap("/secrets", "/secrets/sub")).toBe(true);
+    expect(pathsOverlap("/secrets/sub", "/secrets")).toBe(true);
+    expect(pathsOverlap("/secrets", "/secrets")).toBe(true);
+  });
+
+  it("root overlaps everything", () => {
+    expect(pathsOverlap("/", "/anything/here")).toBe(true);
+    expect(pathsOverlap("/anything/here", "/")).toBe(true);
+  });
+
+  it("uses component-aware matching, not string prefix", () => {
+    expect(pathsOverlap("/secret", "/secrets")).toBe(false);
+    expect(pathsOverlap("/workspace", "/secrets")).toBe(false);
+  });
+});
+
+describe("hasInterruptPermission", () => {
+  it("is true only when a rule uses interrupt mode", () => {
+    expect(hasInterruptPermission([])).toBe(false);
+    expect(
+      hasInterruptPermission([
+        { operations: ["read"], paths: ["/x/**"], mode: "deny" },
+      ]),
+    ).toBe(false);
+    expect(
+      hasInterruptPermission([
+        { operations: ["read"], paths: ["/x/**"], mode: "interrupt" },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("buildFsInterruptPredicates", () => {
+  it("returns empty when there are no interrupt rules", () => {
+    expect(buildFsInterruptPredicates([])).toEqual({});
+    expect(
+      buildFsInterruptPredicates([
+        { operations: ["write"], paths: ["/x/**"], mode: "deny" },
+      ]),
+    ).toEqual({});
+  });
+
+  it("registers only tools whose operation can interrupt", () => {
+    const out = buildFsInterruptPredicates([
+      { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+    ]);
+    expect(Object.keys(out).sort()).toEqual(["edit_file", "write_file"]);
+  });
+
+  it("registers read tools for a read interrupt rule", () => {
+    const out = buildFsInterruptPredicates([
+      { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+    ]);
+    expect(Object.keys(out).sort()).toEqual([
+      "glob",
+      "grep",
+      "ls",
+      "read_file",
+    ]);
+  });
+
+  it("excludes tools listed in excludeTools", () => {
+    const out = buildFsInterruptPredicates(
+      [{ operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" }],
+      new Set(["write_file"]),
+    );
+    expect(Object.keys(out)).toEqual(["edit_file"]);
+  });
+});
+
+describe("exact-scope predicate", () => {
+  const rules: FilesystemPermission[] = [
+    { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+  ];
+
+  it.each([
+    ["/secrets/key.pem", true],
+    ["/workspace/x.txt", false],
+    // `/secrets/**` matches `/secrets` under the repo's micromatch glob rules.
+    ["/secrets", true],
+  ])("path %s -> %s", (filePath, expected) => {
+    const when = predicate(rules, "write_file");
+    expect(when({ file_path: filePath })).toBe(expected);
+  });
+
+  it("does not fire when a deny rule wins first", () => {
+    const denyFirst: FilesystemPermission[] = [
+      { operations: ["write"], paths: ["/secrets/**"], mode: "deny" },
+      { operations: ["write"], paths: ["/secrets/**"], mode: "interrupt" },
+    ];
+    const when = predicate(denyFirst, "write_file");
+    expect(when({ file_path: "/secrets/key.pem" })).toBe(false);
+  });
+
+  it("ignores non-string and invalid paths", () => {
+    const when = predicate(rules, "write_file");
+    expect(when({ file_path: 123 })).toBe(false);
+    expect(when({ file_path: "/secrets/../etc/passwd" })).toBe(false);
+    expect(when({})).toBe(false);
+  });
+});
+
+describe("bulk-scope predicate", () => {
+  const rules: FilesystemPermission[] = [
+    { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+  ];
+
+  it.each([
+    [{ path: undefined }, true],
+    [{}, true],
+    [{ path: "/" }, true],
+    [{ path: "/secrets" }, true],
+    [{ path: "/secrets/sub" }, true],
+    [{ path: "/workspace" }, false],
+    [{ path: "/secret" }, false],
+    [{ path: "/secrets/../etc/passwd" }, false],
+  ])("args %o -> %s", (args, expected) => {
+    const when = predicate(rules, "ls");
+    expect(when(args as Record<string, unknown>)).toBe(expected);
+  });
+});
+
+describe("glob bulk predicate gates on pattern arg", () => {
+  const rules: FilesystemPermission[] = [
+    { operations: ["read"], paths: ["/secrets/**"], mode: "interrupt" },
+  ];
+
+  it.each([
+    [{ pattern: "/secrets/**", path: "/workspace" }, true],
+    [{ pattern: "/secrets/sub/*.txt", path: "/workspace" }, true],
+    [{ pattern: "/**/key.pem", path: "/workspace" }, true],
+    [{ pattern: "/workspace/**", path: "/workspace" }, false],
+    [{ pattern: "../secrets/*", path: "/workspace" }, true],
+    [{ pattern: "../../etc/*", path: "/workspace/sub" }, true],
+    [{ pattern: "*.txt", path: "/workspace" }, false],
+    [{ pattern: "*.txt", path: "/secrets" }, true],
+  ])("args %o -> %s", (args, expected) => {
+    const when = predicate(rules, "glob");
+    expect(when(args as Record<string, unknown>)).toBe(expected);
+  });
+});

--- a/libs/deepagents/src/permissions/interrupt.ts
+++ b/libs/deepagents/src/permissions/interrupt.ts
@@ -1,0 +1,241 @@
+import { decidePathAccess, validatePath } from "./enforce.js";
+import type { FilesystemOperation, FilesystemPermission } from "./types.js";
+
+/**
+ * Scope of a filesystem tool's path argument.
+ *
+ * - `"exact"`: the call operates on exactly the named path (`read_file`,
+ *   `write_file`, `edit_file`). The interrupt fires iff that path matches an
+ *   interrupt-mode rule.
+ * - `"bulk"`: the path argument names a search root and the call may surface
+ *   any descendant (`ls`, `glob`, `grep`). The interrupt fires whenever the
+ *   search subtree could intersect an interrupt-mode rule, and — when the path
+ *   argument is omitted — fires for any interrupt-mode rule on the operation
+ *   because a pathless bulk call can touch anything.
+ */
+type ToolScope = "exact" | "bulk";
+
+interface FsToolPathArg {
+  operation: FilesystemOperation;
+  pathArg: string;
+  scope: ToolScope;
+  /** Set only for `glob`, whose `pattern` can redirect the search root. */
+  patternArg?: string;
+}
+
+/**
+ * Maps each filesystem tool to the metadata its interrupt predicate needs.
+ * Mirrors the filesystem tool input schemas defined in `middleware/fs.ts`.
+ */
+const FS_TOOL_PATH_ARGS: Record<string, FsToolPathArg> = {
+  ls: { operation: "read", pathArg: "path", scope: "bulk" },
+  read_file: { operation: "read", pathArg: "file_path", scope: "exact" },
+  write_file: { operation: "write", pathArg: "file_path", scope: "exact" },
+  edit_file: { operation: "write", pathArg: "file_path", scope: "exact" },
+  glob: {
+    operation: "read",
+    pathArg: "path",
+    scope: "bulk",
+    patternArg: "pattern",
+  },
+  grep: { operation: "read", pathArg: "path", scope: "bulk" },
+};
+
+const GLOB_WILDCARD_CHARS = new Set(["*", "?", "[", "{"]);
+
+/** Normalize backslash separators to forward slashes. */
+function toPosixPath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function splitSegments(path: string): string[] {
+  return toPosixPath(path)
+    .split("/")
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Return the longest leading directory of `pattern` with no wildcards.
+ *
+ * For `/secrets/**` returns `/secrets`; for `/a/*\/b` returns `/a`; for a
+ * pattern with a wildcard at or near the root (`/**\/secrets`, `/*\/foo`)
+ * falls back to `/`. The root fallback makes overlap checks match any subtree
+ * — conservative over-gating, since we cannot statically pin where the rule
+ * resolves.
+ */
+export function globAnchor(pattern: string): string {
+  const posix = toPosixPath(pattern);
+  const isAbsolute = posix.startsWith("/");
+  const safe: string[] = [];
+  for (const segment of splitSegments(posix)) {
+    if ([...segment].some((c) => GLOB_WILDCARD_CHARS.has(c))) {
+      break;
+    }
+    safe.push(segment);
+  }
+  if (safe.length === 0) {
+    return "/";
+  }
+  return (isAbsolute ? "/" : "") + safe.join("/");
+}
+
+/**
+ * Return true if the subtree at `callPath` intersects the subtree at
+ * `ruleAnchor`. Two subtrees overlap when one is a component-wise prefix of
+ * the other (or they're equal). The root `/` overlaps everything; `/secret`
+ * does not overlap `/secrets`.
+ */
+export function pathsOverlap(callPath: string, ruleAnchor: string): boolean {
+  const a = splitSegments(callPath);
+  const b = splitSegments(ruleAnchor);
+  const shared = Math.min(a.length, b.length);
+  for (let i = 0; i < shared; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Whether a glob `pattern` reaches an interrupt-mode subtree regardless of the
+ * call's `path`. An absolute pattern is matched from its own root, so gate on
+ * the pattern's anchor. A relative pattern containing `..` can climb out of
+ * `path`, so treat it as firing.
+ */
+function bulkPatternFires(
+  rawPattern: string,
+  interruptAnchors: string[],
+): boolean {
+  const posix = toPosixPath(rawPattern);
+  if (posix.startsWith("/")) {
+    const anchor = globAnchor(rawPattern);
+    return interruptAnchors.some((a) => pathsOverlap(anchor, a));
+  }
+  return splitSegments(posix).includes("..");
+}
+
+type WhenPredicate = (args: Record<string, unknown>) => boolean;
+
+function makeExactWhenPredicate(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+  pathArg: string,
+): WhenPredicate {
+  return (args) => {
+    const raw = args[pathArg];
+    if (typeof raw !== "string") {
+      return false;
+    }
+    let normalized: string;
+    try {
+      normalized = validatePath(raw);
+    } catch {
+      return false;
+    }
+    return decidePathAccess(rules, operation, normalized) === "interrupt";
+  };
+}
+
+function makeBulkWhenPredicate(
+  rules: readonly FilesystemPermission[],
+  operation: FilesystemOperation,
+  pathArg: string,
+  patternArg: string | undefined,
+): WhenPredicate {
+  const interruptAnchors: string[] = [];
+  for (const rule of rules) {
+    if (rule.mode !== "interrupt" || !rule.operations.includes(operation)) {
+      continue;
+    }
+    for (const pattern of rule.paths) {
+      interruptAnchors.push(globAnchor(pattern));
+    }
+  }
+
+  return (args) => {
+    if (interruptAnchors.length === 0) {
+      return false;
+    }
+    const raw = args[pathArg];
+    let normalized: string;
+    if (typeof raw !== "string") {
+      // A missing path (e.g. bulk tools default to `/`) can't be localized,
+      // so fire; any other non-string is malformed, so don't.
+      if (raw === undefined || raw === null) {
+        normalized = "/";
+      } else {
+        return false;
+      }
+    } else {
+      try {
+        normalized = validatePath(raw);
+      } catch {
+        return false;
+      }
+    }
+    if (interruptAnchors.some((anchor) => pathsOverlap(normalized, anchor))) {
+      return true;
+    }
+    if (patternArg !== undefined) {
+      const rawPattern = args[patternArg];
+      if (
+        typeof rawPattern === "string" &&
+        bulkPatternFires(rawPattern, interruptAnchors)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+
+/**
+ * Build per-tool predicates that decide whether a filesystem tool call should
+ * pause for human approval under interrupt-mode permission rules.
+ *
+ * Returns an entry for each filesystem tool whose operation is governed by at
+ * least one interrupt-mode rule. Tools named in `excludeTools` (e.g. tools the
+ * caller already routes through `interruptOn`) are skipped so the user-supplied
+ * configuration wins.
+ */
+export function buildFsInterruptPredicates(
+  rules: readonly FilesystemPermission[],
+  excludeTools: ReadonlySet<string> = new Set(),
+): Record<string, WhenPredicate> {
+  const predicates: Record<string, WhenPredicate> = {};
+  if (!rules.some((rule) => rule.mode === "interrupt")) {
+    return predicates;
+  }
+
+  for (const [toolName, meta] of Object.entries(FS_TOOL_PATH_ARGS)) {
+    if (excludeTools.has(toolName)) {
+      continue;
+    }
+    const applies = rules.some(
+      (rule) =>
+        rule.mode === "interrupt" && rule.operations.includes(meta.operation),
+    );
+    if (!applies) {
+      continue;
+    }
+    predicates[toolName] =
+      meta.scope === "exact"
+        ? makeExactWhenPredicate(rules, meta.operation, meta.pathArg)
+        : makeBulkWhenPredicate(
+            rules,
+            meta.operation,
+            meta.pathArg,
+            meta.patternArg,
+          );
+  }
+
+  return predicates;
+}
+
+/** Whether any rule requests interrupt-mode human approval. */
+export function hasInterruptPermission(
+  rules: readonly FilesystemPermission[],
+): boolean {
+  return rules.some((rule) => rule.mode === "interrupt");
+}

--- a/libs/deepagents/src/permissions/types.ts
+++ b/libs/deepagents/src/permissions/types.ts
@@ -4,9 +4,14 @@
 export type FilesystemOperation = "read" | "write";
 
 /**
- * Whether a matched rule permits or blocks the operation.
+ * Effect when a tool call matches a rule.
+ *
+ * - `"allow"` (default): the call proceeds.
+ * - `"deny"`: the tool returns a permission-denied error.
+ * - `"interrupt"`: the call is paused for human approval before it runs,
+ *   via the same human-in-the-loop interrupt used by `interruptOn`.
  */
-export type PermissionMode = "allow" | "deny";
+export type PermissionMode = "allow" | "deny" | "interrupt";
 
 /**
  * A single filesystem permission rule.
@@ -34,7 +39,16 @@ export interface FilesystemPermission {
   paths: string[];
 
   /**
-   * Whether matching paths are permitted or blocked. Defaults to `"allow"`.
+   * What happens when this rule matches. Defaults to `"allow"`.
+   *
+   * - `"allow"`: the call proceeds.
+   * - `"deny"`: the tool returns a permission-denied error.
+   * - `"interrupt"`: the call pauses for human approval before it runs.
+   *   Best paired with patterns that have a literal leading anchor (e.g.
+   *   `/secrets/**`). Bulk tools (`ls`/`glob`/`grep`) fire the interrupt
+   *   whenever their search subtree could overlap the rule's anchored
+   *   prefix, so a fully unanchored pattern (`/**\/secrets`) conservatively
+   *   over-fires for any bulk call.
    */
   mode?: PermissionMode;
 }


### PR DESCRIPTION
## Description
Ports the Python `interrupt_on` filesystem permission feature to deepagents.js. `FilesystemPermission` rules now accept `mode: "interrupt"`, which pauses a matching filesystem tool call for human approval before it runs — the path-scoped counterpart to `interruptOn`. Exact-path tools (`read_file`/`write_file`/`edit_file`) interrupt only when the target path matches a rule; bulk tools (`ls`/`glob`/`grep`) interrupt when their search subtree could overlap a rule's anchor. Since the upstream JS `humanInTheLoopMiddleware` has no per-call `when` predicate, this adds a small path-gated middleware that emits the same HITL request/response shape, so resuming works identically. Tools already covered by `interruptOn` are excluded so the user's config wins.

## Release Note
Filesystem permission rules now support `mode: "interrupt"` to pause matching file operations for human approval.

## Test Plan
- [ ] Verify `read_file` on an interrupt-matched path pauses with `__interrupt__`, an unrelated path does not, and resuming with an approve decision proceeds.

Made by [Open SWE](https://openswe.vercel.app)