### PR TITLE
ci: enforce sha-pinned github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: pnpm dlx pkg-pr-new publish './libs/*' './libs/providers/*'
         continue-on-error: true
       - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-artifacts
           path: build-artifacts.tar.gz
@@ -127,7 +127,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-artifacts
       - name: Extract build artifacts
@@ -152,7 +152,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-artifacts
       - name: Extract build artifacts

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -139,7 +139,7 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v5.0.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install dependencies
         run: pnpm install
@@ -191,7 +191,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v5.0.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Download all platform packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -11,6 +11,39 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
+  pin-github-actions:
+    name: "validate action pins"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: "Require SHA-pinned GitHub Actions"
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          files=(.github/workflows/*.yml .github/workflows/*.yaml)
+          violations="$(
+            perl -ne '
+              if (/^\s*-?\s*uses:\s*([^#\s]+)/) {
+                my $use = $1;
+                next if $use =~ m{^\./|^docker://};
+                if ($use !~ /@[0-9a-fA-F]{40}$/) {
+                  print "$ARGV:$.: $use\n";
+                }
+              }
+              close ARGV if eof;
+            ' "${files[@]}"
+          )"
+
+          if [[ -n "$violations" ]]; then
+            echo "::error::GitHub Actions must be pinned by commit SHA."
+            echo "$violations"
+            exit 1
+          fi
+
   lint-pr-title:
     name: "validate format"
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 # misc
 .DS_Store
 *.pem
+*.key
+*.crt
 .idea
 
 # debug
@@ -34,6 +36,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env.*
 .env*.local
 .env
 
@@ -59,3 +62,5 @@ agent-os
 sandbox-workspace/
 coverage
 workspace/
+__pycache__/
+.venv/


### PR DESCRIPTION
## Summary
- add PR linting that rejects external GitHub Actions not pinned to a 40-character commit SHA
- keep existing action refs pinned and align stale version comments with their pinned SHAs
- extend .gitignore coverage for local env, key/cert, Python cache, and virtualenv files

## Testing
- local SHA-pin check over .github/workflows/*.yml and *.yaml
- ruby YAML parse for .github/workflows/*.yml
- git diff --cached --check