### PR TITLE
fix(deepagents): base64-encode binary FileData content in StoreBackend store values

### DIFF
--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -325,6 +325,55 @@ describe("StoreBackend", () => {
       expect(readRes.content).toContain("Hello");
     });
 
+    it("round-trips binary content through a store that persists values as JSON", async () => {
+      // Stores backed by a JSON column (e.g. the Postgres store's JSONB
+      // values) round-trip every value through JSON serialization, which
+      // turns a raw Uint8Array into a numeric-keyed byte map and made any
+      // binary file written through such a store unreadable.
+      const inner = new InMemoryStore();
+      const jsonStore = {
+        put: (namespace: string[], key: string, value: any) =>
+          inner.put(namespace, key, JSON.parse(JSON.stringify(value))),
+        get: (namespace: string[], key: string) => inner.get(namespace, key),
+        search: (namespace: string[], options?: any) =>
+          inner.search(namespace, options),
+        delete: (namespace: string[], key: string) =>
+          inner.delete(namespace, key),
+      };
+      const runtime = {
+        state: { files: {}, messages: [] },
+        store: jsonStore as any,
+      };
+      const backend = new StoreBackend(runtime);
+
+      const pngBytes = new Uint8Array([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]);
+      const upload = await backend.uploadFiles([["/image.png", pngBytes]]);
+      expect(upload[0].error).toBeNull();
+
+      const raw = await backend.readRaw("/image.png");
+      expect(raw.error).toBeUndefined();
+      expect(raw.data!.content).toBeInstanceOf(Uint8Array);
+      expect(Array.from(raw.data!.content as Uint8Array)).toEqual(
+        Array.from(pngBytes),
+      );
+
+      const download = await backend.downloadFiles(["/image.png"]);
+      expect(download[0].error).toBeNull();
+      expect(Array.from(download[0].content!)).toEqual(Array.from(pngBytes));
+
+      // Text files keep their plain-string store representation.
+      await backend.uploadFiles([
+        ["/note.txt", new TextEncoder().encode("plain text")],
+      ]);
+      const storedText = await inner.get(["filesystem"], "/note.txt");
+      expect(typeof storedText!.value.content).toBe("string");
+      expect(storedText!.value.encoding).toBeUndefined();
+      const readBack = await backend.read("/note.txt");
+      expect(readBack.content).toContain("plain text");
+    });
+
     it("should upload binary (image) files as Uint8Array", async () => {
       const { runtime } = makeConfig();
       const backend = new StoreBackend(runtime);
@@ -467,7 +516,7 @@ describe("StoreBackend", () => {
 
       const full = await backend.read("/img.png");
       const withOffsetLimit = await backend.read("/img.png", 5, 2);
-      expect(withOffsetLimit.content).toBe(full.content);
+      expect(withOffsetLimit.content).toStrictEqual(full.content);
     });
   });
 

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -359,11 +359,18 @@ export class StoreBackend implements BackendProtocolV2 {
   private convertStoreItemToFileData(storeItem: Item): FileData {
     const value = storeItem.value as any;
 
+    // Reverse the base64 encoding applied by convertFileDataToStoreValue for
+    // binary content (see the comment there).
+    const content: FileData["content"] =
+      value.encoding === "base64" && typeof value.content === "string"
+        ? new Uint8Array(Buffer.from(value.content, "base64"))
+        : value.content;
+
     const hasValidContent =
-      value.content !== undefined &&
-      (Array.isArray(value.content) ||
-        typeof value.content === "string" ||
-        ArrayBuffer.isView(value.content));
+      content !== undefined &&
+      (Array.isArray(content) ||
+        typeof content === "string" ||
+        ArrayBuffer.isView(content));
 
     if (
       !hasValidContent ||
@@ -376,20 +383,43 @@ export class StoreBackend implements BackendProtocolV2 {
     }
 
     return {
-      content: value.content,
+      content,
       ...(value.mimeType ? { mimeType: value.mimeType } : {}),
       created_at: value.created_at,
       modified_at: value.modified_at,
-    };
+    } as FileData;
   }
 
   /**
    * Convert FileData to a value suitable for store.put().
    *
+   * Binary content is base64-encoded with an `encoding: "base64"` marker:
+   * BaseStore implementations that persist values as JSON (e.g. the Postgres
+   * store's JSONB column) cannot represent a raw Uint8Array — JSON
+   * serialization turns it into a numeric-keyed byte map
+   * ({"0":123,"1":34,...}) that fails FileData validation on read, so any
+   * binary file written through such a store was stored unreadable.
+   * convertStoreItemToFileData reverses the encoding; in-memory stores that
+   * return the raw Uint8Array untouched are unaffected.
+   *
    * @param fileData - The FileData to convert
    * @returns Object with content, mimeType, created_at, and modified_at fields
    */
   private convertFileDataToStoreValue(fileData: FileData): Record<string, any> {
+    if (ArrayBuffer.isView(fileData.content)) {
+      const bytes = fileData.content as Uint8Array;
+      return {
+        content: Buffer.from(
+          bytes.buffer,
+          bytes.byteOffset,
+          bytes.byteLength,
+        ).toString("base64"),
+        encoding: "base64",
+        ...("mimeType" in fileData ? { mimeType: fileData.mimeType } : {}),
+        created_at: fileData.created_at,
+        modified_at: fileData.modified_at,
+      };
+    }
     return {
       content: fileData.content,
       ...("mimeType" in fileData ? { mimeType: fileData.mimeType } : {}),


### PR DESCRIPTION
## Problem

`StoreBackend.convertFileDataToStoreValue` passes binary `FileData.content` to `store.put()` as a raw `Uint8Array`. `BaseStore` implementations that persist values as JSON — e.g. the LangGraph Postgres store, whose `value` column is JSONB — round-trip every value through JSON serialization, which turns a `Uint8Array` into a numeric-keyed byte map:

```json
{"content": {"0": 137, "1": 80, "2": 78, ...}}
```

On the way back, `convertStoreItemToFileData` rejects that shape (`Store item does not contain valid FileData fields`), so **any binary file written through `StoreBackend` against a JSON-backed store is stored successfully and then permanently unreadable**. This hits more than images: any extension without a recognized text MIME (`.jsonl` included) takes the binary path in `uploadFiles`.

## Fix

`convertFileDataToStoreValue` base64-encodes binary content and marks the store value with `encoding: "base64"`; `convertStoreItemToFileData` reverses it. Text content keeps its plain-string representation (no store-format change), and values written by in-memory stores as real `Uint8Array`s still pass through untouched.

One existing assertion updated: `read()` of a binary file now returns a defensive copy rather than an alias of store-internal state, so the offset/limit identity check (`toBe`) becomes a value check (`toStrictEqual`) — object identity across reads was an artifact of the in-memory store returning its internal buffer by reference, not a documented contract.

## Test

Adds a regression test that wraps `InMemoryStore` with JSON round-tripping on `put` (the exact behavior of a JSONB-backed store) and asserts a PNG byte payload survives `uploadFiles → readRaw/downloadFiles` byte-for-byte, while text files keep a plain-string store representation with no `encoding` marker.

## Verification

Hit in production against the LangGraph `PostgresStore`: every `.jsonl` file uploaded through `StoreBackend` was written as an unreadable byte map (verified by inspecting the JSONB rows) and failed FileData validation on read. With this change the same flow round-trips correctly. `libs/deepagents` vitest suite: 1178 passing locally (the 6 pre-existing `*.int.test.ts` typecheck errors about `@langchain/sandbox-standard-tests` are unrelated and present on `main`).