### PR TITLE
fix(deepagents): let grep match an exact file path on State/Store backends

### DIFF
--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -212,6 +212,20 @@ describe("StoreBackend", () => {
     expect(readAfter.content).not.toContain("foo");
   });
 
+  it("greps an exact file path, not only directory prefixes", async () => {
+    const { runtime } = makeConfig();
+    const backend = new StoreBackend(runtime);
+
+    await backend.write("/data/rows.txt", '{"account":"acct-1"}');
+    await backend.write("/data/other.txt", "acct-1 elsewhere");
+
+    const res = await backend.grep("acct-1", "/data/rows.txt");
+    expect(res.error).toBeUndefined();
+    expect(res.matches).toEqual([
+      { path: "/data/rows.txt", line: 1, text: '{"account":"acct-1"}' },
+    ]);
+  });
+
   it("should handle grep with glob filter", async () => {
     const { runtime } = makeConfig();
     const backend = new StoreBackend(runtime);

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -17,6 +17,7 @@ import {
   TOOL_RESULT_TOKEN_LIMIT,
   createFileData,
   adaptSandboxProtocol,
+  grepMatchesFromFiles,
 } from "./utils.js";
 import type {
   BackendProtocol,
@@ -26,6 +27,57 @@ import type {
   SandboxBackendProtocolV2,
 } from "./protocol.js";
 import { isSandboxBackend } from "./protocol.js";
+
+describe("grepMatchesFromFiles", () => {
+  const files = {
+    "/data/rows.jsonl": createFileData(
+      '{"account":"acct-1"}',
+      undefined,
+      "v2",
+      "text/plain",
+    ),
+    "/data/other.txt": createFileData(
+      "acct-1 appears here too",
+      undefined,
+      "v2",
+      "text/plain",
+    ),
+    "/notes.md": createFileData(
+      "no accounts here",
+      undefined,
+      "v2",
+      "text/markdown",
+    ),
+  };
+
+  it("searches a directory subtree", () => {
+    const matches = grepMatchesFromFiles(files, "acct-1", "/data");
+    expect(matches.map((m) => m.path).sort()).toEqual([
+      "/data/other.txt",
+      "/data/rows.jsonl",
+    ]);
+  });
+
+  it("matches an exact file path (not just directory prefixes)", () => {
+    const matches = grepMatchesFromFiles(files, "acct-1", "/data/rows.jsonl");
+    expect(matches).toEqual([
+      { path: "/data/rows.jsonl", line: 1, text: '{"account":"acct-1"}' },
+    ]);
+  });
+
+  it("returns no matches for a file path whose content lacks the pattern", () => {
+    expect(grepMatchesFromFiles(files, "acct-1", "/notes.md")).toEqual([]);
+  });
+
+  it("applies the glob filter to an exact file path", () => {
+    expect(
+      grepMatchesFromFiles(files, "acct-1", "/data/rows.jsonl", "*.txt"),
+    ).toEqual([]);
+    expect(
+      grepMatchesFromFiles(files, "acct-1", "/data/rows.jsonl", "*.jsonl"),
+    ).toHaveLength(1);
+  });
+});
 
 describe("validatePath", () => {
   it("should add leading slash if missing", () => {

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -737,6 +737,11 @@ export function grepSearchFiles(
  *
  * Performs literal text search (not regex). Binary files are skipped.
  * Returns an empty array when no matches are found or on invalid input.
+ *
+ * `path` may be a directory (its subtree is searched) or an exact file
+ * path. validatePath normalizes with a trailing slash, so without the
+ * exact-key check a file path could never match its own key and grepping
+ * a single file silently returned no matches.
  */
 export function grepMatchesFromFiles(
   files: Record<string, FileData>,
@@ -752,7 +757,9 @@ export function grepMatchesFromFiles(
   }
 
   let filtered = Object.fromEntries(
-    Object.entries(files).filter(([fp]) => fp.startsWith(normalizedPath)),
+    Object.entries(files).filter(
+      ([fp]) => fp.startsWith(normalizedPath) || `${fp}/` === normalizedPath,
+    ),
   );
 
   if (glob) {


### PR DESCRIPTION
## Problem

`grepMatchesFromFiles` (the shared grep for `StateBackend` and `StoreBackend`) normalizes its `path` argument via `validatePath`, which **always appends a trailing slash**, then keeps only files whose key starts with that prefix:

```
grep(pattern, "/data/rows.txt")
  → normalizedPath = "/data/rows.txt/"
  → files["/data/rows.txt"].startsWith("/data/rows.txt/")  // false
  → []
```

So grepping a **specific file** — a perfectly normal call, and one that works against shell-backed sandboxes — silently returns zero matches on state/store backends. Silent-empty is the worst failure mode here: an agent concludes "the pattern isn't in the file" and answers wrong, with no error to catch.

## Fix

The filter also accepts an exact file-key match (`` `${fp}/` === normalizedPath ``). Directory-subtree semantics, glob filtering, and the binary-file skip are unchanged.

## Test

Adds `grepMatchesFromFiles` unit coverage (directory subtree, exact file path, exact file without the pattern, glob applied to an exact file path) and a `StoreBackend.grep` regression test for the exact-file case.

## Verification

Hit in production: our tool-result offload handle instructs the model to `grep(pattern, "<offloaded file path>")`; against the store backend every such call returned `[]` for data written moments earlier. `libs/deepagents` vitest suite: 1181 passing locally (the 6 pre-existing `*.int.test.ts` typecheck errors about `@langchain/sandbox-standard-tests` are unrelated and present on `main`).

Adjacent observation (out of scope here): files with text content but an unrecognized extension (e.g. `.jsonl`) get a non-text MIME and are skipped by grep's binary filter even when the path matches — worth a separate look.