### PR TITLE
fix(deepagents): forward subagent results as text

### DIFF
--- a/.changeset/eight-pillows-leave.md
+++ b/.changeset/eight-pillows-leave.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): forward subagent results as text
+
+Fixed a 400 `invalid_request_error` that occurred when a subagent used an Anthropic server-side tool (web search, web fetch, or code execution): the subagent's `server_tool_use`/`*_tool_result` blocks were forwarded to the parent agent as `tool_result` content, which the API rejects. Subagent results are now passed back to the parent as their text content (matching the Python implementation), which resolves the error and also handles a trailing empty `end_turn` message.

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -345,10 +345,8 @@ describe("Subagent content block filtering", () => {
       ],
     });
 
-    const checkpointer = new MemorySaver();
     const agent = createDeepAgent({
       model,
-      checkpointer,
       subagents: [
         {
           name: "worker",
@@ -384,10 +382,7 @@ describe("Subagent content block filtering", () => {
       (msg: BaseMessage) => (msg as ToolMessage).name === "task",
     ) as ToolMessage;
     expect(taskToolMessage).toBeDefined();
-    expect(taskToolMessage.content).toContainEqual({
-      type: "text",
-      text: "Here is the result",
-    });
+    expect(taskToolMessage.content).toBe("Here is the result");
   });
 
   it("should filter thinking and redacted_thinking blocks from subagent response content", async () => {
@@ -424,10 +419,8 @@ describe("Subagent content block filtering", () => {
       ],
     });
 
-    const checkpointer = new MemorySaver();
     const agent = createDeepAgent({
       model,
-      checkpointer,
       subagents: [
         {
           name: "worker",
@@ -452,19 +445,125 @@ describe("Subagent content block filtering", () => {
         ToolMessage.isInstance(msg) && (msg as ToolMessage).name === "task",
     ) as ToolMessage;
     expect(taskToolMessage).toBeDefined();
-    expect(taskToolMessage.content).toContainEqual({
-      type: "text",
-      text: "Final answer",
+    expect(taskToolMessage.content).toBe("Final answer");
+  });
+
+  it("should filter Anthropic server-tool blocks from subagent response content", async () => {
+    const mockSubagent = RunnableLambda.from(async () => ({
+      messages: [
+        new AIMessage({
+          content: [
+            {
+              type: "server_tool_use",
+              id: "srvtoolu_1",
+              name: "web_search",
+              input: { query: "example" },
+            },
+            {
+              type: "web_search_tool_result",
+              tool_use_id: "srvtoolu_1",
+              content: [
+                {
+                  type: "web_search_result",
+                  title: "Example",
+                  url: "https://example.com",
+                  encrypted_content: "...",
+                },
+              ],
+            },
+            { type: "text", text: "Final answer" },
+          ],
+        }),
+      ],
+    }));
+
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "Do work",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+        "Done",
+      ],
     });
-    if (Array.isArray(taskToolMessage.content)) {
-      const invalidBlocks = (
-        taskToolMessage.content as Array<{ type: string }>
-      ).filter(
-        (block) =>
-          block.type === "thinking" || block.type === "redacted_thinking",
-      );
-      expect(invalidBlocks).toHaveLength(0);
-    }
+
+    const agent = createDeepAgent({
+      model,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          runnable: mockSubagent,
+        },
+      ],
+    });
+
+    const result = await agent.invoke({ messages: [new HumanMessage("Test")] });
+
+    const taskToolMessage = result.messages.find(
+      (msg: BaseMessage) =>
+        ToolMessage.isInstance(msg) && (msg as ToolMessage).name === "task",
+    ) as ToolMessage;
+    expect(taskToolMessage.content).not.toContain("server_tool_use");
+  });
+
+  it("should use the last AIMessage with non-empty text, skipping a trailing empty message", async () => {
+    const mockSubagent = RunnableLambda.from(async () => ({
+      messages: [
+        new AIMessage({ content: "The real answer" }),
+        // Anthropic sometimes emits a trailing empty `end_turn` AIMessage.
+        new AIMessage({ content: "" }),
+      ],
+    }));
+
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "Do work",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+        "Done",
+      ],
+    });
+
+    const agent = createDeepAgent({
+      model,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          runnable: mockSubagent,
+        },
+      ],
+    });
+
+    const result = await agent.invoke({ messages: [new HumanMessage("Test")] });
+
+    const taskToolMessage = result.messages.find(
+      (msg: BaseMessage) =>
+        ToolMessage.isInstance(msg) && (msg as ToolMessage).name === "task",
+    ) as ToolMessage;
+    expect(taskToolMessage.content).toBe("The real answer");
   });
 
   it("should fall back to 'Task completed' when all content blocks are invalid", async () => {

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -464,11 +464,7 @@ function returnCommandWithStateUpdate(
       const text =
         typeof message.content === "string"
           ? message.content.trim()
-          : message.content
-              .filter((block) => block.type === "text")
-              .map((block) => ("text" in block ? block.text : ""))
-              .join("\n")
-              .trim();
+          : message.text?.trim() ?? "";
       if (text) {
         content = text;
         break;

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -464,7 +464,7 @@ function returnCommandWithStateUpdate(
       const text =
         typeof message.content === "string"
           ? message.content.trim()
-          : message.text?.trim() ?? "";
+          : (message.text?.trim() ?? "");
       if (text) {
         content = text;
         break;

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -19,7 +19,7 @@ import {
 import { Command, getCurrentTaskInput } from "@langchain/langgraph";
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
 import type { Runnable } from "@langchain/core/runnables";
-import { HumanMessage } from "@langchain/core/messages";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { FilesystemPermission } from "../permissions/types.js";
 
 export type { AgentMiddleware };
@@ -452,16 +452,26 @@ function returnCommandWithStateUpdate(
   if (result.structuredResponse != null) {
     content = JSON.stringify(result.structuredResponse);
   } else {
-    const messages = result.messages as BaseMessage[];
-    const lastMessage = messages?.[messages.length - 1];
-
-    content = lastMessage?.content || "Task completed";
-    if (Array.isArray(content)) {
-      content = content.filter(
-        (block) => !INVALID_TOOL_MESSAGE_BLOCK_TYPES.includes(block.type),
-      );
-      if (content.length === 0) {
-        content = "Task completed";
+    // Walk back to the last AIMessage with non-empty text and forward only that
+    // text as a string. Anthropic sometimes emits a trailing empty `end_turn`
+    // AIMessage after a final tool call, which would otherwise be forwarded as
+    // an empty ToolMessage.
+    const messages = (result.messages as BaseMessage[]) ?? [];
+    content = "Task completed";
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const message = messages[i];
+      if (!message || !AIMessage.isInstance(message)) continue;
+      const text =
+        typeof message.content === "string"
+          ? message.content.trim()
+          : message.content
+              .filter((block) => block.type === "text")
+              .map((block) => ("text" in block ? block.text : ""))
+              .join("\n")
+              .trim();
+      if (text) {
+        content = text;
+        break;
       }
     }
   }


### PR DESCRIPTION
## Summary

A deep agent that delegates to a subagent 400s when that subagent uses an Anthropic server-side tool (web search, web fetch, code execution, MCP). The subagent's final-message content blocks e.g. server_tool_use/..._tool_result were forwarded verbatim as the task ToolMessage content. On the parent agent's next request they serialize into a tool_result, which Anthropic rejects:

`400 invalid_request_error
messages.N.content.0.tool_result.content.0: Input tag 'server_tool_use' found using 'type'
does not match any of the expected tags: 'document','image','search_result','text','tool_reference'`

## Solution

Now matches the Python impl: forward only the subagent's text answer. returnCommandWithStateUpdate now walks back to the last AIMessage with non-empty text and uses that text (a string) as the ToolMessage content.

- Confirmed the Python deepagents impl is not affected (it forwards .text); this aligns JS with Python.
- Reproduced the 400 across {web_search, code_execution, web_fetch} × {claude-haiku-4-5, claude-sonnet-4-6} on the latest published packages; all green after the fix.

## Tests
- New: subagent server-tool blocks are filtered from forwarded content.
- New: walk-back uses the last non-empty AIMessage, skipping a trailing empty message.
- Updated the #239/#245 tests to assert the (now string) ToolMessage content.
- No regressions in subagent-related tests in the evals suite