### PR TITLE
fix(deepagents): read_file must not emit unsendable document blocks for non-PDF binaries

### DIFF
--- a/.changeset/read-file-non-pdf-binary.md
+++ b/.changeset/read-file-non-pdf-binary.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Fix `read_file` emitting an unsendable document block for non-PDF binary files. Provider APIs only accept `application/pdf` for base64 document blocks, so reading any other binary (fonts, wasm, archives, etc.) caused a 400 (`document.source.base64.media_type: Input should be 'application/pdf'`). Non-PDF binaries now return a short text note instead; PDFs and image/audio/video blocks are unchanged.

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1048,6 +1048,58 @@ describe("createFilesystemMiddleware", () => {
         }
       }
     });
+
+    it("read_file returns a text note for non-PDF binaries instead of an unsendable document block", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.read = vi.fn().mockResolvedValue({
+        content: Buffer.from([0x00, 0x01, 0x02, 0x03]),
+        mimeType: "application/octet-stream",
+      });
+      vi.mocked(getCurrentTaskInput).mockReturnValue({
+        messages: [],
+        files: {},
+      });
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+      const readFileTool = middleware.tools!.find(
+        (t: any) => t.name === "read_file",
+      ) as any;
+
+      const result = await readFileTool.invoke({ file_path: "/logo.bin" });
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result[0].type).toBe("text");
+      expect(result[0].text).toContain("/logo.bin");
+      expect(JSON.stringify(result)).not.toContain('"type":"file"');
+    });
+
+    it("read_file still returns a document block for application/pdf", async () => {
+      const pdf = Buffer.from("%PDF-1.4 fake pdf bytes");
+      const mockBackend = createMockBackend();
+      mockBackend.read = vi.fn().mockResolvedValue({
+        content: pdf,
+        mimeType: "application/pdf",
+      });
+      vi.mocked(getCurrentTaskInput).mockReturnValue({
+        messages: [],
+        files: {},
+      });
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+      const readFileTool = middleware.tools!.find(
+        (t: any) => t.name === "read_file",
+      ) as any;
+
+      const result = await readFileTool.invoke({ file_path: "/doc.pdf" });
+
+      expect(result[0].type).toBe("file");
+      expect(result[0].mimeType).toBe("application/pdf");
+      expect(result[0].data).toBe(pdf.toString("base64"));
+    });
   });
 
   describe("tool result truncation integration", () => {

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -739,7 +739,18 @@ function createReadFileTool(
         if (mimeType.startsWith("video/")) {
           return [{ type: "video", mimeType, data: base64Data }];
         }
-        return [{ type: "file", mimeType, data: base64Data }];
+        // Providers only accept application/pdf for base64 document blocks;
+        // any other binary type is rejected (e.g. Anthropic 400s). Surface a
+        // note instead of emitting an unsendable block.
+        if (mimeType === "application/pdf") {
+          return [{ type: "file", mimeType, data: base64Data }];
+        }
+        return [
+          {
+            type: "text",
+            text: `Cannot read '${file_path}': unsupported binary file type (${mimeType}).`,
+          },
+        ];
       }
 
       let content =


### PR DESCRIPTION
## Problem

`read_file` base64-encodes any non-text file into a `type: "file"` content block, which provider adapters translate into a document block. Provider APIs only accept `application/pdf` for base64 document blocks, so as soon as an agent reads any *other* binary file in a repo (fonts, `.wasm`, archives, `.ico`, etc.) the request fails:

```
Error 400 invalid_request_error
messages.N.content.M.tool_result.content.0.document.source.base64.media_type:
Input should be 'application/pdf'
```

This makes `read_file` (and thus any deep agent) unusable on repositories that contain non-PDF binaries — the agent only has to read one to hard-fail the run.

## Fix

In `createReadFileTool` (`libs/deepagents/src/middleware/fs.ts`), gate the `type: "file"` document block on `application/pdf`. Any other binary type returns a short text note instead of an unsendable block. `image/`, `audio/`, `video/` blocks and PDFs are unchanged.

## Tests

Added two unit tests in `fs.test.ts`:
- non-PDF binary (`application/octet-stream`) → text note, never a `type: "file"` block (fails on `main`).
- `application/pdf` → still returns the document block (regression guard).

`oxfmt` + `oxlint` clean.

## Context

Hit while running [OpenWiki](https://github.com/langchain-ai/openwiki) (which uses deepagents) against a large repo — the agent read a non-PDF binary and every run 400'd.