### PR TITLE
fix(deepagents): edit_file reports initial-content write, not '0 occurrence(s)', on empty files

### DIFF
--- a/libs/deepagents/src/middleware/fs.permissions.test.ts
+++ b/libs/deepagents/src/middleware/fs.permissions.test.ts
@@ -255,6 +255,45 @@ describe("fs tool permissions", () => {
       ).rejects.toThrow();
       expect(backend.edit).not.toHaveBeenCalled();
     });
+
+    it("reports an initial-content write (not '0 occurrence(s)') on the empty-file init path", async () => {
+      const backend = createMockBackend();
+      // Empty old_string on an empty file: performStringReplacement returns
+      // [newString, 0] — content IS written, occurrences is 0.
+      (backend.edit as any).mockResolvedValue({
+        error: null,
+        occurrences: 0,
+        filesUpdate: null,
+      });
+      const middleware = createFilesystemMiddleware({
+        backend,
+        permissions: [],
+      });
+
+      const result = await getTool(middleware, "edit_file").invoke({
+        file_path: "/notes.md",
+        old_string: "",
+        new_string: "# Hello\n",
+      });
+      const text = JSON.stringify(result);
+      expect(text).toContain("initial content");
+      expect(text).not.toContain("0 occurrence");
+    });
+
+    it("reports the replacement count for a normal edit", async () => {
+      const backend = createMockBackend(); // edit mock → occurrences: 1
+      const middleware = createFilesystemMiddleware({
+        backend,
+        permissions: [],
+      });
+
+      const result = await getTool(middleware, "edit_file").invoke({
+        file_path: "/notes.md",
+        old_string: "a",
+        new_string: "b",
+      });
+      expect(JSON.stringify(result)).toContain("replaced 1 occurrence(s)");
+    });
   });
 
   describe("ls", () => {

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -872,8 +872,15 @@ function createEditFileTool(
         return result.error;
       }
 
+      // occurrences === 0 on a non-error result is the empty-file init path
+      // (empty old_string sets initial content; see performStringReplacement).
+      // A genuine no-match returns an "Error: String not found" result above,
+      // so 0 here always means content was written, not a no-op replacement.
       const message = new ToolMessage({
-        content: `Successfully replaced ${result.occurrences} occurrence(s) in '${file_path}'`,
+        content:
+          result.occurrences === 0
+            ? `Successfully wrote initial content to '${file_path}'`
+            : `Successfully replaced ${result.occurrences} occurrence(s) in '${file_path}'`,
         tool_call_id: runtime.toolCall?.id as string,
         name: "edit_file",
         metadata: result.metadata,


### PR DESCRIPTION
## Summary

Follow-up to #161. That issue was the `occurrences = -1` bug when both the file content and `old_string` are empty; the fix added an intentional "set initial content" special case in `performStringReplacement` that returns `[newString, 0]` — the content is written, and occurrences is `0`.

The success **message** for that path was never updated, so `edit_file` on an empty file now reports:

```
Successfully replaced 0 occurrence(s) in '<path>'
```

The content was written correctly, but the message describes a no-op replacement. Because `edit_file` results are consumed by an LLM, an agent that writes initial content into an empty file reads "replaced 0 occurrence(s)" and reasonably concludes the write failed — retrying, switching tools, or reporting it as a bug. (We hit exactly this during manual testing: an agent flagged "edit_file succeeded but reported 0 occurrences despite writing content" as a suspected harness anomaly.)

## Change

Branch the `edit_file` success message on `result.occurrences === 0`:

```
Successfully wrote initial content to '<path>'
```

This is safe because a genuine zero-match on a non-empty file returns `Error: String not found in file` *before* the success message is built (and an empty `old_string` on a non-empty file returns `Error: oldString cannot be empty`). So the only non-error path that reaches the message with `occurrences === 0` is the empty-file init case — where content really was written.

## Tests

Added two deterministic tests in `fs.permissions.test.ts` (mock-backend harness, no live model):

- `occurrences: 0` → message contains "initial content" and not "0 occurrence(s)"
- `occurrences: 1` → message still reports "replaced 1 occurrence(s)"

`vitest run src/middleware/fs.permissions.test.ts` → 31 passed, no type errors.

## Notes

- Message-only change; no behavior change to what gets written.
- Verified against `deepagents@1.10.5` (the shipped `Successfully replaced …` template and the `content === "" && oldString === ""` special case are both present in the published bundle) and on current `main`.
