### PR TITLE
fix(deepagents): declare LangChain runtime packages as peer dependencies

### DIFF
--- a/.changeset/proud-otters-rescue.md
+++ b/.changeset/proud-otters-rescue.md
@@ -1,0 +1,15 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): declare LangChain runtime packages as peer dependencies
+
+Move `@langchain/core`, `@langchain/langgraph`, `@langchain/langgraph-sdk`, and
+`langchain` from `dependencies` to `peerDependencies` so they resolve to a single
+shared instance in the consumer's tree. Previously they were bundled as regular
+dependencies, which let a consumer end up with two copies of `@langchain/core`
+(e.g. `1.2.0` vs `1.2.1`). Because these packages ship classes with private/
+protected fields, the duplicate copies are treated as nominally distinct types,
+producing errors like passing a `ChatOpenAI` model to `createDeepAgent` or a
+compiled graph to the local protocol helpers. As peers, the app controls the
+version and bumping `@langchain/core` no longer requires a `deepagents` release.

--- a/.changeset/proud-otters-rescue.md
+++ b/.changeset/proud-otters-rescue.md
@@ -5,8 +5,10 @@
 fix(deepagents): declare LangChain runtime packages as peer dependencies
 
 Move `@langchain/core`, `@langchain/langgraph`, `@langchain/langgraph-sdk`, and
-`langchain` from `dependencies` to `peerDependencies` so they resolve to a single
-shared instance in the consumer's tree. Previously they were bundled as regular
+`langchain` from `dependencies` to `peerDependencies`, and also declare
+`@langchain/langgraph-checkpoint` as a peer (its `BaseCheckpointSaver`/`BaseStore`
+types are part of the public API), so they resolve to a single shared instance in
+the consumer's tree. Previously they were bundled as regular
 dependencies, which let a consumer end up with two copies of `@langchain/core`
 (e.g. `1.2.0` vs `1.2.1`). Because these packages ship classes with private/
 protected fields, the duplicate copies are treated as nominally distinct types,

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -44,6 +44,15 @@ pnpm add deepagents
 yarn add deepagents
 ```
 
+> [!IMPORTANT]
+> `deepagents` declares the LangChain runtime packages as **peer dependencies** so
+> your app controls their versions and everything resolves to a single shared copy. 
+> npm 7+ and pnpm 8+ install these automatically; **Yarn users must add them explicitly**:
+>
+> ```bash
+> yarn add @langchain/core @langchain/langgraph @langchain/langgraph-checkpoint @langchain/langgraph-sdk langchain langsmith
+> ```
+
 ```typescript
 import { createDeepAgent } from "deepagents";
 

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -46,7 +46,7 @@ yarn add deepagents
 
 > [!IMPORTANT]
 > `deepagents` declares the LangChain runtime packages as **peer dependencies** so
-> your app controls their versions and everything resolves to a single shared copy. 
+> your app controls their versions and everything resolves to a single shared copy.
 > npm 7+ and pnpm 8+ install these automatically; **Yarn users must add them explicitly**:
 >
 > ```bash

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -38,18 +38,17 @@
   },
   "homepage": "https://github.com/langchain-ai/deepagentsjs#readme",
   "dependencies": {
-    "@langchain/core": "^1.2.0",
-    "@langchain/langgraph": "^1.4.4",
-    "@langchain/langgraph-sdk": "^1.9.23",
     "fast-glob": "^3.3.3",
-    "langchain": "^1.5.0",
     "micromatch": "^4.0.8",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@langchain/anthropic": "^1.5.0",
+    "@langchain/core": "^1.2.0",
+    "@langchain/langgraph": "^1.4.4",
     "@langchain/langgraph-checkpoint": "^1.1.2",
+    "@langchain/langgraph-sdk": "^1.9.23",
     "@langchain/openai": "^1.5.1",
     "@langchain/sandbox-standard-tests": "workspace:*",
     "@langchain/tavily": "^1.2.0",
@@ -59,6 +58,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
     "dotenv": "^17.2.4",
+    "langchain": "^1.5.0",
     "tsdown": "^0.22.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
@@ -99,6 +99,10 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
+    "@langchain/core": "^1.2.0",
+    "@langchain/langgraph": "^1.4.4",
+    "@langchain/langgraph-sdk": "^1.9.23",
+    "langchain": "^1.5.0",
     "langsmith": "^0.7.1"
   },
   "files": [

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -101,6 +101,7 @@
   "peerDependencies": {
     "@langchain/core": "^1.2.0",
     "@langchain/langgraph": "^1.4.4",
+    "@langchain/langgraph-checkpoint": "^1.1.2",
     "@langchain/langgraph-sdk": "^1.9.23",
     "langchain": "^1.5.0",
     "langsmith": "^0.7.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,21 +605,9 @@ importers:
 
   libs/deepagents:
     dependencies:
-      '@langchain/core':
-        specifier: ^1.2.0
-        version: 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/langgraph':
-        specifier: ^1.4.4
-        version: 1.4.4(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
-      '@langchain/langgraph-sdk':
-        specifier: ^1.9.23
-        version: 1.9.23(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
-      langchain:
-        specifier: ^1.5.0
-        version: 1.5.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0)
       langsmith:
         specifier: ^0.7.1
         version: 0.7.10(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
@@ -636,9 +624,18 @@ importers:
       '@langchain/anthropic':
         specifier: ^1.5.0
         version: 1.5.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
+      '@langchain/core':
+        specifier: ^1.2.0
+        version: 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langchain/langgraph':
+        specifier: ^1.4.4
+        version: 1.4.4(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       '@langchain/langgraph-checkpoint':
         specifier: ^1.1.2
         version: 1.1.2(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
+      '@langchain/langgraph-sdk':
+        specifier: ^1.9.23
+        version: 1.9.23(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@langchain/openai':
         specifier: ^1.5.1
         version: 1.5.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)
@@ -666,6 +663,9 @@ importers:
       dotenv:
         specifier: ^17.2.4
         version: 17.4.2
+      langchain:
+        specifier: ^1.5.0
+        version: 1.5.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0)
       tsdown:
         specifier: ^0.22.1
         version: 0.22.3(tsx@4.22.4)(typescript@6.0.3)


### PR DESCRIPTION
Updates to `@langchain/core` can cause downstream friction with TypeScript:

```
Type 'ChatOpenAI<ChatOpenAICallOptions>' is not assignable to type 'string | BaseLanguageModel<any, BaseLanguageModelCallOptions> | undefined'.
  Type 'ChatOpenAI<ChatOpenAICallOptions>' is not assignable to type 'BaseLanguageModel<any, BaseLanguageModelCallOptions>'.
    Types of property 'getGraph' are incompatible.
      Type '(_?: import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/runnables/types").RunnableConfig<Record<string, any>> | undefined) => import("/Users/christian.bromann/Sites/L...' is not assignable to type '(_?: import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/runnables/types").RunnableConfig<Record<string, any>> | undefined) => import("/Users/christian.bromann/Sites/L...'.
        Types of parameters '_' and '_' are incompatible.
          Type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/runnables/types").RunnableConfig<Record<string, any>> | undefined' is not assignable to type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/runnables/types").RunnableConfig<Record<string, any>> | undefined'.
            Type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/runnables/types").RunnableConfig<Record<string, any>>' is not assignable to type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/runnables/types").RunnableConfig<Record<string, any>>'.
              Types of property 'callbacks' are incompatible.
                Type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").Callbacks | undefined' is not assignable to type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").Callbacks | undefined'.
                  Type 'CallbackManager' is not assignable to type 'Callbacks | undefined'.
                    Type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManager' is not assignable to type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManager'.
                      The types returned by 'handleLLMStart(...)' are incompatible between these types.
                        Type 'Promise<import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManagerForLLMRun[]>' is not assignable to type 'Promise<import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManagerForLLMRun[]>'.
                          Type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManagerForLLMRun[]' is not assignable to type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManagerForLLMRun[]'.
                            Type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.0_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManagerForLLMRun' is not assignable to type 'import("/Users/christian.bromann/Sites/LangChain/deployment-cookbook/js-langsmith/node_modules/.pnpm/@langchain+core@1.2.1_openai@6.44.0_ws@8.21.0_zod@4.4.3__ws@8.21.0/node_modules/@langchain/core/dist/callbacks/manager").CallbackManagerForLLMRun'.
                              Property 'inheritableHandlers' is protected but type 'BaseRunManager' is not a class derived from 'BaseRunManager'.ts(2322)
```

to avoid this we should move the LangChain dependency to become peer deps.

- Moved `@langchain/core`, `@langchain/langgraph`, `@langchain/langgraph-sdk`, and `langchain` from `dependencies` to `peerDependencies` in `libs/deepagents`, keeping dev copies for isolated build/test.
- Lets consumers bump `@langchain/core` without requiring a new `deepagents` release; a release is only needed to widen the peer range across a major.
- Note on install contract: npm 7+ and pnpm 8+ auto-install peers; Yarn only warns, so Yarn users must add the four packages explicitly (worth a README follow-up).
