### PR TITLE
fix: migrate Daytona SDK dependency [closes #609]

### DIFF
--- a/.changeset/sour-dragons-sparkle.md
+++ b/.changeset/sour-dragons-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@langchain/daytona": patch
+---
+
+Replace deprecated `@daytonaio/sdk` dependency with `@daytona/sdk`.

--- a/libs/providers/daytona/README.md
+++ b/libs/providers/daytona/README.md
@@ -208,7 +208,7 @@ await sdk.fs.createFolder("src", "755");
 await sdk.fs.uploadFile(Buffer.from("content"), "src/index.ts");
 ```
 
-See the [@daytonaio/sdk documentation](https://www.npmjs.com/package/@daytonaio/sdk) for all available SDK methods.
+See the [@daytona/sdk documentation](https://www.npmjs.com/package/@daytona/sdk) for all available SDK methods.
 
 ## Factory Functions
 

--- a/libs/providers/daytona/package.json
+++ b/libs/providers/daytona/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/langchain-ai/deepagentsjs#readme",
   "dependencies": {
-    "@daytonaio/sdk": "^0.184.0"
+    "@daytona/sdk": "^0.184.0"
   },
   "peerDependencies": {
     "deepagents": ">=1.9.0-alpha.0"

--- a/libs/providers/daytona/src/sandbox.test.ts
+++ b/libs/providers/daytona/src/sandbox.test.ts
@@ -33,7 +33,7 @@ async function* asyncIterator<T>(items: T[]): AsyncIterableIterator<T> {
 }
 
 // Mock the Daytona SDK with a proper class
-vi.mock("@daytonaio/sdk", () => {
+vi.mock("@daytona/sdk", () => {
   return {
     Daytona: class MockDaytona {
       create = mockDaytonaInstance.create;

--- a/libs/providers/daytona/src/sandbox.ts
+++ b/libs/providers/daytona/src/sandbox.ts
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 
-import { Daytona, type Sandbox } from "@daytonaio/sdk";
+import { Daytona, type Sandbox } from "@daytona/sdk";
 import {
   BaseSandbox,
   type ExecuteResponse,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,7 +681,7 @@ importers:
 
   libs/providers/daytona:
     dependencies:
-      '@daytonaio/sdk':
+      '@daytona/sdk':
         specifier: ^0.184.0
         version: 0.184.0(ws@8.21.0)
     devDependencies:
@@ -1199,9 +1199,8 @@ packages:
   '@daytona/toolbox-api-client@0.184.0':
     resolution: {integrity: sha512-uuhJJF0uLAnK6nNM7sgjTErf7NKnrc+kd0AlYjdxsDk7Nad+v0FZeecQZ4GEE4GDSr/Hg3f9SxgHFVY/rGLrCQ==}
 
-  '@daytonaio/sdk@0.184.0':
-    resolution: {integrity: sha512-9dIzN1keoS10DVVXoI1f1WEz/FeJc0iTIv2z21Yg844j2gdCclsvQJVhV3rUHRxinRLSuyr312PIb9/xZEglDg==}
-    deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
+  '@daytona/sdk@0.184.0':
+    resolution: {integrity: sha512-g5lepSxT2Q9L53LwKc7UnMsuTTAwkTVVlYz/0WpiBFPOzz733UUnM+ehlDELHBV+97FgfBwz8JlDXJe58+VY4A==}
 
   '@deno/sandbox@0.13.2':
     resolution: {integrity: sha512-hteIwQ/mqkJHLrxtcONSCntziOAEWZz0Q2m/Ps4E+HjimLaQxsqpBU0Xn6hin23yf2wOCls336PG9epbMliUOQ==}
@@ -4464,7 +4463,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@daytonaio/sdk@0.184.0(ws@8.21.0)':
+  '@daytona/sdk@0.184.0(ws@8.21.0)':
     dependencies:
       '@aws-sdk/client-s3': 3.1071.0
       '@aws-sdk/lib-storage': 3.1071.0(@aws-sdk/client-s3@3.1071.0)


### PR DESCRIPTION
## Description
Closes #609 by updating `@langchain/daytona` to the maintained `@daytona/sdk` at `^0.184.0` while preserving the same SDK API usage. Added a patch changeset; `@daytona/sdk` is Apache-2.0 and maintained by Daytona as the direct replacement for deprecated `@daytonaio/sdk`.

## Self-Hosted Release Note
`@langchain/daytona` now depends on `@daytona/sdk` instead of deprecated `@daytonaio/sdk`.

## Test Plan
- [ ] Verify package publish metadata resolves `@daytona/sdk` `^0.184.0`.

Made by [Open SWE](https://openswe.vercel.app/agents/d6f434c5-39c6-eef7-6cc6-670cf092bb67)