### PR TITLE
chore(quickjs): refine dynamic subagent prompt to trigger on workflow keyword and to improve iterative eval behavior

### DIFF
--- a/.changeset/dry-shrimps-lead.md
+++ b/.changeset/dry-shrimps-lead.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+chore(quickjs): refine dynamic subagent prompt to trigger on workflow keyword and to improve iterative eval behavior

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -62,6 +62,10 @@ describe("createCodeInterpreterMiddleware", () => {
       expect(text).toContain("64 MB total");
       expect(text).not.toContain("async readFile");
       expect(text).not.toContain("async writeFile");
+      // With no PTC tools exposed, the REPL prompt should not reference the
+      // `tools.*` namespace and should say the REPL is pure computation.
+      expect(text).toContain("pure computation");
+      expect(text).not.toContain("`tools.*` namespace documented below");
     });
 
     it("should use custom system prompt when provided", async () => {
@@ -196,6 +200,11 @@ describe("createCodeInterpreterMiddleware", () => {
       const req = mockHandler.mock.calls[0][0];
       expect(req.systemMessage.text).toContain("tools.agentTool");
       expect(req.systemMessage.text).toContain("tools.extraTool");
+      // With PTC exposed, the REPL prompt references the `tools.*` namespace.
+      expect(req.systemMessage.text).toContain(
+        "`tools.*` namespace documented below",
+      );
+      expect(req.systemMessage.text).not.toContain("pure computation");
     });
   });
 

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -62,8 +62,10 @@ function renderSubagentPrompt(toolName: string): string {
     ### Dispatching Subagents with \`task\`
 
     \`task\` is your primitive for running configured subagents from inside the
-    JavaScript REPL. You orchestrate everything else - fan-out, filtering,
-    deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+    JavaScript REPL. Your job here is to DISTRIBUTE work, not to do it yourself:
+    write JavaScript that fans work out to subagents and assembles their results.
+    You handle the orchestration - fan-out, filtering, deduplication, multi-stage
+    flow, and synthesis - in plain JavaScript.
 
     #### The primitive
 
@@ -81,13 +83,19 @@ function renderSubagentPrompt(toolName: string): string {
     the configured subagent names.
 
     \`description\` is the only prompt the subagent receives for this dispatch. Make
-    it complete: include the goal, constraints, relevant context, what to inspect,
-    and the exact shape or level of detail you expect back. Each dispatch is
-    stateless from the caller's perspective; you cannot send follow-up messages to
-    the same subagent run.
+    it complete: the goal, the constraints, what to inspect, and the exact shape
+    or level of detail you expect back. Give context as locators — file paths and
+    symbol names — not as pasted file contents. If you already read a file while
+    exploring, still pass its path and let the subagent read it; do not paste back
+    what you read. Each dispatch is stateless from the caller's perspective; you
+    cannot send follow-up messages to the same subagent run.
 
-    \`responseSchema\` is optional. When provided, the resolved value is already a
-    typed JavaScript value matching the schema. Do not call \`JSON.parse\` unless the
+    \`responseSchema\` is optional, but set it on any dispatch whose result feeds
+    later code. A deterministic, typed shape is what lets you compose the next
+    stage reliably — index it, sort it, compare fields, branch on it, merge it —
+    instead of parsing free-form text. This is what makes a whole workflow
+    composable as one script. When provided, the resolved value is already a typed
+    JavaScript value matching the schema; do not call \`JSON.parse\` unless the
     subagent intentionally returned a JSON string. Dynamic schemas work for
     declarative subagents; runnable-backed subagents reject dynamic schemas because
     their runnable is already compiled.
@@ -108,9 +116,15 @@ function renderSubagentPrompt(toolName: string): string {
     dispatch result back onto its item. Multi-stage analysis means: run a pass,
     filter or regroup the array in JS, then run another pass over the survivors.
 
-    Prefer one \`${toolName}\` call that performs the whole workflow. Splitting the
-    workflow across multiple \`${toolName}\` calls costs model turns and forces you to
-    re-establish state.
+    Once you have explored and are ready to run the workflow, compose the whole
+    thing as a single \`${toolName}\` script that executes end to end — even a
+    multi-stage one. A tournament (generate candidates, compare them pairwise,
+    pick a winner) or a fan-out-and-synthesize (review every item, then combine
+    the findings) is one script, with each stage feeding the next in JS, not a
+    series of separate \`${toolName}\` calls. Splitting across calls costs model
+    turns and forces you to re-establish REPL state. Reach for another call only
+    when a later stage genuinely depends on your own judgment of what an earlier
+    stage produced.
 
     #### Fan out with bounded concurrency
 
@@ -119,13 +133,15 @@ function renderSubagentPrompt(toolName: string): string {
     enforces a hard per-REPL cap of 32 concurrent subagent calls.
 
     \`\`\`javascript
+    const files = ["/src/a.ts", "/src/b.ts", "/src/c.ts"]; // found while exploring
     const batchSize = 10;
     const reviewed = [];
-    for (let i = 0; i < items.length; i += batchSize) {
-      const batch = items.slice(i, i + batchSize);
-      reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    for (let i = 0; i < files.length; i += batchSize) {
+      const batch = files.slice(i, i + batchSize);
+      reviewed.push(...(await Promise.all(batch.map(async (file) => {
         const result = await task({
-          description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+          description: "Read " + file + " and review it for SQL injection. " +
+            "Cite line numbers.",
           subagentType: "reviewer",
           responseSchema: {
             type: "object",
@@ -146,61 +162,44 @@ function renderSubagentPrompt(toolName: string): string {
             required: ["vulnerabilities"],
           },
         });
-        return { ...it, ...result };
+        return { file, ...result };
       }))));
     }
     \`\`\`
 
-    #### Use parent JS for cheap work; use subagents for agentic work
+    #### Explore with your own tools first, then distribute
 
-    Use JavaScript in the parent REPL for deterministic orchestration: joining
-    arrays, deduping, sorting, filtering, grouping, batching, and merging results.
-    If the \`tools.*\` namespace is exposed, also use it to pre-read files or collect
-    shared data once, then pass only the relevant content to each subagent in
-    \`description\`.
+    You already have your normal tools for reading, listing, globbing, and
+    grepping files. Use them to explore and understand the task BEFORE you write
+    the orchestration script. These are ordinary tool calls, separate from the
+    \`${toolName}\` tool: read the data file, list or glob the directory, grep for
+    what matters, then decide how to split the work.
 
-    Use \`task\` for work that benefits from an autonomous agentic loop: reading
-    or searching with the subagent's own tools, inspecting multiple files, following
-    leads, making judgment calls, or producing a final synthesized report.
+    Never write \`${toolName}\` code that spawns a subagent just to read or parse a
+    file or list a directory. That is a deterministic step you do yourself with a
+    direct tool call; spending a whole agent loop on it is wasteful.
 
-    #### Pre-read shared context in the parent when useful
+    Once you understand the shape of the work, you have creative freedom in how
+    you split it:
 
-    If many subagents need the same source list or file content and \`tools.*\` is
-    available, gather that context once in the parent REPL before dispatching:
+    - One dispatch per file or per record, when the items are already separate.
+    - Chunk a large input yourself — read it, split it, optionally write a small
+      input file per chunk — and dispatch one subagent per chunk.
+    - A cheap classification pass first, then deeper dispatches only for the items
+      that warrant them.
 
-    \`\`\`javascript
-    const files = (await tools.glob({ pattern: "src/**/*.ts" }))
-      .split("\\n")
-      .filter(Boolean);
+    Then write JavaScript in the \`${toolName}\` tool that distributes the heavy,
+    agentic work to subagents with \`task()\`: analyzing file contents, exploring a
+    codebase, making judgment calls, rewriting code, or synthesizing a report.
 
-    const items = await Promise.all(files.map(async (file) => {
-      const content = await tools.readFile({ file_path: file });
-      return { file, content };
-    }));
-
-    const batchSize = 10;
-    const results = [];
-    for (let i = 0; i < items.length; i += batchSize) {
-      const batch = items.slice(i, i + batchSize);
-      results.push(...(await Promise.all(batch.map(async (it) => {
-        const finding = await task({
-          description:
-            "Review this file for auth bypasses. Return concrete findings only.\\n\\n" +
-            "File: " + it.file + "\\n\\n" +
-            it.content,
-          subagentType: "reviewer",
-          responseSchema: {
-            type: "object",
-            properties: {
-              findings: { type: "array", items: { type: "object" } },
-            },
-            required: ["findings"],
-          },
-        });
-        return { ...it, ...finding };
-      }))));
-    }
-    \`\`\`
+    Hand each subagent a locator, not a payload. Subagents have their own file
+    tools, so for anything that lives in a file — a file to review, rewrite, or
+    audit — pass the path and let the subagent read it. Do NOT read a whole file
+    just to paste its contents into the description; that bloats every dispatch
+    and duplicates the file across them. Reserve inline content for small or
+    derived data that has no path of its own: a single parsed record, or a chunk
+    you split out of a larger input (write the chunk to its own file and pass that
+    path if it is large). Assemble the results in JS.
 
     #### Compose multiple stages
 
@@ -209,57 +208,56 @@ function renderSubagentPrompt(toolName: string): string {
     only for those items.
 
     \`\`\`javascript
-    const tagged = [];
-    for (let i = 0; i < items.length; i += 10) {
-      const batch = items.slice(i, i + 10);
-      tagged.push(...(await Promise.all(batch.map(async (it) => {
-        const tag = await task({
-          description: "Classify " + it.file + " as handler, util, test, or config.",
-          subagentType: "reviewer",
-          responseSchema: {
-            type: "object",
-            properties: { kind: { type: "string" }, risky: { type: "boolean" } },
-            required: ["kind", "risky"],
-          },
-        });
-        return { ...it, ...tag };
-      }))));
-    }
+    const tagged = await Promise.all(files.map((file) =>
+      task({
+        description: "Read " + file + " and classify it as handler, util, " +
+          "test, or config.",
+        subagentType: "reviewer",
+        responseSchema: {
+          type: "object",
+          properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+          required: ["kind", "risky"],
+        },
+      }).then((tag) => ({ file, ...tag }))
+    ));
 
     const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
-    const deepReviews = [];
-    for (let i = 0; i < riskyHandlers.length; i += 10) {
-      const batch = riskyHandlers.slice(i, i + 10);
-      deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-        const review = await task({
-          description: "Deep security review of " + it.file + ". Cite line numbers.",
-          subagentType: "reviewer",
-        });
-        return { ...it, review };
-      }))));
-    }
+    const deepReviews = await Promise.all(riskyHandlers.map((it) =>
+      task({
+        description: "Deep security review of " + it.file + ". Cite line numbers.",
+        subagentType: "reviewer",
+      }).then((review) => ({ ...it, review }))
+    ));
     \`\`\`
 
-    #### Get results out without flooding your context
+    #### Return results via the last expression, not \`console.log\`
 
-    Keep large result sets in JS variables. Do not \`console.log\` the full result set.
-    If \`tools.writeFile\` is exposed, persist structured output from inside the eval:
+    The value of the last expression in an \`${toolName}\` call (or a resolved
+    top-level \`await\`) is returned to you as the result. Make that final
+    expression the variable holding your result and read it from there.
+    \`console.log\` is only for incidental debugging: its output is capped and
+    truncated, while the returned value is not, so never \`console.log\` your
+    actual results.
 
-    \`\`\`javascript
-    await tools.writeFile({
-      file_path: "/results/subagent-output.json",
-      content: JSON.stringify(deepReviews),
-    });
-    \`\`\`
-
-    Otherwise return a compact summary or a small slice of the results, not the
-    entire intermediate dataset.
+    Keep large intermediate sets in JS variables and return only a compact
+    summary or a small slice, not the entire dataset. To persist full output,
+    have a subagent write it, or write it with your own file tool outside the
+    \`${toolName}\` call.
 
     #### Across evals
 
     Variables persist according to the interpreter persistence mode above, but
-    re-establish what you need in each eval. Doing the whole workflow in one
+    re-establish what you need in each eval. Doing the dispatch in one
     \`${toolName}\` call is usually simplest.
+
+    #### When the user asks for a "workflow"
+
+    If the user's request mentions running a "workflow" (or otherwise uses the
+    word "workflow"), fan the work out to subagents rather than doing it all
+    yourself. Explore with your own tools first as needed, then write JavaScript
+    in the \`${toolName}\` tool that dispatches subagents with \`task()\` and
+    assembles their results. The point is to distribute the heavy work in
+    parallel, not to grind through it one tool call at a time.
   `;
 }
 
@@ -267,14 +265,18 @@ function renderReplSystemPrompt(opts: {
   toolName: string;
   timeout: number;
   memoryLimitMb: number;
+  hasPtc: boolean;
 }): string {
+  const sideEffects = opts.hasPtc
+    ? " External side effects from inside the REPL are reachable only via the `tools.*` namespace documented below."
+    : " The REPL is pure computation; do any filesystem or other I/O with your normal tools, outside this tool.";
   return dedent`
     ### Interpreter
 
     An \`${opts.toolName}\` tool is available. It runs JavaScript in a persistent REPL.
     - State (variables, functions) persists across tool calls within a single turn of conversation. They DO NOT persist across multiple turns.
     - Top-level \`await\` works; Promises resolve before the call returns.
-    - Runtime sandbox: no built-in filesystem, network, stdlib, or wall-clock APIs (\`fetch\`, \`require\`, \`fs\`, \`process\`, real \`Date.now()\` are unavailable or stubbed). External side effects from inside the REPL are only reachable via the \`tools.*\` namespace when it is exposed (see below); without it, the REPL is pure computation.
+    - Runtime sandbox: no built-in filesystem, network, stdlib, or wall-clock APIs (\`fetch\`, \`require\`, \`fs\`, \`process\`, real \`Date.now()\` are unavailable or stubbed).${sideEffects}
     - Timeout: ${opts.timeout}s per call. Memory: ${opts.memoryLimitMb} MB total.
     - \`console.log\` output is captured and returned alongside the result.
   `;
@@ -373,14 +375,6 @@ export function createCodeInterpreterMiddleware(
   if (maxPtcCalls !== null && maxPtcCalls !== undefined && maxPtcCalls < 1) {
     throw new Error("`maxPtcCalls` must be >= 1 or null");
   }
-
-  const baseSystemPrompt =
-    customSystemPrompt ||
-    renderReplSystemPrompt({
-      toolName,
-      timeout: executionTimeoutMs / 1000,
-      memoryLimitMb: Math.floor(memoryLimitBytes / (1024 * 1024)),
-    });
 
   const middlewareId = crypto.randomUUID();
 
@@ -504,6 +498,15 @@ export function createCodeInterpreterMiddleware(
       if (ptcTools.length > 0 && !cachedPtcPrompt) {
         cachedPtcPrompt = await generatePtcPrompt(ptcTools);
       }
+
+      const baseSystemPrompt =
+        customSystemPrompt ||
+        renderReplSystemPrompt({
+          toolName,
+          timeout: executionTimeoutMs / 1000,
+          memoryLimitMb: Math.floor(memoryLimitBytes / (1024 * 1024)),
+          hasPtc: ptcTools.length > 0,
+        });
 
       const subagentPrompt =
         taskTool && maxSubagentConcurrency > 0

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -116,15 +116,12 @@ function renderSubagentPrompt(toolName: string): string {
     dispatch result back onto its item. Multi-stage analysis means: run a pass,
     filter or regroup the array in JS, then run another pass over the survivors.
 
-    Once you have explored and are ready to run the workflow, compose the whole
-    thing as a single \`${toolName}\` script that executes end to end — even a
-    multi-stage one. A tournament (generate candidates, compare them pairwise,
-    pick a winner) or a fan-out-and-synthesize (review every item, then combine
-    the findings) is one script, with each stage feeding the next in JS, not a
-    series of separate \`${toolName}\` calls. Splitting across calls costs model
-    turns and forces you to re-establish REPL state. Reach for another call only
-    when a later stage genuinely depends on your own judgment of what an earlier
-    stage produced.
+    You can run the whole workflow in one \`${toolName}\` call or split it across
+    several — both are fine. A single end-to-end script (generate, compare, pick a
+    winner; or review every item, then synthesize) is clean when you can write it
+    in one go; splitting is also fine when you want to inspect results between
+    stages. Either way, don't redo work across calls — reuse what is already in
+    scope (see "Reuse what earlier evals left in scope" below).
 
     #### Fan out with bounded concurrency
 
@@ -244,11 +241,33 @@ function renderSubagentPrompt(toolName: string): string {
     have a subagent write it, or write it with your own file tool outside the
     \`${toolName}\` call.
 
-    #### Across evals
+    #### Reuse what earlier evals left in scope
 
-    Variables persist according to the interpreter persistence mode above, but
-    re-establish what you need in each eval. Doing the dispatch in one
-    \`${toolName}\` call is usually simplest.
+    The REPL is persistent within a turn: every top-level variable, function, and
+    class you declare is kept and is available in your next \`${toolName}\` call
+    (each is hoisted to global scope). So if a later step needs something an
+    earlier eval produced or bound, **reference that variable by name** — do not
+    write a new literal that re-types data a previous eval already returned or
+    computed.
+
+    If you catch yourself pasting a big array or object of values you produced in
+    an earlier call, that is the tell: the variable is still in scope, so use it.
+    Re-typing prior results as a fresh literal wastes tokens and drifts from what
+    actually ran.
+
+    \`\`\`javascript
+    // An earlier eval bound this:
+    //   const auditResults = await Promise.all(files.map(/* ...audit... */));
+
+    // A later eval — reference it; do NOT paste the findings back in as a literal:
+    const findings = auditResults.flatMap((r) =>
+      r.findings.map((f) => ({ ...f, file: r.file }))
+    );
+    const verified = await Promise.all(findings.map((f) =>
+      task({ description: "Verify this finding: " + f.evidence, subagentType: "verifier" })
+        .then((v) => ({ ...f, ...v }))
+    ));
+    \`\`\`
 
     #### When the user asks for a "workflow"
 


### PR DESCRIPTION
### Summary

Prompt change only, no runtime behavior change.

Reworks the quickjs code-interpreter subagent prompt to steer the orchestrator toward an explore-then-distribute workflow. It explores with its own tools first, hands subagents file paths instead of pasted contents, reuses persisted REPL variables rather than re-pasting prior eval output, and returns results via the last expression instead of `console.log`. Also gates the REPL sandbox note so it only mentions the `tools.*` namespace when PTC is actually exposed.