### PR TITLE
feat(deepagents): add registry types, items, builders

### DIFF
--- a/libs/create-deepagent/package.json
+++ b/libs/create-deepagent/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@clack/prompts": "^1.6.0",
     "commander": "^15.0.0",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.13",

--- a/libs/create-deepagent/registry/frameworks/deno.ts
+++ b/libs/create-deepagent/registry/frameworks/deno.ts
@@ -1,0 +1,12 @@
+import { createFramework } from "../../src/registry/framework.js";
+
+export const deno = createFramework({
+  id: "deno",
+  title: "Deno",
+  defaultProjectName: "deno-deepagents",
+  frameworkDir: "deno",
+  envFilePath: ".env",
+  packageJsonPath: "package.json",
+  agentPath: "server/agent",
+  files: [],
+});

--- a/libs/create-deepagent/registry/frameworks/deno/.placeholder
+++ b/libs/create-deepagent/registry/frameworks/deno/.placeholder
@@ -1,0 +1,2 @@
+# Template files are vendored from langchain-ai/deployment-cookbook.
+# This is a placeholder — replace with the actual template project.

--- a/libs/create-deepagent/registry/frameworks/hono.ts
+++ b/libs/create-deepagent/registry/frameworks/hono.ts
@@ -1,0 +1,32 @@
+import {
+  createFramework,
+  ProviderAwareFile,
+} from "../../src/registry/framework.js";
+
+const ENV_D_TS: ProviderAwareFile = {
+  path: "worker/env.d.ts",
+  getContent: ({ providerConfig }) => {
+    const envVars = providerConfig.env
+      .map((e) => `  ${e.name}: string;`)
+      .join("\n");
+
+    return `interface Env {
+  ASSETS: Fetcher;
+  SESSIONS: DurableObjectNamespace;
+${envVars}
+  [key: string]: string | undefined;
+}
+`;
+  },
+};
+
+export const hono = createFramework({
+  id: "hono",
+  title: "Hono",
+  defaultProjectName: "hono-deepagents",
+  frameworkDir: "hono",
+  envFilePath: ".env",
+  packageJsonPath: "package.json",
+  agentPath: "worker/agent",
+  files: [ENV_D_TS],
+});

--- a/libs/create-deepagent/registry/frameworks/hono/.placeholder
+++ b/libs/create-deepagent/registry/frameworks/hono/.placeholder
@@ -1,0 +1,2 @@
+# Template files are vendored from langchain-ai/deployment-cookbook.
+# This is a placeholder — replace with the actual template project.

--- a/libs/create-deepagent/registry/frameworks/next.ts
+++ b/libs/create-deepagent/registry/frameworks/next.ts
@@ -1,0 +1,12 @@
+import { createFramework } from "../../src/registry/framework.js";
+
+export const next = createFramework({
+  id: "next",
+  title: "Next.js",
+  defaultProjectName: "next-deepagents",
+  frameworkDir: "next",
+  envFilePath: ".env.local",
+  packageJsonPath: "package.json",
+  agentPath: "lib/agent",
+  files: [],
+});

--- a/libs/create-deepagent/registry/frameworks/next/.placeholder
+++ b/libs/create-deepagent/registry/frameworks/next/.placeholder
@@ -1,0 +1,2 @@
+# Template files are vendored from langchain-ai/deployment-cookbook.
+# This is a placeholder — replace with the actual template project.

--- a/libs/create-deepagent/registry/frameworks/nuxt.ts
+++ b/libs/create-deepagent/registry/frameworks/nuxt.ts
@@ -1,0 +1,12 @@
+import { createFramework } from "../../src/registry/framework.js";
+
+export const nuxt = createFramework({
+  id: "nuxt",
+  title: "Nuxt",
+  defaultProjectName: "nuxt-deepagents",
+  frameworkDir: "nuxt",
+  envFilePath: ".env",
+  packageJsonPath: "package.json",
+  agentPath: "server/agent",
+  files: [],
+});

--- a/libs/create-deepagent/registry/frameworks/nuxt/.placeholder
+++ b/libs/create-deepagent/registry/frameworks/nuxt/.placeholder
@@ -1,0 +1,2 @@
+# Template files are vendored from langchain-ai/deployment-cookbook.
+# This is a placeholder — replace with the actual template project.

--- a/libs/create-deepagent/registry/frameworks/vite.ts
+++ b/libs/create-deepagent/registry/frameworks/vite.ts
@@ -1,0 +1,14 @@
+import {
+  createFramework,
+} from "../../src/registry/framework.js";
+
+export const hono = createFramework({
+  id: "react-vite",
+  title: "React + Vite",
+  defaultProjectName: "react-deepagents",
+  frameworkDir: "vite",
+  envFilePath: ".env",
+  packageJsonPath: "package.json",
+  agentPath: "agent",
+  files: [],
+});

--- a/libs/create-deepagent/registry/frameworks/vite.ts
+++ b/libs/create-deepagent/registry/frameworks/vite.ts
@@ -1,6 +1,6 @@
 import { createFramework } from "../../src/registry/framework.js";
 
-export const hono = createFramework({
+export const vite = createFramework({
   id: "react-vite",
   title: "React + Vite",
   defaultProjectName: "react-deepagents",

--- a/libs/create-deepagent/registry/frameworks/vite.ts
+++ b/libs/create-deepagent/registry/frameworks/vite.ts
@@ -1,6 +1,4 @@
-import {
-  createFramework,
-} from "../../src/registry/framework.js";
+import { createFramework } from "../../src/registry/framework.js";
 
 export const hono = createFramework({
   id: "react-vite",

--- a/libs/create-deepagent/registry/frameworks/vite/.placeholder
+++ b/libs/create-deepagent/registry/frameworks/vite/.placeholder
@@ -1,0 +1,2 @@
+# Template files are vendored from langchain-ai/deployment-cookbook.
+# This is a placeholder — replace with the actual template project.

--- a/libs/create-deepagent/registry/providers/anthropic.ts
+++ b/libs/create-deepagent/registry/providers/anthropic.ts
@@ -1,0 +1,15 @@
+import { createProvider } from "../../src/registry/provider.js";
+
+export const anthropic = createProvider({
+  id: "anthropic",
+  title: "Anthropic",
+  defaultModel: "claude-sonnet-4-5-20250929",
+  dependencies: ["@langchain/anthropic"],
+  env: [
+    {
+      name: "ANTHROPIC_API_KEY",
+      prompt: "Anthropic API key",
+      required: false,
+    },
+  ],
+});

--- a/libs/create-deepagent/registry/providers/fireworks.ts
+++ b/libs/create-deepagent/registry/providers/fireworks.ts
@@ -1,0 +1,15 @@
+import { createProvider } from "../../src/registry/provider.js";
+
+export const fireworks = createProvider({
+  id: "fireworks",
+  title: "Fireworks",
+  defaultModel: "accounts/fireworks/models/glm-5p1",
+  dependencies: ["@langchain/community"],
+  env: [
+    {
+      name: "FIREWORKS_API_KEY",
+      prompt: "Fireworks API key",
+      required: false,
+    },
+  ],
+});

--- a/libs/create-deepagent/registry/providers/fireworks.ts
+++ b/libs/create-deepagent/registry/providers/fireworks.ts
@@ -4,7 +4,7 @@ export const fireworks = createProvider({
   id: "fireworks",
   title: "Fireworks",
   defaultModel: "accounts/fireworks/models/glm-5p1",
-  dependencies: ["@langchain/community"],
+  dependencies: ["@langchain/fireworks"],
   env: [
     {
       name: "FIREWORKS_API_KEY",

--- a/libs/create-deepagent/registry/providers/google.ts
+++ b/libs/create-deepagent/registry/providers/google.ts
@@ -1,0 +1,15 @@
+import { createProvider } from "../../src/registry/provider.js";
+
+export const google = createProvider({
+  id: "google-genai",
+  title: "Google",
+  defaultModel: "gemini-3.5-flash",
+  dependencies: ["@langchain/google-genai"],
+  env: [
+    {
+      name: "GOOGLE_API_KEY",
+      prompt: "Google API key",
+      required: false,
+    },
+  ],
+});

--- a/libs/create-deepagent/registry/providers/openai.ts
+++ b/libs/create-deepagent/registry/providers/openai.ts
@@ -1,0 +1,15 @@
+import { createProvider } from "../../src/registry/provider.js";
+
+export const openai = createProvider({
+  id: "openai",
+  title: "OpenAI",
+  defaultModel: "gpt-5.4-mini",
+  dependencies: ["@langchain/openai"],
+  env: [
+    {
+      name: "OPENAI_API_KEY",
+      prompt: "OpenAI API key",
+      required: false,
+    },
+  ],
+});

--- a/libs/create-deepagent/src/registry/framework.ts
+++ b/libs/create-deepagent/src/registry/framework.ts
@@ -28,6 +28,8 @@ export interface FrameworkConfig<T extends string = string> {
   postInit?: (opts: { projectPath: string }) => void;
 }
 
-export function createFramework<T extends string>(config: FrameworkConfig<T>): FrameworkConfig<T> {
+export function createFramework<T extends string>(
+  config: FrameworkConfig<T>,
+): FrameworkConfig<T> {
   return config;
 }

--- a/libs/create-deepagent/src/registry/framework.ts
+++ b/libs/create-deepagent/src/registry/framework.ts
@@ -1,0 +1,33 @@
+import type { ProviderConfig } from "./provider.js";
+
+export interface ProviderAwareFile {
+  /** Path relative to project root, e.g. "worker/env.d.ts" */
+  path: string;
+  /** Returns the file content, optionally using provider config for string injection */
+  getContent: (config: { providerConfig: ProviderConfig }) => string;
+}
+
+export interface FrameworkConfig<T extends string = string> {
+  /** Unique identifier. Probably the same as frameworkDir */
+  id: T;
+  /** Shown in the "Select your framework" prompt */
+  title: string;
+  /** e.g. "next-deepagents" */
+  defaultProjectName: string;
+  /** Template dir name, e.g. "next-js" */
+  frameworkDir: string;
+  /** Path to the env file, relative to project root */
+  envFilePath: string;
+  /** Path to package.json, relative to project root */
+  packageJsonPath: string;
+  /** Where agent-related files are written, relative to project root */
+  agentPath: string;
+  /** Context-dependent files to be written (e.g. env.d.ts) */
+  files: ProviderAwareFile[];
+  /** Post-init instructions, if necessary */
+  postInit?: (opts: { projectPath: string }) => void;
+}
+
+export function createFramework<T extends string>(config: FrameworkConfig<T>): FrameworkConfig<T> {
+  return config;
+}

--- a/libs/create-deepagent/src/registry/index.ts
+++ b/libs/create-deepagent/src/registry/index.ts
@@ -18,6 +18,7 @@ import { next } from "../../registry/frameworks/next.js";
 import { nuxt } from "../../registry/frameworks/nuxt.js";
 import { hono } from "../../registry/frameworks/hono.js";
 import { deno } from "../../registry/frameworks/deno.js";
+import { vite } from "../../registry/frameworks/vite.js";
 
 export const providers = {
   [openai.id]: openai,
@@ -32,5 +33,6 @@ export const frameworks = {
   [nuxt.id]: nuxt,
   [hono.id]: hono,
   [deno.id]: deno,
+  [vite.id]: vite,
 } as const;
 export type FrameworkKey = keyof typeof frameworks;

--- a/libs/create-deepagent/src/registry/index.ts
+++ b/libs/create-deepagent/src/registry/index.ts
@@ -1,0 +1,36 @@
+export {
+  createProvider,
+  type ProviderConfig,
+  type EnvVarSpec,
+} from "./provider.js";
+export {
+  createFramework,
+  type FrameworkConfig,
+  type ProviderAwareFile,
+} from "./framework.js";
+
+import { openai } from "../../registry/providers/openai.js";
+import { anthropic } from "../../registry/providers/anthropic.js";
+import { google } from "../../registry/providers/google.js";
+import { fireworks } from "../../registry/providers/fireworks.js";
+
+import { next } from "../../registry/frameworks/next.js";
+import { nuxt } from "../../registry/frameworks/nuxt.js";
+import { hono } from "../../registry/frameworks/hono.js";
+import { deno } from "../../registry/frameworks/deno.js";
+
+export const providers = {
+  [openai.id]: openai,
+  [anthropic.id]: anthropic,
+  [google.id]: google,
+  [fireworks.id]: fireworks,
+} as const;
+export type ProviderKey = keyof typeof providers;
+
+export const frameworks = {
+  [next.id]: next,
+  [nuxt.id]: nuxt,
+  [hono.id]: hono,
+  [deno.id]: deno,
+} as const;
+export type FrameworkKey = keyof typeof frameworks;

--- a/libs/create-deepagent/src/registry/provider.ts
+++ b/libs/create-deepagent/src/registry/provider.ts
@@ -22,6 +22,8 @@ export interface ProviderConfig<T extends string = string> {
   env: EnvVarSpec[];
 }
 
-export function createProvider<T extends string>(config: ProviderConfig<T>): ProviderConfig<T> {
+export function createProvider<T extends string>(
+  config: ProviderConfig<T>,
+): ProviderConfig<T> {
   return config;
 }

--- a/libs/create-deepagent/src/registry/provider.ts
+++ b/libs/create-deepagent/src/registry/provider.ts
@@ -1,0 +1,27 @@
+export interface EnvVarSpec {
+  /** Env var name, e.g. "OPENAI_API_KEY" */
+  name: string;
+  /** Prompt label, e.g. "OpenAI API key" */
+  prompt?: string;
+  /** Whether the user must enter a value (default: false — may skip and fill .env later) */
+  required?: boolean;
+  /** Prefill value */
+  default?: string;
+}
+
+export interface ProviderConfig<T extends string = string> {
+  /** Unique id, e.g. "anthropic" */
+  id: T;
+  /** Shown in the "Select your provider" prompt */
+  title: string;
+  /** Default model, e.g. "gpt-5.4" */
+  defaultModel: string;
+  /** Required dependencies to merge into package.json */
+  dependencies: string[];
+  /** Credential vars to prompt for + write to the env file */
+  env: EnvVarSpec[];
+}
+
+export function createProvider<T extends string>(config: ProviderConfig<T>): ProviderConfig<T> {
+  return config;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,9 +528,6 @@ importers:
       '@langchain/core':
         specifier: ^1.1.42
         version: 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/google-genai':
-        specifier: ^2.2.0
-        version: 2.2.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
       '@langchain/openai':
         specifier: ^1.4.1
         version: 1.5.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)
@@ -1434,10 +1431,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@google/generative-ai@0.24.1':
-    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
-    engines: {node: '>=18.0.0'}
-
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
@@ -1518,12 +1511,6 @@ packages:
   '@langchain/core@1.2.0':
     resolution: {integrity: sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==}
     engines: {node: '>=20'}
-
-  '@langchain/google-genai@2.2.0':
-    resolution: {integrity: sha512-1mDqbmB6+iC6ZBQY15r5xJg9wPErnQ774inpKh6qi6BrrjadDwaPHoklJW5IXU94edKiDpm1akIzJCrQDWe6yA==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@langchain/core': ^1.2.0
 
   '@langchain/langgraph-checkpoint@1.1.2':
     resolution: {integrity: sha512-m5Xd7W3G9JrlEhFZ5WAcqZPgE46R9gr1gFDFaVqEKeuwin3tgEp0jlPbru+iFXCug338DcQjFS/Kuuci21ydvw==}
@@ -4706,8 +4693,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@google/generative-ai@0.24.1': {}
-
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -4803,11 +4788,6 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
       - ws
-
-  '@langchain/google-genai@2.2.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
-    dependencies:
-      '@google/generative-ai': 0.24.1
-      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
 
   '@langchain/langgraph-checkpoint@1.1.2(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       '@langchain/core':
         specifier: ^1.1.42
         version: 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langchain/google-genai':
+        specifier: ^2.2.0
+        version: 2.2.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
       '@langchain/openai':
         specifier: ^1.4.1
         version: 1.5.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)
@@ -588,6 +591,43 @@ importers:
         specifier: ^4.0.18
         version: 4.1.9(vitest@4.1.9)
       '@vitest/ui':
+        specifier: ^4.0.18
+        version: 4.1.9(vitest@4.1.9)
+      tsdown:
+        specifier: ^0.22.1
+        version: 0.22.3(tsx@4.22.4)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  libs/create-deepagent:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^1.6.0
+        version: 1.6.0
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@tsconfig/recommended':
+        specifier: ^1.0.13
+        version: 1.0.13
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.9.3
+      '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.1.9(vitest@4.1.9)
       tsdown:
@@ -1193,6 +1233,14 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@clack/core@1.4.2':
+    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.6.0':
+    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
+    engines: {node: '>= 20.12.0'}
+
   '@daytona/api-client@0.184.0':
     resolution: {integrity: sha512-wfBVkH48Aiz4mVR4n8Qzd2g7OhU3pr/ZASOTwLncTZ/LJDpBiVFtVk+KOYKRSNEHWXs6znPbMXxRIh9pTdmYeg==}
 
@@ -1386,6 +1434,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
+
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
@@ -1466,6 +1518,12 @@ packages:
   '@langchain/core@1.2.0':
     resolution: {integrity: sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==}
     engines: {node: '>=20'}
+
+  '@langchain/google-genai@2.2.0':
+    resolution: {integrity: sha512-1mDqbmB6+iC6ZBQY15r5xJg9wPErnQ774inpKh6qi6BrrjadDwaPHoklJW5IXU94edKiDpm1akIzJCrQDWe6yA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.2.0
 
   '@langchain/langgraph-checkpoint@1.1.2':
     resolution: {integrity: sha512-m5Xd7W3G9JrlEhFZ5WAcqZPgE46R9gr1gFDFaVqEKeuwin3tgEp0jlPbru+iFXCug338DcQjFS/Kuuci21ydvw==}
@@ -2620,6 +2678,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2778,6 +2840,15 @@ packages:
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -3607,6 +3678,9 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -4452,6 +4526,18 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
+  '@clack/core@1.4.2':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.6.0':
+    dependencies:
+      '@clack/core': 1.4.2
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@daytona/api-client@0.184.0':
     dependencies:
       axios: 1.15.1
@@ -4620,6 +4706,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@google/generative-ai@0.24.1': {}
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -4715,6 +4803,11 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
       - ws
+
+  '@langchain/google-genai@2.2.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
+    dependencies:
+      '@google/generative-ai': 0.24.1
+      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
 
   '@langchain/langgraph-checkpoint@1.1.2(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
     dependencies:
@@ -5721,6 +5814,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@15.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -5860,6 +5955,16 @@ snapshots:
       micromatch: 4.0.8
 
   fast-sha256@1.3.0: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -6663,6 +6768,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## Summary
Adds the registry items to be consumed by all of this projects' system:
- **Providers**
  - OpenAI
  - Anthropic
  - Google
  - Fireworks
- **Frameworks**
  - React + Vite
  - Hono
  - Next
  - Nuxt
  - Deno

Adds placeholders for the repos themselves

## Callouts
- The framework metadata in framework configs (particularly thinking of file/dir paths) should map 1:1 with your cookbook repos
- "builder functions" are effectively just a thin typing layer right now - likely more substantive in the future