### PR TITLE
feat(deepagents): support subagent middleware and extensionless text reads

### DIFF
--- a/.changeset/codex-subagent-middleware.md
+++ b/.changeset/codex-subagent-middleware.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Add `generalPurposeSubagentMiddleware` so callers can extend the automatically-created general-purpose subagent without reimplementing DeepAgents internals.

--- a/.changeset/codex-subagent-middleware.md
+++ b/.changeset/codex-subagent-middleware.md
@@ -3,3 +3,5 @@
 ---
 
 Add `generalPurposeSubagentMiddleware` so callers can extend the automatically-created general-purpose subagent without reimplementing DeepAgents internals.
+
+Treat unknown-extension UTF-8 files as `text/plain` when reading from the filesystem, while preserving true binary `application/octet-stream` files as binary content.

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -107,6 +107,16 @@ const agent = createDeepAgent({
 });
 ```
 
+To extend the built-in general-purpose subagent without replacing DeepAgents'
+default subagent setup, pass middleware through `generalPurposeSubagentMiddleware`:
+
+```typescript
+const agent = createDeepAgent({
+  tools: [myCustomTool],
+  generalPurposeSubagentMiddleware: [sanitizeToolResultsMiddleware],
+});
+```
+
 See the [JavaScript Deep Agents docs](https://docs.langchain.com/oss/javascript/deepagents/overview) for full configuration options.
 
 ## LangGraph Native

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
+import { createMiddleware } from "langchain";
+import { fakeModel } from "@langchain/core/testing";
 import { createDeepAgent } from "./agent.js";
 import { isAnthropicModel } from "./utils.js";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
 import {
+  AIMessage,
   HumanMessage,
   SystemMessage,
   type BaseMessage,
@@ -10,7 +13,7 @@ import {
 import { MemorySaver, StateSchema } from "@langchain/langgraph";
 import { createFileData } from "./backends/utils.js";
 import { ConfigurationError } from "./errors.js";
-import { assertAllDeepAgentQualities } from "./testing/utils.js";
+import { assertAllDeepAgentQualities, sampleTool } from "./testing/utils.js";
 import { z } from "zod/v4";
 
 describe("isAnthropicModel", () => {
@@ -169,6 +172,60 @@ describe("Built-in tool name collision detection", () => {
     expect(() =>
       createDeepAgent({ model, tools: [makeTool("my_custom_tool")] }),
     ).not.toThrow();
+  });
+});
+
+describe("General-purpose subagent middleware", () => {
+  it("should apply configured middleware to the auto-created general-purpose subagent", async () => {
+    const wrappedToolNames: string[] = [];
+    const trackingMiddleware = createMiddleware({
+      name: "GeneralPurposeTrackingMiddleware",
+      wrapToolCall: async (request, handler) => {
+        const result = await handler(request);
+        if (request.toolCall?.name) {
+          wrappedToolNames.push(request.toolCall.name);
+        }
+        return result;
+      },
+    });
+
+    const model = fakeModel()
+      .respondWithTools([
+        {
+          name: "task",
+          id: "call_general_purpose",
+          args: {
+            subagent_type: "general-purpose",
+            description: "Call sample_tool with middleware-check.",
+          },
+        },
+      ])
+      .respondWithTools([
+        {
+          name: "sample_tool",
+          id: "call_sample_tool",
+          args: { sample_input: "middleware-check" },
+        },
+      ])
+      .respond(new AIMessage("Subagent finished."))
+      .respond(new AIMessage("Root finished."));
+
+    const agent = createDeepAgent({
+      model,
+      tools: [sampleTool],
+      generalPurposeSubagentMiddleware: [trackingMiddleware],
+    });
+
+    await agent.invoke(
+      {
+        messages: [
+          new HumanMessage("Delegate this to the general-purpose subagent."),
+        ],
+      },
+      { recursionLimit: 100 },
+    );
+
+    expect(wrappedToolNames).toEqual(["sample_tool"]);
   });
 });
 

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -150,6 +150,8 @@ export function createDeepAgent<
   > = readonly [],
   TStateSchema extends AnyStateSchema | InteropZodObject | undefined =
     undefined,
+  const TGeneralPurposeSubagentMiddleware extends readonly AgentMiddleware[] =
+    readonly [],
 >(
   params: CreateDeepAgentParams<
     TResponse,
@@ -158,7 +160,8 @@ export function createDeepAgent<
     TSubagents,
     TTools,
     TStreamTransformers,
-    TStateSchema
+    TStateSchema,
+    TGeneralPurposeSubagentMiddleware
   > = {} as CreateDeepAgentParams<
     TResponse,
     ContextSchema,
@@ -166,7 +169,8 @@ export function createDeepAgent<
     TSubagents,
     TTools,
     TStreamTransformers,
-    TStateSchema
+    TStateSchema,
+    TGeneralPurposeSubagentMiddleware
   >,
 ) {
   const {
@@ -175,6 +179,7 @@ export function createDeepAgent<
     systemPrompt,
     stateSchema,
     middleware: customMiddleware = [],
+    generalPurposeSubagentMiddleware = [],
     subagents = [],
     responseFormat,
     contextSchema,
@@ -324,6 +329,7 @@ export function createDeepAgent<
       model,
       skills,
       tools: effectiveTools,
+      middleware: generalPurposeSubagentMiddleware,
     });
     inlineSubagents.unshift(generalPurposeSpec);
   }
@@ -492,6 +498,7 @@ export function createDeepAgent<
     ...typeof builtInMiddleware,
     ...TMiddleware,
     ...FlattenSubAgentMiddleware<TSubagents>,
+    ...TGeneralPurposeSubagentMiddleware,
   ];
 
   /**

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -414,6 +414,41 @@ describe("FilesystemBackend", () => {
   });
 
   describe("binary file handling", () => {
+    it("should read extensionless UTF-8 files as text/plain", async () => {
+      const root = tmpDir;
+      const filePath = path.join(root, "Dockerfile");
+      await writeFile(filePath, "FROM node:22\nRUN echo hello\n");
+
+      const backend = new FilesystemBackend({
+        rootDir: root,
+        virtualMode: false,
+      });
+
+      const result = await backend.read(filePath);
+      expect(result.error).toBeUndefined();
+      expect(typeof result.content).toBe("string");
+      expect(result.content).toContain("FROM node:22");
+      expect(result.mimeType).toBe("text/plain");
+    });
+
+    it("should keep extensionless binary files as application/octet-stream", async () => {
+      const root = tmpDir;
+      const filePath = path.join(root, "binary");
+      const binaryData = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+      await fs.writeFile(filePath, binaryData);
+
+      const backend = new FilesystemBackend({
+        rootDir: root,
+        virtualMode: false,
+      });
+
+      const result = await backend.read(filePath);
+      expect(result.error).toBeUndefined();
+      expect(result.content).toBeInstanceOf(Uint8Array);
+      expect(result.content).toEqual(new Uint8Array(binaryData));
+      expect(result.mimeType).toBe("application/octet-stream");
+    });
+
     it("should read binary files as Uint8Array", async () => {
       const root = tmpDir;
       // PNG header bytes
@@ -495,6 +530,26 @@ describe("FilesystemBackend", () => {
   });
 
   describe("readRaw", () => {
+    it("should return text/plain for extensionless UTF-8 files", async () => {
+      const root = tmpDir;
+      const filePath = path.join(root, "Dockerfile");
+      await writeFile(filePath, "FROM node:22\nRUN echo hello\n");
+
+      const backend = new FilesystemBackend({
+        rootDir: root,
+        virtualMode: false,
+      });
+
+      const result = await backend.readRaw(filePath);
+      expect(result.error).toBeUndefined();
+      expect(typeof result.data!.content).toBe("string");
+      expect(result.data!.content).toBe("FROM node:22\nRUN echo hello\n");
+      expect("mimeType" in result.data!).toBe(true);
+      expect((result.data! as { mimeType: string }).mimeType).toBe(
+        "text/plain",
+      );
+    });
+
     it("should return v2 format for text files", async () => {
       const root = tmpDir;
       const filePath = path.join(root, "test.txt");

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -32,6 +32,7 @@ import type {
 import {
   checkEmptyContent,
   getMimeType,
+  inferMimeTypeFromContent,
   isTextMimeType,
   performStringReplacement,
 } from "./utils.js";
@@ -61,6 +62,21 @@ export class FilesystemBackend implements BackendProtocolV2 {
     this.cwd = rootDir ? path.resolve(rootDir) : process.cwd();
     this.virtualMode = virtualMode;
     this.maxFileSizeBytes = maxFileSizeMb * 1024 * 1024;
+  }
+
+  private static normalizeReadContent(
+    buffer: Uint8Array,
+    mimeType: string,
+  ): { content: string | Uint8Array; mimeType: string } {
+    const inferredMimeType = inferMimeTypeFromContent(mimeType, buffer);
+    if (isTextMimeType(inferredMimeType)) {
+      return {
+        content: Buffer.from(buffer).toString("utf-8"),
+        mimeType: inferredMimeType,
+      };
+    }
+
+    return { content: new Uint8Array(buffer), mimeType: inferredMimeType };
   }
 
   /**
@@ -203,7 +219,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
     try {
       const resolvedPath = this.resolvePath(filePath);
 
-      const mimeType = getMimeType(filePath);
+      let mimeType = getMimeType(filePath);
       const isBinary = !isTextMimeType(mimeType);
 
       let content: string;
@@ -219,9 +235,18 @@ export class FilesystemBackend implements BackendProtocolV2 {
         try {
           if (isBinary) {
             const buffer = await fd.readFile();
-            return { content: new Uint8Array(buffer), mimeType };
+            const normalized = FilesystemBackend.normalizeReadContent(
+              buffer,
+              mimeType,
+            );
+            if (!isTextMimeType(normalized.mimeType)) {
+              return normalized;
+            }
+            content = normalized.content as string;
+            mimeType = normalized.mimeType;
+          } else {
+            content = await fd.readFile({ encoding: "utf-8" });
           }
-          content = await fd.readFile({ encoding: "utf-8" });
         } finally {
           await fd.close();
         }
@@ -235,9 +260,18 @@ export class FilesystemBackend implements BackendProtocolV2 {
         }
         if (isBinary) {
           const buffer = await fs.readFile(resolvedPath);
-          return { content: new Uint8Array(buffer), mimeType };
+          const normalized = FilesystemBackend.normalizeReadContent(
+            buffer,
+            mimeType,
+          );
+          if (!isTextMimeType(normalized.mimeType)) {
+            return normalized;
+          }
+          content = normalized.content as string;
+          mimeType = normalized.mimeType;
+        } else {
+          content = await fs.readFile(resolvedPath, "utf-8");
         }
-        content = await fs.readFile(resolvedPath, "utf-8");
       }
 
       const emptyMsg = checkEmptyContent(content);
@@ -271,7 +305,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
   async readRaw(filePath: string): Promise<ReadRawResult> {
     const resolvedPath = this.resolvePath(filePath);
 
-    const mimeType = getMimeType(filePath);
+    let mimeType = getMimeType(filePath);
     const isBinary = !isTextMimeType(mimeType);
 
     let content: string;
@@ -289,9 +323,14 @@ export class FilesystemBackend implements BackendProtocolV2 {
       try {
         if (isBinary) {
           const buffer = await fd.readFile();
+          const normalized = FilesystemBackend.normalizeReadContent(
+            buffer,
+            mimeType,
+          );
+          mimeType = normalized.mimeType;
           return {
             data: {
-              content: new Uint8Array(buffer),
+              content: normalized.content,
               mimeType,
               created_at: stat.ctime.toISOString(),
               modified_at: stat.mtime.toISOString(),
@@ -312,9 +351,14 @@ export class FilesystemBackend implements BackendProtocolV2 {
       }
       if (isBinary) {
         const buffer = await fs.readFile(resolvedPath);
+        const normalized = FilesystemBackend.normalizeReadContent(
+          buffer,
+          mimeType,
+        );
+        mimeType = normalized.mimeType;
         return {
           data: {
-            content: new Uint8Array(buffer),
+            content: normalized.content,
             mimeType,
             created_at: stat.ctime.toISOString(),
             modified_at: stat.mtime.toISOString(),
@@ -629,12 +673,6 @@ export class FilesystemBackend implements BackendProtocolV2 {
 
     for (const fp of files) {
       try {
-        // Skip binary files
-        const mimeType = getMimeType(fp);
-        if (!isTextMimeType(mimeType)) {
-          continue;
-        }
-
         // Filter by glob if provided
         if (
           includeGlob &&
@@ -650,7 +688,21 @@ export class FilesystemBackend implements BackendProtocolV2 {
         }
 
         // Read and search using literal substring matching
-        const content = await fs.readFile(fp, "utf-8");
+        const mimeType = getMimeType(fp);
+        let content: string;
+        if (isTextMimeType(mimeType)) {
+          content = await fs.readFile(fp, "utf-8");
+        } else {
+          const buffer = await fs.readFile(fp);
+          const normalized = FilesystemBackend.normalizeReadContent(
+            buffer,
+            mimeType,
+          );
+          if (!isTextMimeType(normalized.mimeType)) {
+            continue;
+          }
+          content = normalized.content as string;
+        }
         const lines = content.split("\n");
 
         for (let i = 0; i < lines.length; i++) {

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -12,6 +12,8 @@ import {
   isFileDataV1,
   migrateToFileDataV2,
   getMimeType,
+  inferMimeTypeFromContent,
+  isLikelyTextContent,
   isTextMimeType,
   adaptBackendProtocol,
   TOOL_RESULT_TOKEN_LIMIT,
@@ -486,6 +488,46 @@ describe("isTextMimeType", () => {
     expect(isTextMimeType("audio/flac")).toBe(false);
     expect(isTextMimeType("video/quicktime")).toBe(false);
     expect(isTextMimeType("application/vnd.ms-powerpoint")).toBe(false);
+  });
+});
+
+describe("isLikelyTextContent", () => {
+  it("should recognize UTF-8 text without an extension", () => {
+    const bytes = new TextEncoder().encode("FROM node:22\nRUN echo hello\n");
+    expect(isLikelyTextContent(bytes)).toBe(true);
+  });
+
+  it("should reject content with NUL bytes", () => {
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    expect(isLikelyTextContent(bytes)).toBe(false);
+  });
+
+  it("should reject invalid UTF-8 bytes", () => {
+    const bytes = new Uint8Array([0xff, 0xfe, 0xfd]);
+    expect(isLikelyTextContent(bytes)).toBe(false);
+  });
+});
+
+describe("inferMimeTypeFromContent", () => {
+  it("should promote unknown UTF-8 content to text/plain", () => {
+    const bytes = new TextEncoder().encode("root = true\n");
+    expect(inferMimeTypeFromContent("application/octet-stream", bytes)).toBe(
+      "text/plain",
+    );
+  });
+
+  it("should keep unknown binary content as application/octet-stream", () => {
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    expect(inferMimeTypeFromContent("application/octet-stream", bytes)).toBe(
+      "application/octet-stream",
+    );
+  });
+
+  it("should not override known binary MIME types", () => {
+    const bytes = new TextEncoder().encode("%PDF text-looking bytes");
+    expect(inferMimeTypeFromContent("application/pdf", bytes)).toBe(
+      "application/pdf",
+    );
   });
 });
 

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -6,6 +6,7 @@
  * enable composition without fragile string parsing.
  */
 
+import { TextDecoder } from "node:util";
 import micromatch from "micromatch";
 import type {
   AnyBackendProtocol,
@@ -137,6 +138,9 @@ const MIME_TYPES: Record<string, string> = {
   ".editorconfig": "text/plain",
 };
 
+const UNKNOWN_BINARY_MIME_TYPE = "application/octet-stream";
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
 function basename(filePath: string): string {
   const normalized = filePath.replace(/\\/g, "/");
   const slashIdx = normalized.lastIndexOf("/");
@@ -255,6 +259,56 @@ export function isFileDataBinary(
   data: FileData,
 ): data is FileDataV2 & { content: Uint8Array } {
   return ArrayBuffer.isView(data.content);
+}
+
+/**
+ * Check whether unknown binary-looking bytes are actually UTF-8 text.
+ *
+ * This is intentionally conservative: known binary MIME types stay binary, and
+ * only application/octet-stream content can be promoted to text/plain.
+ */
+export function isLikelyTextContent(content: Uint8Array): boolean {
+  if (content.length === 0) {
+    return true;
+  }
+
+  let decoded: string;
+  try {
+    decoded = utf8Decoder.decode(content);
+  } catch {
+    return false;
+  }
+
+  let suspiciousControlChars = 0;
+  for (let i = 0; i < decoded.length; i++) {
+    const charCode = decoded.charCodeAt(i);
+    const allowedControlChar =
+      charCode === 0x09 || // tab
+      charCode === 0x0a || // line feed
+      charCode === 0x0c || // form feed
+      charCode === 0x0d; // carriage return
+
+    if (charCode === 0 || (charCode < 0x20 && !allowedControlChar)) {
+      suspiciousControlChars += 1;
+    }
+  }
+
+  return suspiciousControlChars / decoded.length <= 0.01;
+}
+
+/**
+ * Promote unknown octet-stream content to text/plain when its bytes look like
+ * ordinary UTF-8 text. Known MIME types are left unchanged.
+ */
+export function inferMimeTypeFromContent(
+  mimeType: string,
+  content: Uint8Array,
+): string {
+  if (mimeType !== UNKNOWN_BINARY_MIME_TYPE) {
+    return mimeType;
+  }
+
+  return isLikelyTextContent(content) ? "text/plain" : mimeType;
 }
 
 /**

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as fsSync from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   fileDataReducer,
   type FilesRecord,
@@ -7,6 +11,7 @@ import {
   NUM_CHARS_PER_TOKEN,
   TOOLS_EXCLUDED_FROM_EVICTION,
 } from "./fs.js";
+import { FilesystemBackend } from "../backends/filesystem.js";
 import type { FileData, BackendProtocolV2 } from "../backends/protocol.js";
 import {
   SystemMessage,
@@ -1014,6 +1019,42 @@ describe("createFilesystemMiddleware", () => {
   });
 
   describe("tools", () => {
+    it("read_file should return text for extensionless UTF-8 files", async () => {
+      const tmpDir = fsSync.mkdtempSync(
+        path.join(os.tmpdir(), "deepagents-fs-tool-"),
+      );
+
+      try {
+        await fs.writeFile(
+          path.join(tmpDir, "Dockerfile"),
+          "FROM node:22\nRUN echo hello\n",
+          "utf-8",
+        );
+
+        const middleware = createFilesystemMiddleware({
+          backend: new FilesystemBackend({
+            rootDir: tmpDir,
+            virtualMode: true,
+          }),
+        });
+        const readFileTool = middleware.tools!.find(
+          (t: any) => t.name === "read_file",
+        ) as any;
+
+        const result = await readFileTool.invoke({
+          file_path: "/Dockerfile",
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          type: "text",
+          text: expect.stringContaining("FROM node:22"),
+        });
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("write_file schema should accept missing content and default to empty string", () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -514,6 +514,8 @@ export interface CreateDeepAgentParams<
     readonly [],
   TStateSchema extends AnyStateSchema | InteropZodObject | undefined =
     undefined,
+  TGeneralPurposeSubagentMiddleware extends readonly AgentMiddleware[] =
+    readonly [],
 > {
   /** The model to use (model name string or LanguageModelLike instance). Defaults to claude-sonnet-4-5-20250929 */
   model?: BaseLanguageModel | string;
@@ -551,6 +553,16 @@ export interface CreateDeepAgentParams<
   stateSchema?: TStateSchema;
   /** Custom middleware to apply after standard middleware */
   middleware?: TMiddleware;
+  /**
+   * Additional middleware to append to the automatically-created
+   * general-purpose subagent.
+   *
+   * This is useful when callers need the built-in general-purpose subagent to
+   * preserve DeepAgents' default setup while adding focused behavior such as
+   * tool-result sanitization. Custom subagents should continue to use their own
+   * `middleware` field.
+   */
+  generalPurposeSubagentMiddleware?: TGeneralPurposeSubagentMiddleware;
   /**
    * List of subagent specifications for task delegation.
    *


### PR DESCRIPTION
## Summary

- Add `generalPurposeSubagentMiddleware` to `createDeepAgent`.
- Pass that middleware into the profile-aware, automatically-created `general-purpose` subagent.
- Treat unknown-extension UTF-8 filesystem reads, such as `Dockerfile` and `LICENSE`, as `text/plain` while preserving true `application/octet-stream` binaries.
- Document the new option and add regression coverage for both the default general-purpose subagent middleware path and extensionless text reads.

## Problem

OpenWiki [#67](https://github.com/langchain-ai/openwiki/pull/67) fixes an Anthropic 400 caused by unsupported file/media content blocks returned from DeepAgents filesystem tools. The main-agent sanitizer was straightforward, but the default DeepAgents `general-purpose` subagent has its own middleware stack and did not inherit the main agent's `middleware`.

Without an upstream extension point, OpenWiki had to duplicate DeepAgents internals: harness-profile resolution, prompt assembly, default general-purpose subagent construction, and tool threading. That was fragile, easy to drift from DeepAgents behavior, and was called out in review.

There was also a related DeepAgents behavior issue: extensionless UTF-8 repository files were surfaced as `application/octet-stream` binary file blocks. That made normal files like `Dockerfile`, `LICENSE`, and `CODEOWNERS` look like unsupported binary data to downstream providers.

## Fix

This PR moves the reusable behavior into DeepAgents:

- `generalPurposeSubagentMiddleware` gives callers a narrow way to extend the default `general-purpose` subagent without redeclaring it.
- The existing profile-aware default subagent creation path stays authoritative, so callers do not need to copy internal provider/model prompt logic.
- Filesystem reads conservatively sniff only unknown `application/octet-stream` bytes. Valid low-control-character UTF-8 content is promoted to `text/plain`; suspicious or invalid bytes remain binary.
- Known MIME types are not overridden, so PDFs, images, audio, video, and other known binary formats keep their existing behavior.

## Cross-Repo Rollout

- OpenWiki [#67](https://github.com/langchain-ai/openwiki/pull/67) is the original Anthropic sanitizer PR and the review thread that exposed the duplicated subagent logic.
- OpenWiki [#89](https://github.com/langchain-ai/openwiki/pull/89) consumes this PR through the `https://pkg.pr.new/deepagents@63aa2e1` preview package and removes the duplicated subagent implementation.
- LangChainJS [#11143](https://github.com/langchain-ai/langchainjs/pull/11143) is complementary defense-in-depth in `@langchain/anthropic`: unknown MIME file blocks should not be mislabeled as PDF documents.

Suggested review order: review this PR first, then OpenWiki [#89](https://github.com/langchain-ai/openwiki/pull/89). OpenWiki [#89](https://github.com/langchain-ai/openwiki/pull/89) should switch from the preview package to the released DeepAgents version after this lands and publishes.

## Reviewer Notes

Please focus on:

- whether `generalPurposeSubagentMiddleware` is the right API shape for extending only the default general-purpose subagent;
- whether middleware ordering is correct relative to the default filesystem/subagent middleware;
- whether the UTF-8 sniffing is conservative enough for unknown-extension files;
- whether any callers could expect unknown extensionless text to remain binary.

## Testing

DeepAgents local validation:

- `pnpm --filter deepagents exec vitest run src/backends/utils.test.ts src/backends/filesystem.test.ts src/middleware/fs.test.ts src/agent.test.ts`
- `pnpm --filter deepagents typecheck`
- `pnpm --filter deepagents build`
- `pnpm format:check`
- `pnpm lint`

OpenWiki validation against this branch:

- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm run build`
- direct `read_file` smoke: extensionless `Dockerfile` returns a text block; real extensionless binary remains `application/octet-stream`
- live Anthropic smoke through OpenWiki general-purpose subagent: `/Dockerfile` was read as text and not skipped; real binary was skipped safely without a 400

CI status at last local check: all DeepAgents GitHub Actions checks passed, integration tests were skipped by workflow configuration, and Vercel reported the existing external authorization-required status.