### PR TITLE
fix(deepagents): use file_path in read_file prompt examples

### DIFF
--- a/.changeset/fix-read-file-file-path.md
+++ b/.changeset/fix-read-file-file-path.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Fix built-in `read_file` prompt examples to use the `file_path` argument name so models stop emitting `path` and failing schema validation.

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1048,6 +1048,32 @@ describe("createFilesystemMiddleware", () => {
         }
       }
     });
+
+    it("read_file examples only reference argument names in its schema", () => {
+      const middleware = createFilesystemMiddleware({
+        backend: createMockBackend(),
+      });
+
+      const readFileTool = middleware.tools!.find(
+        (t: any) => t.name === "read_file",
+      ) as any;
+      expect(readFileTool).toBeDefined();
+
+      // Argument names the tool actually accepts.
+      const schemaKeys = Object.keys(
+        readFileTool.schema.toJSONSchema().properties ?? {},
+      );
+      // Argument names the description teaches, e.g. read_file(file_path, ...).
+      const exampleArgs = [
+        ...String(readFileTool.description).matchAll(/read_file\(([a-z_]+)/g),
+      ].map((m) => m[1]);
+
+      // Guard against silently passing if the examples are ever removed.
+      expect(exampleArgs.length).toBeGreaterThan(0);
+      for (const arg of exampleArgs) {
+        expect(schemaKeys).toContain(arg);
+      }
+    });
   });
 
   describe("tool result truncation integration", () => {

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -487,10 +487,10 @@ export const READ_FILE_TOOL_DESCRIPTION = context`
   Usage:
   - By default, it reads up to ${DEFAULT_READ_LINE_LIMIT} lines starting from the beginning of the file
   - **IMPORTANT for large files and codebase exploration**: Use pagination with offset and limit parameters to avoid context overflow
-    - First scan: read_file(path, limit=${DEFAULT_READ_LINE_LIMIT}) to see file structure
-    - Read more sections: read_file(path, offset=${DEFAULT_READ_LINE_LIMIT}, limit=200) for next 200 lines
+    - First scan: read_file(file_path, limit=${DEFAULT_READ_LINE_LIMIT}) to see file structure
+    - Read more sections: read_file(file_path, offset=${DEFAULT_READ_LINE_LIMIT}, limit=200) for next 200 lines
     - Only omit limit (read full file) when necessary for editing
-  - Specify offset and limit: read_file(path, offset=0, limit=${DEFAULT_READ_LINE_LIMIT}) reads first ${DEFAULT_READ_LINE_LIMIT} lines
+  - Specify offset and limit: read_file(file_path, offset=0, limit=${DEFAULT_READ_LINE_LIMIT}) reads first ${DEFAULT_READ_LINE_LIMIT} lines
   - Results are returned using cat -n format, with line numbers starting at 1
 - Lines longer than ${INT_FORMATTER.format(MAX_LINE_LENGTH)} characters will be split into multiple lines with continuation markers (e.g., 5.1, 5.2, etc.). When you specify a limit, these continuation lines count towards the limit.
   - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -304,7 +304,7 @@ const SKILLS_SYSTEM_PROMPT = context`
   User: "Can you research the latest developments in quantum computing?"
 
   1. Check available skills above → See "web-research" skill with its full path
-  2. Read the full skill file: \`read_file(path, limit=${DEFAULT_SKILL_READ_LINE_LIMIT})\`
+  2. Read the full skill file: \`read_file(file_path, limit=${DEFAULT_SKILL_READ_LINE_LIMIT})\`
   3. Follow the skill's research workflow (search → organize → synthesize)
   4. Use any helper scripts with absolute paths
 


### PR DESCRIPTION
## Problem

The `read_file` tool schema requires the argument `file_path`, but two built-in prompts illustrate the call with an argument named `path`:

- `READ_FILE_TOOL_DESCRIPTION` in `libs/deepagents/src/middleware/fs.ts` (`read_file(path, limit=...)`, `read_file(path, offset=..., limit=...)`)
- the skills workflow prompt in `libs/deepagents/src/middleware/skills.ts` (`read_file(path, limit=...)`)

Models that copy the example emit a `path` argument and fail schema validation on the very first read:

```
Error invoking tool 'read_file' with kwargs {"path":".../SKILL.md","limit":1000}
Error: Received tool input did not match expected schema
Invalid input: expected string, received undefined
  -> at file_path
```

## Change

Align the four example lines with the actual schema by renaming the example argument `path` → `file_path`. This is a prompt/documentation fix only — the tool schema (`file_path`) is unchanged, so there is no API/behavior change for callers.

## Test

Adds one test under `createFilesystemMiddleware › tools` in `fs.test.ts` that derives the allowed argument names from the `read_file` tool's schema (`schema.toJSONSchema().properties`) and asserts every argument shown in the tool description's `read_file(...)` examples is one of them. It fails if an example ever references an argument the tool does not accept (verified red before this change, green after).

## Verification

- `pnpm build` — passes
- `pnpm --filter deepagents typecheck` — passes
- `pnpm --filter deepagents test:unit` — 1177 passed

A patch changeset is included.
