### PR TITLE
fix(quickjs): unwrap `Command`/`ToolMessage` envelopes from tool and subagent results

### DIFF
--- a/.changeset/real-planes-dig.md
+++ b/.changeset/real-planes-dig.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": patch
+---
+
+fix(quickjs): unwrap Command/ToolMessage envelopes from tool and subagent results

--- a/libs/providers/quickjs/src/coerce.test.ts
+++ b/libs/providers/quickjs/src/coerce.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { unwrapToolEnvelope } from "./coerce.js";
+
+/** A Command-shaped value like the deepagents task tool resolves to. */
+function command(...contents: unknown[]) {
+  return {
+    lg_name: "Command",
+    update: {
+      files: {},
+      messages: contents.map((content) => ({ content })),
+    },
+  };
+}
+
+/** A ToolMessage-shaped value (live-instance style). */
+function toolMessage(content: unknown) {
+  return { content, tool_call_id: "call_1", _getType: () => "tool" };
+}
+
+describe("unwrapToolEnvelope", () => {
+  it("returns a plain string unchanged", () => {
+    expect(unwrapToolEnvelope("just text")).toBe("just text");
+  });
+
+  it("returns null and undefined unchanged", () => {
+    expect(unwrapToolEnvelope(null)).toBeNull();
+    expect(unwrapToolEnvelope(undefined)).toBeUndefined();
+  });
+
+  it("unwraps the last message content from a Command envelope", () => {
+    const json = JSON.stringify({ root_cause: "race condition" });
+    expect(unwrapToolEnvelope(command(json))).toBe(json);
+  });
+
+  it("takes the last message when a Command has several", () => {
+    expect(unwrapToolEnvelope(command("first", "second", "final"))).toBe(
+      "final",
+    );
+  });
+
+  it("reverse-scans past trailing messages with no content", () => {
+    const cmd = {
+      update: { messages: [{ content: "real" }, { content: null }, {}] },
+    };
+    expect(unwrapToolEnvelope(cmd)).toBe("real");
+  });
+
+  it("reads serialized message content under kwargs.content", () => {
+    const cmd = {
+      update: {
+        messages: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "ToolMessage"],
+            kwargs: { content: "from-kwargs" },
+          },
+        ],
+      },
+    };
+    expect(unwrapToolEnvelope(cmd)).toBe("from-kwargs");
+  });
+
+  it("unwraps a bare ToolMessage to its content", () => {
+    expect(unwrapToolEnvelope(toolMessage("hello"))).toBe("hello");
+  });
+
+  it("unwraps the last ToolMessage from a message list", () => {
+    const list = [toolMessage("a"), toolMessage("b")];
+    expect(unwrapToolEnvelope(list)).toBe("b");
+  });
+
+  it("unwraps a Command nested inside a message list", () => {
+    expect(unwrapToolEnvelope([command("x"), command("y")])).toBe("y");
+  });
+
+  it("returns a content-block array unchanged (caller handles text join)", () => {
+    const blocks = [
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world" },
+    ];
+    expect(unwrapToolEnvelope(blocks)).toBe(blocks);
+  });
+
+  it("returns a plain { content } data object unchanged (not a message)", () => {
+    const obj = { content: "not-a-message", other: 1 };
+    expect(unwrapToolEnvelope(obj)).toBe(obj);
+  });
+
+  it("returns a plain object unchanged", () => {
+    const obj = { foo: "bar" };
+    expect(unwrapToolEnvelope(obj)).toBe(obj);
+  });
+
+  it("returns a Command with no message payload unchanged", () => {
+    const cmd = { update: { files: {} } };
+    expect(unwrapToolEnvelope(cmd)).toBe(cmd);
+  });
+});

--- a/libs/providers/quickjs/src/coerce.test.ts
+++ b/libs/providers/quickjs/src/coerce.test.ts
@@ -1,20 +1,21 @@
 import { describe, it, expect } from "vitest";
+import { Command } from "@langchain/langgraph";
+import { ToolMessage } from "@langchain/core/messages";
 import { unwrapToolEnvelope } from "./coerce.js";
 
-/** A Command-shaped value like the deepagents task tool resolves to. */
-function command(...contents: unknown[]) {
-  return {
-    lg_name: "Command",
+/** A Command like the deepagents task tool resolves to. */
+function command(...contents: unknown[]): Command {
+  return new Command({
     update: {
-      files: {},
-      messages: contents.map((content) => ({ content })),
+      messages: contents.map(
+        (content, i) =>
+          new ToolMessage({
+            content: content as string,
+            tool_call_id: `c${i}`,
+          }),
+      ),
     },
-  };
-}
-
-/** A ToolMessage-shaped value (live-instance style). */
-function toolMessage(content: unknown) {
-  return { content, tool_call_id: "call_1", _getType: () => "tool" };
+  });
 }
 
 describe("unwrapToolEnvelope", () => {
@@ -38,60 +39,20 @@ describe("unwrapToolEnvelope", () => {
     );
   });
 
-  it("reverse-scans past trailing messages with no content", () => {
-    const cmd = {
-      update: { messages: [{ content: "real" }, { content: null }, {}] },
-    };
-    expect(unwrapToolEnvelope(cmd)).toBe("real");
-  });
-
-  it("reads serialized message content under kwargs.content", () => {
-    const cmd = {
-      update: {
-        messages: [
-          {
-            lc: 1,
-            type: "constructor",
-            id: ["langchain_core", "messages", "ToolMessage"],
-            kwargs: { content: "from-kwargs" },
-          },
-        ],
-      },
-    };
-    expect(unwrapToolEnvelope(cmd)).toBe("from-kwargs");
-  });
-
   it("unwraps a bare ToolMessage to its content", () => {
-    expect(unwrapToolEnvelope(toolMessage("hello"))).toBe("hello");
-  });
-
-  /** A serialized LangChain message (payload only under kwargs.content). */
-  function serializedMessage(content: unknown) {
-    return {
-      lc: 1,
-      type: "constructor",
-      id: ["langchain_core", "messages", "ToolMessage"],
-      kwargs: { content },
-    };
-  }
-
-  it("unwraps a bare serialized ToolMessage (content under kwargs)", () => {
-    expect(unwrapToolEnvelope(serializedMessage("serialized"))).toBe(
-      "serialized",
-    );
-  });
-
-  it("unwraps the last entry from a list of serialized messages", () => {
-    const list = [serializedMessage("a"), serializedMessage("b")];
-    expect(unwrapToolEnvelope(list)).toBe("b");
+    const message = new ToolMessage({ content: "hello", tool_call_id: "c0" });
+    expect(unwrapToolEnvelope(message)).toBe("hello");
   });
 
   it("unwraps the last ToolMessage from a message list", () => {
-    const list = [toolMessage("a"), toolMessage("b")];
+    const list = [
+      new ToolMessage({ content: "a", tool_call_id: "a" }),
+      new ToolMessage({ content: "b", tool_call_id: "b" }),
+    ];
     expect(unwrapToolEnvelope(list)).toBe("b");
   });
 
-  it("unwraps a Command nested inside a message list", () => {
+  it("unwraps a Command nested in a list", () => {
     expect(unwrapToolEnvelope([command("x"), command("y")])).toBe("y");
   });
 
@@ -114,7 +75,7 @@ describe("unwrapToolEnvelope", () => {
   });
 
   it("returns a Command with no message payload unchanged", () => {
-    const cmd = { update: { files: {} } };
+    const cmd = new Command({ update: { files: {} } });
     expect(unwrapToolEnvelope(cmd)).toBe(cmd);
   });
 });

--- a/libs/providers/quickjs/src/coerce.test.ts
+++ b/libs/providers/quickjs/src/coerce.test.ts
@@ -65,6 +65,27 @@ describe("unwrapToolEnvelope", () => {
     expect(unwrapToolEnvelope(toolMessage("hello"))).toBe("hello");
   });
 
+  /** A serialized LangChain message (payload only under kwargs.content). */
+  function serializedMessage(content: unknown) {
+    return {
+      lc: 1,
+      type: "constructor",
+      id: ["langchain_core", "messages", "ToolMessage"],
+      kwargs: { content },
+    };
+  }
+
+  it("unwraps a bare serialized ToolMessage (content under kwargs)", () => {
+    expect(unwrapToolEnvelope(serializedMessage("serialized"))).toBe(
+      "serialized",
+    );
+  });
+
+  it("unwraps the last entry from a list of serialized messages", () => {
+    const list = [serializedMessage("a"), serializedMessage("b")];
+    expect(unwrapToolEnvelope(list)).toBe("b");
+  });
+
   it("unwraps the last ToolMessage from a message list", () => {
     const list = [toolMessage("a"), toolMessage("b")];
     expect(unwrapToolEnvelope(list)).toBe("b");

--- a/libs/providers/quickjs/src/coerce.ts
+++ b/libs/providers/quickjs/src/coerce.ts
@@ -29,10 +29,17 @@ function isCommandLike(value: unknown): value is Record<string, unknown> {
  * by a message discriminator so arbitrary tool results aren't misread.
  */
 function isMessageLike(value: unknown): boolean {
-  if (!isPlainObject(value) || "update" in value || !("content" in value)) {
+  if (!isPlainObject(value) || "update" in value) {
     return false;
   }
   const v = value as Record<string, unknown>;
+  // Content sits at the top level on live instances, or under `kwargs` on the
+  // serialized form — accept either so bare serialized messages aren't missed.
+  const hasContent =
+    "content" in v || (isPlainObject(v.kwargs) && "content" in v.kwargs);
+  if (!hasContent) {
+    return false;
+  }
   return (
     typeof v._getType === "function" ||
     typeof v.getType === "function" ||

--- a/libs/providers/quickjs/src/coerce.ts
+++ b/libs/providers/quickjs/src/coerce.ts
@@ -93,12 +93,10 @@ export function unwrapToolEnvelope(value: unknown): unknown {
   if (typeof value === "string") {
     return value;
   }
-
   if (isCommandLike(value)) {
     const inner = extractCommandContent(value);
     return inner === value ? value : unwrapToolEnvelope(inner);
   }
-
   if (isMessageLike(value)) {
     return unwrapToolEnvelope(messageContent(value));
   }

--- a/libs/providers/quickjs/src/coerce.ts
+++ b/libs/providers/quickjs/src/coerce.ts
@@ -7,81 +7,25 @@
  * the underlying output, not the envelope, so this unwraps those shapes to the
  * content the model actually cares about.
  */
-
-/**
- * Narrow to a non-null, non-array object.
- */
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-/**
- * A LangGraph `Command`-like value: an object carrying an `update` payload.
- * Live `Command` instances and their serialized form both expose `update`.
- */
-function isCommandLike(value: unknown): value is Record<string, unknown> {
-  return isPlainObject(value) && "update" in value;
-}
-
-/**
- * A LangChain message-like value (e.g. `ToolMessage`): an object with `content`
- * that is not a `Command`, distinguished from a plain `{ content }` data object
- * by a message discriminator so arbitrary tool results aren't misread.
- */
-function isMessageLike(value: unknown): boolean {
-  if (!isPlainObject(value) || "update" in value) {
-    return false;
-  }
-  const v = value as Record<string, unknown>;
-  // Content sits at the top level on live instances, or under `kwargs` on the
-  // serialized form — accept either so bare serialized messages aren't missed.
-  const hasContent =
-    "content" in v || (isPlainObject(v.kwargs) && "content" in v.kwargs);
-  if (!hasContent) {
-    return false;
-  }
-  return (
-    typeof v._getType === "function" ||
-    typeof v.getType === "function" ||
-    "tool_call_id" in v ||
-    v.lc_serializable === true ||
-    // serialized LangChain message: id: ["langchain_core","messages","ToolMessage"]
-    Array.isArray(v.id)
-  );
-}
-
-/**
- * Read a message's content, handling live instances and serialized form.
- */
-function messageContent(message: unknown): unknown {
-  if (!isPlainObject(message)) {
-    return undefined;
-  }
-  if (message.content != null) {
-    return message.content;
-  }
-
-  const kwargs = message.kwargs;
-  if (isPlainObject(kwargs) && kwargs.content != null) {
-    return kwargs.content;
-  }
-
-  return undefined;
-}
+import { isCommand, type Command } from "@langchain/langgraph";
+import { BaseMessage } from "@langchain/core/messages";
 
 /**
  * Return the trailing message content from a `Command`'s `update.messages`,
  * scanning from the end for the last message that actually has content. Returns
  * the command unchanged when it has no message-shaped payload.
  */
-function extractCommandContent(command: Record<string, unknown>): unknown {
-  const update = command.update;
-  const messages = isPlainObject(update) ? update.messages : undefined;
+function extractCommandContent(command: Command): unknown {
+  const update: unknown = command.update;
+  const messages =
+    update !== null && typeof update === "object"
+      ? (update as { messages?: unknown }).messages
+      : undefined;
   if (Array.isArray(messages)) {
     for (let i = messages.length - 1; i >= 0; i--) {
-      const content = messageContent(messages[i]);
-      if (content != null) {
-        return content;
+      const message = messages[i];
+      if (BaseMessage.isInstance(message) && message.content != null) {
+        return message.content;
       }
     }
   }
@@ -97,30 +41,26 @@ function extractCommandContent(command: Record<string, unknown>): unknown {
  * @returns The unwrapped content, or `value` itself when it isn't an envelope.
  */
 export function unwrapToolEnvelope(value: unknown): unknown {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (isCommandLike(value)) {
+  if (typeof value === "string") return value;
+
+  if (isCommand(value)) {
     const inner = extractCommandContent(value);
     return inner === value ? value : unwrapToolEnvelope(inner);
   }
-  if (isMessageLike(value)) {
-    return unwrapToolEnvelope(messageContent(value));
+
+  if (BaseMessage.isInstance(value)) {
+    return unwrapToolEnvelope(value.content);
   }
 
   if (Array.isArray(value)) {
     for (let i = value.length - 1; i >= 0; i--) {
       const entry = value[i];
-      if (isMessageLike(entry)) {
-        const content = messageContent(entry);
-        return unwrapToolEnvelope(content);
+      if (BaseMessage.isInstance(entry)) {
+        return unwrapToolEnvelope(entry.content);
       }
-
-      if (isCommandLike(entry)) {
+      if (isCommand(entry)) {
         const inner = extractCommandContent(entry);
-        if (inner !== entry) {
-          return unwrapToolEnvelope(inner);
-        }
+        if (inner !== entry) return unwrapToolEnvelope(inner);
       }
     }
     return value;

--- a/libs/providers/quickjs/src/coerce.ts
+++ b/libs/providers/quickjs/src/coerce.ts
@@ -1,0 +1,125 @@
+/**
+ * Coercion of tool / subagent return values for the QuickJS bridge.
+ *
+ * The deepagents `task` tool resolves to a LangGraph `Command` whose payload
+ * carries the subagent's final message(s) under `update.messages`; some tools
+ * return a `ToolMessage` or a list of messages. The interpreter bridges need
+ * the underlying output, not the envelope, so this unwraps those shapes to the
+ * content the model actually cares about.
+ */
+
+/**
+ * Narrow to a non-null, non-array object.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * A LangGraph `Command`-like value: an object carrying an `update` payload.
+ * Live `Command` instances and their serialized form both expose `update`.
+ */
+function isCommandLike(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value) && "update" in value;
+}
+
+/**
+ * A LangChain message-like value (e.g. `ToolMessage`): an object with `content`
+ * that is not a `Command`, distinguished from a plain `{ content }` data object
+ * by a message discriminator so arbitrary tool results aren't misread.
+ */
+function isMessageLike(value: unknown): boolean {
+  if (!isPlainObject(value) || "update" in value || !("content" in value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v._getType === "function" ||
+    typeof v.getType === "function" ||
+    "tool_call_id" in v ||
+    v.lc_serializable === true ||
+    // serialized LangChain message: id: ["langchain_core","messages","ToolMessage"]
+    Array.isArray(v.id)
+  );
+}
+
+/**
+ * Read a message's content, handling live instances and serialized form.
+ */
+function messageContent(message: unknown): unknown {
+  if (!isPlainObject(message)) {
+    return undefined;
+  }
+  if (message.content != null) {
+    return message.content;
+  }
+
+  const kwargs = message.kwargs;
+  if (isPlainObject(kwargs) && kwargs.content != null) {
+    return kwargs.content;
+  }
+
+  return undefined;
+}
+
+/**
+ * Return the trailing message content from a `Command`'s `update.messages`,
+ * scanning from the end for the last message that actually has content. Returns
+ * the command unchanged when it has no message-shaped payload.
+ */
+function extractCommandContent(command: Record<string, unknown>): unknown {
+  const update = command.update;
+  const messages = isPlainObject(update) ? update.messages : undefined;
+  if (Array.isArray(messages)) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const content = messageContent(messages[i]);
+      if (content != null) {
+        return content;
+      }
+    }
+  }
+  return command;
+}
+
+/**
+ * Unwrap a LangChain `Command` / `ToolMessage` / message-list envelope to the
+ * underlying content. Non-envelope values (strings, content-block arrays, plain
+ * objects) are returned unchanged.
+ *
+ * @param value The raw value returned by a tool or subagent dispatch.
+ * @returns The unwrapped content, or `value` itself when it isn't an envelope.
+ */
+export function unwrapToolEnvelope(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (isCommandLike(value)) {
+    const inner = extractCommandContent(value);
+    return inner === value ? value : unwrapToolEnvelope(inner);
+  }
+
+  if (isMessageLike(value)) {
+    return unwrapToolEnvelope(messageContent(value));
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = value.length - 1; i >= 0; i--) {
+      const entry = value[i];
+      if (isMessageLike(entry)) {
+        const content = messageContent(entry);
+        return unwrapToolEnvelope(content);
+      }
+
+      if (isCommandLike(entry)) {
+        const inner = extractCommandContent(entry);
+        if (inner !== entry) {
+          return unwrapToolEnvelope(inner);
+        }
+      }
+    }
+    return value;
+  }
+
+  return value;
+}

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -399,6 +399,52 @@ describe("createCodeInterpreterMiddleware", () => {
       expect(result).toContain("bug1");
     });
 
+    it("should unwrap a Command result and parse structured output in REPL", async () => {
+      // The real deepagents task tool resolves to a Command envelope, not a
+      // plain string. The bridge must unwrap update.messages[-1].content.
+      const structured = { bugs: ["bug1", "bug2"] };
+      const mockTaskTool = {
+        name: "task",
+        invoke: vi.fn().mockResolvedValue({
+          lg_name: "Command",
+          update: {
+            files: {},
+            messages: [{ content: JSON.stringify(structured) }],
+          },
+        }),
+      };
+
+      const middleware = createCodeInterpreterMiddleware();
+      const jsTool = middleware.tools!.find(
+        (t: any) => t.name === "eval",
+      ) as any;
+
+      const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+      await middleware.wrapModelCall!(
+        {
+          systemMessage: new SystemMessage("Base"),
+          state: {},
+          runtime: { configurable: { thread_id: "command-unwrap-test" } },
+          tools: [...(middleware.tools || []), mockTaskTool],
+        } as any,
+        mockHandler,
+      );
+
+      const result = await jsTool.invoke(
+        {
+          code: `const r = await task({
+            description: "find bugs",
+            subagentType: "researcher",
+            responseSchema: { type: "object", properties: { bugs: { type: "array" } } },
+          });
+          r.bugs[1]`,
+        },
+        { configurable: { thread_id: "command-unwrap-test" } },
+      );
+
+      expect(result).toContain("bug2");
+    });
+
     it("should use fresh config on each eval call for tracing context", async () => {
       const configs: any[] = [];
       const mockTaskTool = {

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { tool } from "langchain";
 import * as z from "zod";
-import { SystemMessage } from "@langchain/core/messages";
+import { SystemMessage, ToolMessage } from "@langchain/core/messages";
+import { Command } from "@langchain/langgraph";
 import {
   createCodeInterpreterMiddleware,
   generatePtcPrompt,
@@ -405,13 +406,18 @@ describe("createCodeInterpreterMiddleware", () => {
       const structured = { bugs: ["bug1", "bug2"] };
       const mockTaskTool = {
         name: "task",
-        invoke: vi.fn().mockResolvedValue({
-          lg_name: "Command",
-          update: {
-            files: {},
-            messages: [{ content: JSON.stringify(structured) }],
-          },
-        }),
+        invoke: vi.fn().mockResolvedValue(
+          new Command({
+            update: {
+              messages: [
+                new ToolMessage({
+                  content: JSON.stringify(structured),
+                  tool_call_id: "c0",
+                }),
+              ],
+            },
+          }),
+        ),
       };
 
       const middleware = createCodeInterpreterMiddleware();

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -38,6 +38,7 @@ import {
   safeToJsonSchema,
 } from "./utils.js";
 import { validateResponseSchema } from "./subagent-dispatch.js";
+import { unwrapToolEnvelope } from "./coerce.js";
 
 /**
  * These type-only imports are required for TypeScript's type inference to work
@@ -432,14 +433,18 @@ export function createCodeInterpreterMiddleware(
         toolConfig,
       );
 
-      if (hasSchema && typeof result === "string") {
+      // The task tool resolves to a Command envelope; unwrap it to the
+      // subagent's actual output before handing it back to the REPL.
+      const content = unwrapToolEnvelope(result);
+
+      if (hasSchema && typeof content === "string") {
         try {
-          return JSON.parse(result);
+          return JSON.parse(content);
         } catch {
-          return result;
+          return content;
         }
       }
-      return result;
+      return content;
     };
   }
 

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -34,6 +34,7 @@ import type {
   SubagentBridgeOptions,
 } from "./types.js";
 import { toCamelCase } from "./utils.js";
+import { unwrapToolEnvelope } from "./coerce.js";
 import { transformForEval } from "./transform.js";
 import { AsyncEvalQueue } from "./eval-queue.js";
 import PQueue from "p-queue";
@@ -99,6 +100,10 @@ function getSharedModule(): Promise<QuickJSAsyncWASMModule> {
  * @returns Plain string representation of the tool output.
  */
 function extractToolText(result: unknown): string {
+  // Unwrap LangChain Command / ToolMessage / message-list envelopes (e.g. a
+  // PTC tool that returns a Command) before extracting text.
+  result = unwrapToolEnvelope(result);
+
   if (typeof result === "string") {
     return result;
   }


### PR DESCRIPTION
### Summary

The deepagents `task` tool resolves to a LangGraph `Command` (and some tools return a `ToolMessage` or a list of messages), but the quickjs bridges passed these envelopes straight to the REPL so `task(...)` and PTC `tools.*` calls handed the model the wrapper instead of the subagent's actual output, breaking the contract that a `responseSchema` dispatch resolves to a typed value.

This PR adds `unwrapToolEnvelope`: a duck-typed unwrap of `Command` / `ToolMessage` / message-list shapes that reverse-scans `update.messages` for the last message with content and reads both live and serialized forms. Non-envelope values pass through unchanged.

`unwrapToolEnvelope` is wired into both bridges, i.e., the `task()` dispatch and the PTC `tools.*` bridge.

Inspired by the Python's [`coerce_tool_output_for_ptc`](https://github.com/langchain-ai/deepagents/blob/4c347603162e181c721e5e2a5ca8bbff6828e23c/libs/partners/quickjs/langchain_quickjs/_format.py#L93-L119).

### Tests

- `coerce.test.ts` provide unit test coverage for `unwrapToolEnvelope`: string/null/undefined passthrough, `Command` (single + multi-message), reverse-scan past empty trailing messages, serialized `kwargs.content`, bare `ToolMessage`, message lists, content-block arrays and plain `{ content }` objects left untouched.
- `middleware.test.ts` provides an integration test that the `task()` bridge returns the parsed structured value from a `Command` result.