### PR TITLE
feat(deepagents): Add commands and TUI

### DIFF
--- a/libs/create-deepagent/src/commands/create/index.ts
+++ b/libs/create-deepagent/src/commands/create/index.ts
@@ -7,7 +7,6 @@ import { handleError } from "../../utils/handleError.js";
 import { logger } from "../../utils/logger.js";
 
 const cliOptionsSchema = z.object({
-  cwd: z.string().optional(),
   name: z.string().optional(),
   force: z.boolean().optional(),
 });
@@ -17,11 +16,6 @@ type TUIOptions = Awaited<ReturnType<typeof runCreateConfig>>;
 export const create = new Command()
   .name("create")
   .description("Initialize your project and install dependencies")
-  .option(
-    "-c, --cwd <cwd>",
-    "The working directory. Defaults to the current directory.",
-    process.cwd(),
-  )
   .option("-f, --force", "Force overwrite of existing files")
   .option("-n, --name <name>", "The name for the new project")
   .action(async (opts) => {
@@ -30,8 +24,8 @@ export const create = new Command()
       const tuiOptions = await runCreateConfig();
       const options = mergeOptions(cliOptions, tuiOptions);
 
-      await preflightCreate();
-      await runCreate(options);
+      const projectPath = await preflightCreate(options);
+      await runCreate(projectPath, options);
     } catch (e) {
       handleError(e);
     }
@@ -42,7 +36,7 @@ export const create = new Command()
  * pretty slim.
  */
 function mergeOptions(cliOptions: CLIOptions, tuiOptions: TUIOptions) {
-  const { cwd, force, name } = cliOptions;
+  const { name, force } = cliOptions;
   const { frameworkChoice, envVars, langSmithKey, providerChoice, tracing } =
     tuiOptions;
 
@@ -53,7 +47,6 @@ function mergeOptions(cliOptions: CLIOptions, tuiOptions: TUIOptions) {
     framework,
     provider,
     projectName: name || framework.defaultProjectName,
-    cwd,
     force,
     tracing,
     langSmithKey,
@@ -62,7 +55,7 @@ function mergeOptions(cliOptions: CLIOptions, tuiOptions: TUIOptions) {
 }
 
 type RunCreateOptions = ReturnType<typeof mergeOptions>;
-async function runCreate(options: RunCreateOptions) {
+async function runCreate(projectPath: string, options: RunCreateOptions) {
   // no-op for now
-  logger.info(JSON.stringify(options));
+  logger.info(JSON.stringify([projectPath, options]));
 }

--- a/libs/create-deepagent/src/commands/create/index.ts
+++ b/libs/create-deepagent/src/commands/create/index.ts
@@ -1,0 +1,72 @@
+import { Command } from "commander";
+import { preflightCreate } from "./preflightCreate.js";
+import { logger } from "../../utils/logger.js";
+import { z } from "zod";
+import { runCreateConfig } from "./runCreateConfig.js";
+import { frameworks, providers } from "../../registry/index.js";
+
+const cliOptionsSchema = z.object({
+  cwd: z.string().optional(),
+  name: z.string().optional(),
+  force: z.boolean().optional(),
+});
+type CLIOptions = z.infer<typeof cliOptionsSchema>;
+type TUIOptions = Awaited<ReturnType<typeof runCreateConfig>>;
+
+export const create = new Command()
+  .name("create")
+  .description("Initialize your project and install dependencies")
+  .option(
+    "-c, --cwd <cwd>",
+    "The working directory. Defaults to the current directory.",
+    process.cwd(),
+  )
+  .option("-f, --force", "Force overwrite of existing files")
+  .option("-n, --name <name>", "The name for the new project")
+  .action(async (opts) => {
+    try {
+      const cliOptions = cliOptionsSchema.parse(opts);
+      const tuiOptions = await runCreateConfig();
+      const options = mergeOptions(cliOptions, tuiOptions);
+
+      await preflightCreate();
+      await runCreate(options);
+    } catch (e) {
+      logger.break();
+      logger.error(
+        `Something went wrong. Please check the error below for more details.`,
+      );
+      logger.error(`If the problem persists, please open an issue on GitHub.`);
+      console.error(e);
+    }
+  });
+
+/**
+ * Merges CLI and TUI options. While CLI options are limited, this function will be
+ * pretty slim.
+ */
+function mergeOptions(cliOptions: CLIOptions, tuiOptions: TUIOptions) {
+  const { cwd, force, name } = cliOptions;
+  const { frameworkChoice, envVars, langSmithKey, providerChoice, tracing } =
+    tuiOptions;
+
+  const framework = frameworks[frameworkChoice];
+  const provider = providers[providerChoice];
+
+  return {
+    framework,
+    provider,
+    projectName: name || framework.defaultProjectName,
+    cwd,
+    force,
+    tracing,
+    langSmithKey,
+    envVars,
+  };
+}
+
+type RunCreateOptions = ReturnType<typeof mergeOptions>;
+async function runCreate(options: RunCreateOptions) {
+  // no-op for now
+  logger.info(JSON.stringify(options));
+}

--- a/libs/create-deepagent/src/commands/create/index.ts
+++ b/libs/create-deepagent/src/commands/create/index.ts
@@ -1,9 +1,10 @@
 import { Command } from "commander";
 import { preflightCreate } from "./preflightCreate.js";
-import { logger } from "../../utils/logger.js";
 import { z } from "zod";
 import { runCreateConfig } from "./runCreateConfig.js";
 import { frameworks, providers } from "../../registry/index.js";
+import { handleError } from "../../utils/handleError.js";
+import { logger } from "../../utils/logger.js";
 
 const cliOptionsSchema = z.object({
   cwd: z.string().optional(),
@@ -32,12 +33,7 @@ export const create = new Command()
       await preflightCreate();
       await runCreate(options);
     } catch (e) {
-      logger.break();
-      logger.error(
-        `Something went wrong. Please check the error below for more details.`,
-      );
-      logger.error(`If the problem persists, please open an issue on GitHub.`);
-      console.error(e);
+      handleError(e);
     }
   });
 

--- a/libs/create-deepagent/src/commands/create/preflightCreate.ts
+++ b/libs/create-deepagent/src/commands/create/preflightCreate.ts
@@ -1,0 +1,3 @@
+export async function preflightCreate() {
+  // no-op for now
+}

--- a/libs/create-deepagent/src/commands/create/preflightCreate.ts
+++ b/libs/create-deepagent/src/commands/create/preflightCreate.ts
@@ -1,3 +1,62 @@
-export async function preflightCreate() {
-  // no-op for now
+import path from "node:path";
+import * as clack from "@clack/prompts";
+import { logger } from "../../utils/logger.js";
+import {
+  dirExists,
+  isDirEmpty,
+  isWriteable,
+  validatePkgName,
+} from "../../utils/validate.js";
+
+export interface PreflightOptions {
+  projectName: string;
+  force?: boolean;
+}
+
+/**
+ * Post-TUI checks before scaffolding. Fails fast on:
+ * - Invalid package name
+ * - Target directory not empty (unless --force or user confirms)
+ * - Target directory not writable
+ */
+export async function preflightCreate(
+  options: PreflightOptions,
+): Promise<string> {
+  const { projectName, force } = options;
+
+  // 1. Validate package name
+  const nameErr = validatePkgName(projectName);
+  if (nameErr) {
+    logger.error(nameErr);
+    process.exit(1);
+  }
+
+  // 2. Resolve project path
+  const projectPath = path.resolve(projectName);
+
+  // 3. Check if target dir already exists and is not empty
+  const exists = await dirExists(projectPath);
+  if (exists && !force) {
+    const empty = await isDirEmpty(projectPath);
+    if (!empty) {
+      const proceed = await clack.confirm({
+        message: `Directory "${projectName}" is not empty. Continue anyway?`,
+        initialValue: false,
+      });
+
+      if (clack.isCancel(proceed) || proceed === false) {
+        clack.cancel("Cancelled, exiting...");
+        process.exit(0);
+      }
+    }
+  }
+
+  // 4. Check if parent dir is writable
+  const writeable = await isWriteable(path.dirname(projectPath));
+  if (!writeable) {
+    logger.error(`Cannot write to ${path.dirname(projectPath)}`);
+    process.exit(1);
+  }
+
+  return projectPath;
 }

--- a/libs/create-deepagent/src/commands/create/runCreateConfig.ts
+++ b/libs/create-deepagent/src/commands/create/runCreateConfig.ts
@@ -8,7 +8,7 @@ import {
   FrameworkConfig,
 } from "../../registry/index.js";
 
-const PROCESSS_EXIT_MESSAGE = 'Cancelled, exiting...';
+const PROCESSS_EXIT_MESSAGE = "Cancelled, exiting...";
 
 /**
  * Guides the user through the config TUI. On SIGINT, either moves to the next
@@ -83,10 +83,13 @@ async function selectProvider() {
 }
 
 /** Prompt the user to enter env vars as are required by the provider spec */
-async function collectEnvVars(provider: ProviderConfig, framework: FrameworkConfig) {
+async function collectEnvVars(
+  provider: ProviderConfig,
+  framework: FrameworkConfig,
+) {
   const envVars: Record<string, string> = {};
   for (const spec of provider.env) {
-    const optionalExitMessage = `Skipping ${spec.prompt}. You can add this later in ${framework.envFilePath}`
+    const optionalExitMessage = `Skipping ${spec.prompt}. You can add this later in ${framework.envFilePath}`;
 
     if (!spec.required) {
       const proceed = (await clack.select({
@@ -144,19 +147,22 @@ async function selectTracing() {
 }
 
 /** Prompt a user for their LangSmith API if tracing is enabled */
-async function collectLangSmithKey(tracing: boolean, framework: FrameworkConfig) {
+async function collectLangSmithKey(
+  tracing: boolean,
+  framework: FrameworkConfig,
+) {
   if (!tracing) return;
 
   const exitMessage = `Skipping LangSmith API key. You can add this later in ${framework.envFilePath}`;
 
-  const proceed = (await clack.select({
+  const proceed = await clack.select({
     message: `Enter your LangSmith API key now?`,
     initialValue: false,
     options: [
       { value: false, label: "Skip for now" },
       { value: true, label: "Yes" },
     ],
-  }));
+  });
 
   if (clack.isCancel(proceed) || proceed === false) {
     clack.cancel(exitMessage);

--- a/libs/create-deepagent/src/commands/create/runCreateConfig.ts
+++ b/libs/create-deepagent/src/commands/create/runCreateConfig.ts
@@ -158,7 +158,7 @@ async function collectLangSmithKey(tracing: boolean, framework: FrameworkConfig)
     ],
   }));
 
-  if (clack.isCancel(proceed)) {
+  if (clack.isCancel(proceed) || proceed === false) {
     clack.cancel(exitMessage);
     return;
   }

--- a/libs/create-deepagent/src/commands/create/runCreateConfig.ts
+++ b/libs/create-deepagent/src/commands/create/runCreateConfig.ts
@@ -1,0 +1,177 @@
+import * as clack from "@clack/prompts";
+import {
+  frameworks,
+  type FrameworkKey,
+  type ProviderKey,
+  providers,
+  ProviderConfig,
+  FrameworkConfig,
+} from "../../registry/index.js";
+
+const PROCESSS_EXIT_MESSAGE = 'Cancelled, exiting...';
+
+/**
+ * Guides the user through the config TUI. On SIGINT, either moves to the next
+ * step or kills the process via `process.kill(0)`
+ */
+export async function runCreateConfig() {
+  clack.intro("create-deepagent");
+
+  const frameworkConfig = await selectFramework();
+  const providerConfig = await selectProvider();
+  const envVars = await collectEnvVars(providerConfig, frameworkConfig);
+  const tracing = (await selectTracing()) ?? false;
+  const langSmithKey = await collectLangSmithKey(tracing, frameworkConfig);
+
+  return {
+    frameworkChoice: frameworkConfig.id,
+    providerChoice: providerConfig.id,
+    envVars,
+    tracing,
+    langSmithKey,
+  };
+}
+
+/** Prompt a user to select their framework */
+async function selectFramework() {
+  const frameworkOptions = Object.values(frameworks).map((f) => ({
+    value: f.id,
+    label: f.title,
+  }));
+
+  const frameworkChoice = await clack.select({
+    message: "Select your framework",
+    options: frameworkOptions,
+  });
+
+  if (clack.isCancel(frameworkChoice)) {
+    clack.cancel(PROCESSS_EXIT_MESSAGE);
+    process.exit(0);
+  }
+
+  const framework = frameworks[frameworkChoice as FrameworkKey];
+  if (!framework) {
+    throw new Error(`Framework "${frameworkChoice}" not found`);
+  }
+
+  return framework;
+}
+
+/** Prompt a user to select their provider */
+async function selectProvider() {
+  const providerOptions = Object.values(providers).map((p) => ({
+    value: p.id,
+    label: p.title,
+  }));
+
+  const providerChoice = (await clack.select({
+    message: "Select your provider",
+    options: providerOptions,
+  })) as string;
+
+  if (clack.isCancel(providerChoice)) {
+    clack.cancel(PROCESSS_EXIT_MESSAGE);
+    process.exit(0);
+  }
+
+  const provider = providers[providerChoice as ProviderKey];
+  if (!provider) {
+    throw new Error(`Provider "${providerChoice}" not found`);
+  }
+
+  return provider;
+}
+
+/** Prompt the user to enter env vars as are required by the provider spec */
+async function collectEnvVars(provider: ProviderConfig, framework: FrameworkConfig) {
+  const envVars: Record<string, string> = {};
+  for (const spec of provider.env) {
+    const optionalExitMessage = `Skipping ${spec.prompt}. You can add this later in ${framework.envFilePath}`
+
+    if (!spec.required) {
+      const proceed = (await clack.select({
+        message: `Enter your ${spec.prompt ?? spec.name}?`,
+        initialValue: false,
+        options: [
+          { value: false, label: "Skip for now" },
+          { value: true, label: "Yes" },
+        ],
+      })) as boolean;
+
+      if (clack.isCancel(proceed)) {
+        clack.cancel(optionalExitMessage);
+        return;
+      }
+
+      if (!proceed) continue;
+    }
+
+    const val = (await clack.password({
+      message: spec.prompt ?? spec.name,
+      mask: "*",
+    })) as string;
+
+    if (clack.isCancel(val)) {
+      if (spec.required) {
+        clack.cancel(PROCESSS_EXIT_MESSAGE);
+        process.exit(0);
+      }
+
+      clack.cancel(optionalExitMessage);
+      return;
+    }
+
+    if (val && val.trim()) {
+      envVars[spec.name] = val;
+    }
+  }
+  return envVars;
+}
+
+/** Prompt a user to enable tracing */
+async function selectTracing() {
+  const tracing = (await clack.confirm({
+    message: "Add LangSmith tracing?",
+    initialValue: false,
+  })) as boolean;
+
+  if (clack.isCancel(tracing)) {
+    clack.cancel("Skipping LangSmith tracing");
+    return;
+  }
+
+  return tracing;
+}
+
+/** Prompt a user for their LangSmith API if tracing is enabled */
+async function collectLangSmithKey(tracing: boolean, framework: FrameworkConfig) {
+  if (!tracing) return;
+
+  const exitMessage = `Skipping LangSmith API key. You can add this later in ${framework.envFilePath}`;
+
+  const proceed = (await clack.select({
+    message: `Enter your LangSmith API key now?`,
+    initialValue: false,
+    options: [
+      { value: false, label: "Skip for now" },
+      { value: true, label: "Yes" },
+    ],
+  }));
+
+  if (clack.isCancel(proceed)) {
+    clack.cancel(exitMessage);
+    return;
+  }
+
+  const langSmithKey = (await clack.password({
+    message: "Enter your LangSmith API key",
+    mask: "*",
+  })) as string;
+
+  if (clack.isCancel(langSmithKey)) {
+    clack.cancel(exitMessage);
+    return;
+  }
+
+  return langSmithKey.trim() ? langSmithKey.trim() : undefined;
+}

--- a/libs/create-deepagent/src/commands/create/runCreateConfig.ts
+++ b/libs/create-deepagent/src/commands/create/runCreateConfig.ts
@@ -90,14 +90,15 @@ async function collectEnvVars(
   const envVars: Record<string, string> = {};
   for (const spec of provider.env) {
     const optionalExitMessage = `Skipping ${spec.prompt}. You can add this later in ${framework.envFilePath}`;
-    const optionalSuffix = ' (press enter to skip)?';
+    const optionalSuffix = " (press enter to skip)?";
 
     if (!spec.required) {
       const result = (await clack.password({
         message: `Enter ${spec.prompt ?? spec.name}${optionalSuffix}`,
         mask: "*",
       })) as string;
-      const resultString = typeof result === 'string' && result.trim() ? result.trim() : undefined;
+      const resultString =
+        typeof result === "string" && result.trim() ? result.trim() : undefined;
 
       if (clack.isCancel(result) || resultString === undefined) {
         if (spec.required) {
@@ -139,11 +140,12 @@ async function collectLangSmithKey(
 
   const exitMessage = `Skipping LangSmith API key. You can add this later in ${framework.envFilePath}`;
 
-  const result = (await clack.password({
+  const result = await clack.password({
     message: "Enter your LangSmith API key (press enter to skip)?",
     mask: "*",
-  }));
-  const resultString = typeof result === 'string' && result.trim() ? result.trim() : undefined;
+  });
+  const resultString =
+    typeof result === "string" && result.trim() ? result.trim() : undefined;
 
   if (clack.isCancel(result) || resultString === undefined) {
     clack.cancel(exitMessage);

--- a/libs/create-deepagent/src/commands/create/runCreateConfig.ts
+++ b/libs/create-deepagent/src/commands/create/runCreateConfig.ts
@@ -90,42 +90,26 @@ async function collectEnvVars(
   const envVars: Record<string, string> = {};
   for (const spec of provider.env) {
     const optionalExitMessage = `Skipping ${spec.prompt}. You can add this later in ${framework.envFilePath}`;
+    const optionalSuffix = ' (press enter to skip)?';
 
     if (!spec.required) {
-      const proceed = (await clack.select({
-        message: `Enter your ${spec.prompt ?? spec.name}?`,
-        initialValue: false,
-        options: [
-          { value: false, label: "Skip for now" },
-          { value: true, label: "Yes" },
-        ],
-      })) as boolean;
+      const result = (await clack.password({
+        message: `Enter ${spec.prompt ?? spec.name}${optionalSuffix}`,
+        mask: "*",
+      })) as string;
+      const resultString = typeof result === 'string' && result.trim() ? result.trim() : undefined;
 
-      if (clack.isCancel(proceed)) {
+      if (clack.isCancel(result) || resultString === undefined) {
+        if (spec.required) {
+          clack.cancel(PROCESSS_EXIT_MESSAGE);
+          process.exit(0);
+        }
+
         clack.cancel(optionalExitMessage);
         return;
       }
 
-      if (!proceed) continue;
-    }
-
-    const val = (await clack.password({
-      message: spec.prompt ?? spec.name,
-      mask: "*",
-    })) as string;
-
-    if (clack.isCancel(val)) {
-      if (spec.required) {
-        clack.cancel(PROCESSS_EXIT_MESSAGE);
-        process.exit(0);
-      }
-
-      clack.cancel(optionalExitMessage);
-      return;
-    }
-
-    if (val && val.trim()) {
-      envVars[spec.name] = val;
+      envVars[spec.name] = resultString;
     }
   }
   return envVars;
@@ -139,8 +123,8 @@ async function selectTracing() {
   })) as boolean;
 
   if (clack.isCancel(tracing)) {
-    clack.cancel("Skipping LangSmith tracing");
-    return;
+    clack.cancel(PROCESSS_EXIT_MESSAGE);
+    process.exit(0);
   }
 
   return tracing;
@@ -155,29 +139,16 @@ async function collectLangSmithKey(
 
   const exitMessage = `Skipping LangSmith API key. You can add this later in ${framework.envFilePath}`;
 
-  const proceed = await clack.select({
-    message: `Enter your LangSmith API key now?`,
-    initialValue: false,
-    options: [
-      { value: false, label: "Skip for now" },
-      { value: true, label: "Yes" },
-    ],
-  });
-
-  if (clack.isCancel(proceed) || proceed === false) {
-    clack.cancel(exitMessage);
-    return;
-  }
-
-  const langSmithKey = (await clack.password({
-    message: "Enter your LangSmith API key",
+  const result = (await clack.password({
+    message: "Enter your LangSmith API key (press enter to skip)?",
     mask: "*",
-  })) as string;
+  }));
+  const resultString = typeof result === 'string' && result.trim() ? result.trim() : undefined;
 
-  if (clack.isCancel(langSmithKey)) {
+  if (clack.isCancel(result) || resultString === undefined) {
     clack.cancel(exitMessage);
     return;
   }
 
-  return langSmithKey.trim() ? langSmithKey.trim() : undefined;
+  return resultString;
 }

--- a/libs/create-deepagent/src/index.ts
+++ b/libs/create-deepagent/src/index.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { create } from "./commands/create/index.js";
+
+import packageJson from "../package.json" with { type: "json" };
+
+async function main() {
+  const program = new Command()
+    .name("create-deepagent")
+    .description("Scaffold a new Deep Agents project")
+    .version(packageJson.version);
+
+  program.addCommand(create, { isDefault: true });
+
+  program.parse();
+}
+
+main();

--- a/libs/create-deepagent/src/registry/index.ts
+++ b/libs/create-deepagent/src/registry/index.ts
@@ -32,7 +32,7 @@ export const frameworks = {
   [next.id]: next,
   [nuxt.id]: nuxt,
   [hono.id]: hono,
-  [deno.id]: deno,
   [vite.id]: vite,
+  [deno.id]: deno,
 } as const;
 export type FrameworkKey = keyof typeof frameworks;

--- a/libs/create-deepagent/src/utils/handleError.ts
+++ b/libs/create-deepagent/src/utils/handleError.ts
@@ -1,0 +1,28 @@
+import { logger } from "./logger.js";
+
+export function handleError(e: unknown) {
+  logger.break();
+  logger.error(
+    `Something went wrong. Please check the error below for more details.`,
+  );
+  logger.error(`If the problem persists, please open an issue on GitHub.`);
+  logger.break();
+
+  if (e && typeof e === "object" && "name" in e && e.name === "ZodError") {
+    // Handle Zod errors
+    const { flatten } = e as unknown as {
+      flatten: () => { fieldErrors: Record<string, string[]> };
+    };
+    for (const [key, value] of Object.entries(flatten().fieldErrors)) {
+      logger.error(`- ${key}: ${value}`);
+    }
+  } else if (
+    e &&
+    typeof e === "object" &&
+    "message" in e &&
+    typeof (e as { message: unknown }).message === "string"
+  ) {
+    // Handle `Error` types
+    logger.error((e as { message: string }).message);
+  }
+}

--- a/libs/create-deepagent/src/utils/logger.ts
+++ b/libs/create-deepagent/src/utils/logger.ts
@@ -1,0 +1,10 @@
+import pc from "picocolors";
+
+export const logger = {
+  info: (msg: string) => console.log(pc.cyan(msg)),
+  success: (msg: string) => console.log(pc.green(msg)),
+  warn: (msg: string) => console.log(pc.yellow(msg)),
+  error: (msg: string) => console.error(pc.red(msg)),
+  break: () => console.log(),
+  step: (msg: string) => console.log(pc.dim("›") + " " + msg),
+};

--- a/libs/create-deepagent/src/utils/validate.ts
+++ b/libs/create-deepagent/src/utils/validate.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+
+/** Check if a path exists and is a directory. */
+export async function dirExists(dir: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(dir);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Check if an existing directory is empty. Throws if the dir cannot be read. */
+export async function isDirEmpty(dir: string): Promise<boolean> {
+  const entries = await fs.promises.readdir(dir);
+  return entries.length === 0;
+}
+
+/** Check if a directory is writable. */
+export async function isWriteable(dir: string): Promise<boolean> {
+  try {
+    await fs.promises.access(dir, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Ensure a directory exists, creating it if necessary. */
+export async function makeDir(dir: string): Promise<void> {
+  await fs.promises.mkdir(dir, { recursive: true });
+}
+
+/** Validate a npm package name. Returns an error message or null if valid. */
+export function validatePkgName(name: string): string | null {
+  if (!name) return "Project name is required";
+  if (name.length > 214) return "Project name must be 214 characters or less";
+  if (name.startsWith(".") || name.startsWith("_"))
+    return "Project name must not start with . or _";
+  if (name.toLowerCase() !== name) return "Project name must be lowercase";
+  if (/\s/.test(name)) return "Project name must not contain spaces";
+  // Per npm naming rules
+  if (!/^[a-z0-9._-]+$/.test(name))
+    return "Project name may only contain lowercase letters, numbers, ., _, and -";
+  return null;
+}

--- a/libs/create-deepagent/tsdown.config.ts
+++ b/libs/create-deepagent/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig([
     clean: true,
     sourcemap: true,
     outDir: "dist",
+    outExtensions: () => ({ js: ".js" }),
     // Add shebang for executable
     banner: {
       js: "#!/usr/bin/env node",


### PR DESCRIPTION
## Summary
- Adds the commanderjs create command, parses CLI args (minimal right now)
- Adds the TUI (including wired providers, frameworks, interrupt/optional handling)
- Scaffolds preflight + runCreate functions
- Build system fix
- Reorder frameworks
## Callouts
- Any thoughts on ordering of frameworks/providers? I'm thinking alphabetical for providers, and the current ordering of frameworks is just a gut feeling
- ctrl+c, when pressed in a select (e.g. Enable LangSmith tracing?) is functionally the same as choose the "false" option
- ctrl+c, when pressed in a text input for an optional field (e.g. Enter OpenAI API key) bumps the user out of that text input rather than interrupting the process

### no interrupt
<video src="https://github.com/user-attachments/assets/5827df34-a1b0-44c8-b41c-82ee978b6bb2"></video>

### with interrupt
<video src="https://github.com/user-attachments/assets/29fcaac2-7f68-4a31-8c64-ba2b35ab3aeb"></video>
