### PR TITLE
chore(quickjs): disallow task as a configurable ptc tool

### DIFF
--- a/.changeset/fiery-parrots-wonder.md
+++ b/.changeset/fiery-parrots-wonder.md
@@ -1,0 +1,5 @@
+---
+"@langchain/quickjs": minor
+---
+
+chore(quickjs): disallow task as a configurable ptc tool

--- a/examples/repl/rlm-agent.ts
+++ b/examples/repl/rlm-agent.ts
@@ -55,8 +55,7 @@ const agent = createDeepAgent({
     When given a complex research task:
     1. Break it into independent sub-tasks
     2. Write a single eval call that spawns ALL sub-agents in parallel
-    3. Aggregate and analyze the results programmatically in the same code
-       block, and return the report
+    3. Aggregate and analyze the results programmatically in the same code block
     4. Write your final synthesis to a file
 
     \`\`\`typescript

--- a/examples/repl/rlm-agent.ts
+++ b/examples/repl/rlm-agent.ts
@@ -1,10 +1,11 @@
 /**
  * Recursive Language Model (RLM) Example
  *
- * Demonstrates the RLM pattern using the QuickJS REPL middleware with
- * programmatic tool calling (PTC). The agent writes code that spawns
- * sub-agents via `tools.task()`, processes their results programmatically,
- * and aggregates findings — all within the sandboxed REPL.
+ * Demonstrates the RLM pattern using the QuickJS REPL middleware. The agent
+ * writes code that spawns sub-agents via the `task()` global, processes their
+ * results programmatically, and aggregates findings — all within the
+ * sandboxed REPL. `task()` is always available in the REPL when the agent has
+ * subagents configured; it does not need to be exposed via PTC.
  *
  * This is the core RLM insight: instead of the LLM verbalizing each
  * sub-agent call as a separate tool invocation, it writes a loop that
@@ -12,10 +13,10 @@
  *
  * Architecture:
  * ```
- * Agent (with eval + PTC)
+ * Agent (with eval)
  *   └── REPL code
- *       ├── tools.task({ description: "analyze chunk 1", ... })
- *       ├── tools.task({ description: "analyze chunk 2", ... })
+ *       ├── task({ description: "analyze chunk 1", ... })
+ *       ├── task({ description: "analyze chunk 2", ... })
  *       └── ... (N parallel sub-agent calls via Promise.all)
  *       └── programmatic aggregation of results
  * ```
@@ -25,7 +26,7 @@ import "dotenv/config";
 import dedent from "dedent";
 import { HumanMessage } from "@langchain/core/messages";
 import { createDeepAgent, type SubAgent } from "deepagents";
-import { createREPLMiddleware } from "@langchain/quickjs";
+import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 import { ChatOpenAI } from "@langchain/openai";
 
 const generalPurpose: SubAgent = {
@@ -47,44 +48,40 @@ const agent = createDeepAgent({
     You are a research analyst that uses code to orchestrate sub-agents.
 
     **CRITICAL: Always use Promise.all to spawn sub-agents in parallel.**
-    Never call tools.task() sequentially in a loop — always build an array
-    of promises and await them together with Promise.all. This runs all
+    Never call task() sequentially in a loop — always build an array of
+    promises and await them together with Promise.all. This runs all
     sub-agents concurrently and is dramatically faster.
 
     When given a complex research task:
     1. Break it into independent sub-tasks
-    2. Write a single eval call that spawns ALL sub-agents in parallel
-    3. Aggregate and analyze the results programmatically in the same code block
-    4. Write your final synthesis to a file
+    2. Write a single eval call that spawns ALL sub-agents in parallel and
+       returns the aggregated report
+    3. Write your final synthesis to a file with your write_file tool
 
     \`\`\`typescript
     const topics = ["topic A", "topic B", "topic C"];
 
-    // ALWAYS fan out in parallel like this:
+    // ALWAYS fan out in parallel like this, using the task() global:
     const results = await Promise.all(
       topics.map(topic =>
-        tools.task({
+        task({
           description: \`Research \${topic} in depth. Return key findings.\`,
           subagentType: "general-purpose",
         })
       )
     );
 
-    // Then aggregate programmatically
+    // Aggregate programmatically and return the report from the eval.
     const report = topics.map((t, i) => \`## \${t}\\n\${results[i]}\`).join("\\n\\n");
-    await writeFile("/research.md", report);
+    report;
     \`\`\`
 
-    Do all sub-agent spawning, result processing, and file writing in a
-    single eval call. Do not use multiple sequential eval calls
-    when the work can be parallelized.
+    Do all sub-agent spawning and aggregation in a single eval call and return
+    the report. Then write your final synthesis to a file with write_file. Do
+    not use multiple sequential eval calls when the work can be parallelized.
   `,
   subagents: [generalPurpose],
-  middleware: [
-    createREPLMiddleware({
-      ptc: ["task"],
-    }),
-  ],
+  middleware: [createCodeInterpreterMiddleware()],
 });
 
 const result = await agent.invoke({

--- a/examples/repl/rlm-agent.ts
+++ b/examples/repl/rlm-agent.ts
@@ -54,9 +54,10 @@ const agent = createDeepAgent({
 
     When given a complex research task:
     1. Break it into independent sub-tasks
-    2. Write a single eval call that spawns ALL sub-agents in parallel and
-       returns the aggregated report
-    3. Write your final synthesis to a file with your write_file tool
+    2. Write a single eval call that spawns ALL sub-agents in parallel
+    3. Aggregate and analyze the results programmatically in the same code
+       block, and return the report
+    4. Write your final synthesis to a file
 
     \`\`\`typescript
     const topics = ["topic A", "topic B", "topic C"];

--- a/libs/providers/quickjs/README.md
+++ b/libs/providers/quickjs/README.md
@@ -100,7 +100,9 @@ PTC configuration is progressive:
 
 ### Recursive Language Model (RLM)
 
-When the `task` tool is exposed via PTC, the agent can spawn sub-agents in parallel from within the REPL:
+When the agent has subagents configured, a `task()` global is available inside
+the REPL (no PTC needed), so the agent can spawn sub-agents in parallel from
+within the REPL:
 
 ```typescript
 const agent = createDeepAgent({
@@ -112,7 +114,7 @@ const agent = createDeepAgent({
       systemPrompt: "...",
     },
   ],
-  middleware: [createQuickJSMiddleware({ ptc: ["task"] })],
+  middleware: [createQuickJSMiddleware()],
 });
 ```
 
@@ -122,15 +124,20 @@ The agent then writes code like:
 const topics = ["quantum computing", "fusion energy", "CRISPR"];
 const results = await Promise.all(
   topics.map((topic) =>
-    tools.task({
+    task({
       description: `Research ${topic} in depth`,
       subagentType: "general-purpose",
     }),
   ),
 );
+// Aggregate and return the report from the eval; the agent then writes it to a
+// file with its own write_file tool.
 const report = topics.map((t, i) => `## ${t}\n${results[i]}`).join("\n\n");
-await writeFile("/research.md", report);
+report;
 ```
+
+> `task` cannot be exposed via `ptc` — it is reserved for the `task()` global,
+> so passing `ptc: ["task"]` throws.
 
 ## API
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -172,17 +172,6 @@ describe("createCodeInterpreterMiddleware", () => {
         /task` tool cannot be exposed/,
       );
     });
-
-    it("should allow names that merely resemble `task`", () => {
-      const tasks = tool(async () => "ok", {
-        name: "tasks",
-        description: "not the subagent task tool",
-        schema: z.object({}),
-      });
-      const result = resolveToolList(["tasks"], [tasks]);
-      expect(result).toHaveLength(1);
-      expect(result[0]).toBe(tasks);
-    });
   });
 
   describe("ptc with tool instances via wrapModelCall", () => {

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -150,6 +150,39 @@ describe("createCodeInterpreterMiddleware", () => {
     it("should return empty array for empty items list", () => {
       expect(resolveToolList([], [agentSearch])).toHaveLength(0);
     });
+
+    it("should throw when the `task` tool is requested by name", () => {
+      const taskTool = tool(async () => "ok", {
+        name: "task",
+        description: "subagent task",
+        schema: z.object({}),
+      });
+      expect(() => resolveToolList(["task"], [taskTool])).toThrow(
+        /task` tool cannot be exposed/,
+      );
+    });
+
+    it("should throw when a `task`-named tool instance is requested", () => {
+      const taskTool = tool(async () => "ok", {
+        name: "task",
+        description: "subagent task",
+        schema: z.object({}),
+      });
+      expect(() => resolveToolList([taskTool], [])).toThrow(
+        /task` tool cannot be exposed/,
+      );
+    });
+
+    it("should allow names that merely resemble `task`", () => {
+      const tasks = tool(async () => "ok", {
+        name: "tasks",
+        description: "not the subagent task tool",
+        schema: z.object({}),
+      });
+      const result = resolveToolList(["tasks"], [tasks]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(tasks);
+    });
   });
 
   describe("ptc with tool instances via wrapModelCall", () => {

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -354,6 +354,9 @@ export async function generatePtcPrompt(
  * StructuredToolInterface objects. Strings are looked up by name in agentTools;
  * instances are included directly without requiring agent registration. Strings
  * that don't match any agent tool are silently omitted.
+ *
+ * Throws if the subagent `task` tool is requested (by name or instance): it is
+ * reserved for the `task()` global and cannot be a `tools.*` PTC member.
  */
 export function resolveToolList(
   items: (string | StructuredToolInterface)[],
@@ -361,6 +364,16 @@ export function resolveToolList(
 ): StructuredToolInterface[] {
   const agentByName = new Map(agentTools.map((t) => [t.name, t]));
   return items.flatMap((item) => {
+    const name = typeof item === "string" ? item : item.name;
+    if (name === "task") {
+      throw new Error(
+        "The subagent `task` tool cannot be exposed via `ptc`. It is always " +
+          "available as the top-level `task()` global inside the REPL (with " +
+          "`subagentType` and `responseSchema` support); exposing it through the " +
+          "`tools.*` namespace would create a second, conflicting dispatch path " +
+          'that drops `responseSchema`. Remove "task" from `ptc`.',
+      );
+    }
     if (typeof item === "string") {
       const found = agentByName.get(item);
       return found ? [found] : [];


### PR DESCRIPTION
### Summary

The code interpreter now comes with a global `task` tool out of the box. As a result, we should disallow specifying the `task` tool for ptc. This PR implements logic that forbids the task tool as in ptc and throws with a  detailed error message if found. This PR also updates the RLM agent example and READMEs.

### Tests

Unit tests validating expected behavior for task by name and tool instance with "task" name.