### PR TITLE
Re-base launch10 delta onto upstream ff7d82a7

### DIFF
--- a/LAUNCH10.md
+++ b/LAUNCH10.md
@@ -1,0 +1,271 @@
+# Launch10 fork of `deepagents`
+
+This is a fork of [`langchain-ai/deepagentsjs`](https://github.com/langchain-ai/deepagentsjs).
+This file documents **everything we changed on top of upstream** so the delta
+is auditable and re-portable when we rebase onto a newer upstream.
+
+- **Upstream remote:** `upstream` → `langchain-ai/deepagentsjs`
+- **Our remote:** `origin` → `launch10/deepagentsjs`
+- **Fork point (merge-base):** `ff7d82a7` (`build(deps): bump the minor-deps-updates-main group (#640)`) — upstream
+  main as of 2026-07-05. Previous fork point was `9221c8a2` (#549); we re-based our
+  delta onto current upstream (see `UPGRADE_PLAN.md`), keeping upstream's absorbed
+  fixes (#608 subagent text forwarding, #598 native `run.subagents`, #566
+  `lc_agent_name`) and layering our changes on top.
+
+All paths below are under `libs/deepagents/src/`. To regenerate the raw diff:
+
+```bash
+git fetch upstream
+git diff ff7d82a7 HEAD -- libs/deepagents/src
+```
+
+---
+
+## Why we forked
+
+Two production problems drove every change here:
+
+1. **Parallel subagents crash on fan-in.** We dispatch N coder subagents in one
+   superstep. Stock deepagents lets a subagent return arbitrary inherited state
+   back to the parent. When several siblings echo the same plain `LastValue`
+   channel in one step, LangGraph throws *"LastValue can only receive one value
+   per step"* (we hit this on `error`, trace `fe0786e3`, and on `jwt`, trace
+   `fa4945ba`).
+2. **The default `task` tool destroys prompt-cache hit rate.** Its description
+   and `subagent_type` schema field embed the live subagent roster. Two agents
+   that share a system prompt (so they *should* share a cache prefix and a cost
+   profile) but register different subagent sets end up with divergent tool
+   bytes — the first cache breakpoint breaks and they never share cache.
+
+Everything else is downstream of fixing those two, plus a dependency pin.
+
+---
+
+## Changes
+
+### 1. Subagent return path is an allowlist, not a denylist
+
+**File:** `middleware/subagents.ts` · **Test:** `middleware/subagentReturnState.test.ts`
+
+Upstream filters subagent *return* state through a denylist (`EXCLUDED_STATE_KEYS`):
+it strips a few known-bad keys and passes everything else back. That's fragile —
+any newly-inherited parent field (a new id, a new flag) silently becomes a fan-in
+crash the next time subagents run in parallel.
+
+We replaced the return path with an **allowlist**:
+
+```ts
+export const RETURN_STATE_ALLOWLIST = ["todos", "files"] as const;
+export function filterReturnState(state) { /* keep only allowlisted keys */ }
+```
+
+A subagent's contribution to the parent is exactly:
+- its **final message** (handled separately as a `ToolMessage`), plus
+- the **reducer-backed channels it legitimately accumulates into** — `todos`
+  (parent's `todosReducer` merges by id) and `files` (`fileDataReducer` merges by
+  path).
+
+Everything else it carries is inherited *parent* context (`jwt`, `websiteId`,
+`mode`, `accountId`, `error`, …) and is dropped. Because no parent scalar is ever
+echoed back, future inherited fields can't reintroduce the crash class — this
+fixes the whole category at the source rather than playing denylist whack-a-mole.
+
+`returnCommandWithStateUpdate()` now calls `filterReturnState(result)` instead of
+`filterStateForSubagent(result)`.
+
+> **Note — the input path is still a denylist.** `filterStateForSubagent()`
+> (state flowing *into* a subagent) intentionally stays a denylist: a child
+> should inherit most of the parent's context minus a few keys
+> (`skillsMetadata`, `memoryContents`, etc.). Allowlist on the way back,
+> denylist on the way in.
+
+> **Note —** `todos` was removed from `EXCLUDED_STATE_KEYS` (see change 3) so it
+> can flow back through the allowlist.
+
+---
+
+### 2. Cache-prefix-stable `task` tool
+
+**Files:** `middleware/subagents.ts`, `types.ts`, `agent.ts`
+
+Two new optional overrides thread from `createDeepAgent` →
+`createSubAgentMiddleware` → `createTaskTool`:
+
+| Param | What it overrides | Default if unset |
+| --- | --- | --- |
+| `taskDescription` | the `task` tool's top-level prose description | upstream roster-bearing description |
+| `subagentTypeDescription` | the `subagent_type` schema-field `.describe()` | `"Name of the agent to use. Available: <roster>"` |
+
+The problem: both the tool description and the `subagent_type` field default to
+embedding `Available: <roster>`. That roster differs per agent, so the serialized
+tool bytes differ, so the prompt-cache prefix diverges one field apart — even
+when two agents share an identical system prompt.
+
+The fix: pass **roster-free constants** for both. The tool then serializes
+byte-identically across agents regardless of which subagents they register, so
+they share a cache prefix (and a cost profile). The actual roster is delivered
+**out-of-band** — e.g. a tail reminder injected at runtime — rather than baked
+into the tool schema.
+
+Correctness is unaffected: `subagent_type` is still validated against the
+registered graphs at dispatch time. We only removed the roster from the *cacheable
+prompt bytes*, not from validation.
+
+**You must set both together.** Setting only `taskDescription` leaves the roster
+in the `subagent_type` field one level down and re-breaks the prefix.
+
+---
+
+### 3. Enhanced `todoListMiddleware` (UUIDs + merge-by-id reducer)
+
+**File:** `middleware/todos.ts` (new) · exported from `index.ts` · wired in `agent.ts`
+
+This *replaces* langchain's `todoListMiddleware` (note the import swap in
+`agent.ts`: `from "langchain"` → `from "./middleware/todos.js"`). It adds:
+
+1. **Auto-generated UUIDs.** `write_todos` stamps `id: t.id || randomUUID()` on
+   every todo so todos are individually addressable across parallel updates.
+2. **A `ReducedValue` `todos` channel with a merge-by-id reducer**
+   (`todosReducer`). Instead of last-write-wins, parallel updates merge:
+   - existing ids update in place; new ids append;
+   - **status never downgrades.** Priority is `completed(2) > in_progress(1) >
+     pending(0)`. Parallel subagents act on stale snapshots, so a late update
+     must not move a todo backward (e.g. `completed → in_progress`).
+3. **An `afterModel` guard** that rejects *parallel* `write_todos` tool calls in
+   a single model turn (returns error `ToolMessage`s). The full list must be
+   written atomically in one call.
+
+> This is the **[pre-existing]** reconciliation mechanism — the id + merge-by-id
+> reducer is what lets streaming todos from subagents reconcile back into the
+> parent without clobbering. Changes 1 and 4 depend on it.
+
+The exported `TodoListMiddlewareOptions` allows `systemPrompt` / `toolDescription`
+overrides (kept for parity with upstream).
+
+---
+
+### 4. Subagent → parent todo reconciliation + real-time streaming
+
+**File:** `middleware/subagents.ts`
+
+The `task` tool gained an optional `todo_id` parameter. When the dispatcher
+passes the parent todo id it's delegating:
+
+- When the subagent finishes, the matching parent todo is auto-flipped to
+  `completed` in the returned `todos` (which then merge back via the reducer from
+  change 3).
+- That flip is **also emitted immediately through the graph stream writer** as a
+  `__state_patch__` event, *bypassing the `Promise.all` batching* of the parallel
+  dispatch. Without this, the frontend only sees todos flip after *every* sibling
+  subagent resolves; with it, each todo flips the moment its subagent finishes.
+
+To make that work we had to **capture the stream writer before
+`subagent.invoke()`**: the subagent's graph invocation replaces the
+`AsyncLocalStorage` context, so `getWriter()` returns `undefined` after `invoke()`
+returns. We grab it up front and tolerate both the function-style and
+`.write()`-style writer shapes.
+
+---
+
+### 5. Per-dispatch `callerId` for shared-backend optimistic concurrency
+
+**File:** `middleware/subagents.ts`
+**Consumer (verified in use):** `langgraph_app/app/services/backends/callerContext.ts`
+and `virtualFilesBackend.ts`
+
+Each `task` dispatch now stamps a fresh `callerId: randomUUID()` into
+`subagentConfig.configurable`. Stock deepagents mints no stable per-sync-subagent
+identity — a spawned coder just inherits the parent's `configurable` — so a shared
+backend can't tell parallel coders apart. Putting it in `configurable` makes it
+ambient (readable via `getConfig()` for the subagent's whole run), and every
+dispatch, including nested sub-coders, gets a distinct one.
+
+**This is actively consumed**, not speculative. `langgraph_app` shares one
+`VirtualFilesBackend` instance across the main agent and every parallel coder
+dispatch. The backend does optimistic-concurrency control (OCC) on writes: it
+tracks, *per caller*, the shasum version each caller read, and sends that as the
+`expected_shasum` compare-and-swap on write. Without a per-caller id, the
+shasum store is keyed only by path, so coder B inherits coder A's post-write
+shasum and silently clobbers A's change (lost update). `callerContext.ts` reads
+our stamped id via `getConfig()` (`currentCallerId()`), falling back to
+`DEFAULT_CALLER_ID = "root"` for the main top-level invoke that carries no
+`callerId`. Subagent fan-out is the *normal* mode there, so this is the common
+path, not an edge case.
+
+> **Rebase implication:** this is a hard dependency of the consuming app. If a
+> future upstream starts minting its own subagent identity under a different
+> `configurable` key, update `callerContext.ts` to read it instead of removing
+> our stamp.
+
+---
+
+### 6. Dependency: `zod` — resolved (manifest matches upstream, runtime is v4)
+
+**Files:** `libs/deepagents/package.json`
+
+**Post-upgrade state (ff7d82a7):** the manifest carries upstream's `zod`
+`^4.3.6`; the launch10 monorepo root override still forces `zod@4.4.3` at
+runtime. We dropped the fork's cosmetic `"zod/v4"` → `"zod"` import flips
+(`testing/utils.ts`, `agent.test-d.ts`) — on a v4 runtime both subpaths resolve
+to the same API, so keeping upstream's imports minimizes divergence. The stale
+`3.25.76` pin described below is gone.
+
+Historical note (pre-upgrade):
+- `libs/deepagents/package.json` had once pinned `zod` to `3.25.76`, overridden
+  at runtime by the monorepo root override to `zod@4.4.3` — misleading but
+  runtime-moot inside the monorepo.
+
+**The declared `3.25.76` pin is overridden and misleading. deepagents actually
+loads `zod@4.4.3` at runtime.** The launch10 monorepo root
+(`/Users/.../launch10/package.json`) carries a workspace-wide pnpm override:
+
+```json
+"pnpm": { "overrides": {
+  "zod": "4.4.3",
+  "miniflare>zod": "3.25.76",
+  "@cloudflare/vitest-pool-workers>zod": "3.25.76"
+}}
+```
+
+`packages/deepagentsjs/libs/deepagents` is a member of that root workspace
+(matched by `packages/*/libs/*`), so the override wins: the live symlink
+`libs/deepagents/node_modules/zod` points at `zod@4.4.3`. `langgraph_app`
+resolves 4.4.3 the same way. Only Cloudflare Workers tooling stays on 3.25.76.
+
+Because the runtime zod is 4.4.3, both `from "zod"` and `from "zod/v4"` resolve
+to the v4 API — which is why the mixed imports work. The `3.25.76` text in
+deepagents' `package.json` is a leftover from when the workspace was on zod 3;
+it no longer reflects reality.
+
+**Recommended cleanup:** bump `libs/deepagents/package.json` `zod` to `^4.4.3`
+(or `^4.3.6`, matching upstream's range) so the manifest stops lying. This is
+runtime-moot inside the monorepo (the override already forces 4.4.3) but matters
+if deepagents is ever consumed standalone — a downstream consumer would install
+zod 3 from the pin, and `from "zod"` would then hand them the v3 API while
+`from "zod/v4"` hands them v4, a split-brain that only surfaces outside this
+repo. Tracked as open cleanup below.
+
+> **Rebase note:** upstream is on zod `^4.3.6`. A naive merge that restores the
+> upstream pin is actually *more correct* than our `3.25.76` — don't fight it.
+
+---
+
+## Rebase checklist
+
+When pulling a newer upstream, re-verify each item survives:
+
+- [ ] Return path still uses `filterReturnState` (allowlist), not the upstream
+      denylist, in `returnCommandWithStateUpdate`.
+- [ ] `RETURN_STATE_ALLOWLIST` still matches the reducer-backed channels
+      (`todos`, `files`) — extend it only if you add a new *reducer-backed* channel.
+- [ ] `taskDescription` / `subagentTypeDescription` overrides still thread
+      through `createDeepAgent` → `createSubAgentMiddleware` → `createTaskTool`,
+      and our callers still pass roster-free constants for both.
+- [ ] `agent.ts` still imports `todoListMiddleware` from `./middleware/todos.js`,
+      not from `langchain`.
+- [ ] `task` tool still accepts `todo_id`; writer is still captured *before*
+      `subagent.invoke()`.
+- [ ] `callerId` is still stamped into `configurable`.
+- [ ] `zod`: runtime is 4.4.3 via the launch10 root override — verify the
+      override still lists `"zod": "4.4.3"`. The deepagents manifest pin is
+      cosmetic; prefer upstream's `^4.x` range over our stale `3.25.76`.

--- a/UPGRADE_PLAN.md
+++ b/UPGRADE_PLAN.md
@@ -1,0 +1,162 @@
+# Upgrade plan: rebase launch10 fork onto current upstream
+
+Goal: move our fork from fork-point `9221c8a2` up to current upstream
+`langchain-ai/deepagentsjs` main, **replaying only our logical changes** and
+letting upstream's new features come for free. Upstream is ~44 commits ahead
+(~20 substantive). None of our 6 changes are made redundant by upstream, but
+two of ours live in code upstream rewrote, so those are re-port (not cherry-pick).
+
+## Strategy: reset + reapply the net delta, do NOT `git rebase` the commits
+
+Our history since the fork is not replayable commit-by-commit:
+- an upstream merge (`8ab020ff`) is already baked into it,
+- the "Cache prewarming" `subagentWarmGate.ts` was added (`bd0b726a`) then
+  removed — net-zero, **skip entirely**,
+- `LAUNCH10.md` is stale (says zod pin `3.25.76`; the manifest is already
+  `^4.4.3`).
+
+So the ground truth is the **net diff**, not the commit log:
+
+```bash
+git diff 9221c8a2 HEAD -- libs/deepagents/src   # 11 files, our real delta
+```
+
+We reset onto new upstream and reapply those 11 files' intent as a small set of
+clean commits.
+
+## The net delta (11 files) and how each is handled
+
+| File | Our change | Upstream touched it? | Action |
+| --- | --- | --- | --- |
+| `middleware/todos.ts` | new: enhanced todo middleware (UUID + merge-by-id reducer + parallel-write guard) | no (new file) | **copy as-is** |
+| `middleware/subagentReturnState.test.ts` | new test | no (new file) | **copy as-is** |
+| `backends/filesystem.ts` (+`.test`) | hide `node_modules` from glob/ls/grep FS view | **no** (upstream changed composite/utils, not filesystem.ts) | **cherry-pick clean** |
+| `testing/utils.ts` | zod import | trivial | trivial reapply |
+| `agent.test-d.ts` | types test tweak | yes (+38, stateSchema tests) | reapply small hunk |
+| `index.ts` | export enhanced todos middleware | yes (+6) | reapply 1-2 lines |
+| `types.ts` | `taskDescription`/`subagentTypeDescription` option types | yes (+55) | reapply small hunk |
+| `middleware/fs.ts` | grep tool description → "ripgrep regex" | yes (+147, eviction) | **re-port** the one string |
+| `agent.ts` | import-swap todos middleware; thread 2 task-tool overrides; wire enhanced todos | **yes, heavy** (#569/#611/#598) | **re-port** |
+| `middleware/subagents.ts` | 4 logical changes (below) | **yes, heavy** (#608/#598/#591/#566) | **re-port — the hard one** |
+
+## "Minus the changes you listed" — keep/drop decisions
+
+Upstream's new work that intersects ours. Explicit calls so we don't fight it:
+
+- **KEEP upstream #608 (forward subagent result as text).** It rewrote the
+  *message-content* half of `returnCommandWithStateUpdate` to fix a real
+  Anthropic 400. Our allowlist change touches the *state* half of the same
+  function. Layer ours on top — do **not** revert theirs.
+- **KEEP upstream #598 (native `run.subagents`, transformer + `stream.ts`
+  deleted).** Our real-time todo streaming (change #4) hung off the old
+  transformer/writer path. Re-anchor our `getWriter()`-before-`invoke()` capture
+  onto the new path; don't try to resurrect the old `stream.ts`.
+- **KEEP upstream #566 (`metadata.lc_agent_name = subagent_type`).** It's
+  adjacent to — not a replacement for — our `callerId`. Our `callerId` stays in
+  `configurable`; their name stays in `metadata`. Keep both.
+- **KEEP upstream #591 (`createSubAgent` exported)** and **#569 (`stateSchema`)** —
+  free, no conflict with us. (`stateSchema` is a future opportunity to move our
+  custom channels out of the fork — out of scope for this upgrade.)
+- **DROP our warm gate** (`subagentWarmGate.*`) — already net-removed in our HEAD.
+- **DROP the zod pin gymnastics.** Take upstream's `zod` range (`^4.3.6`) or keep
+  our `^4.4.3`; both resolve to v4. Delete the stale `3.25.76` narrative.
+
+## Step-by-step
+
+### 0. Prep
+```bash
+cd packages/deepagentsjs
+git fetch upstream
+git checkout -b upgrade/upstream-$(date +%Y%m%d) upstream/main   # target = upstream main HEAD
+git tag pre-upgrade-backup <current-fork-HEAD>                    # safety
+# capture ground truth for reference during re-port:
+git diff 9221c8a2 <current-fork-HEAD> -- libs/deepagents/src > /tmp/launch10-delta.patch
+```
+
+### 1. Land the no-conflict files (mechanical)
+Copy/cherry-pick these from the old HEAD; they apply clean on new upstream:
+- `middleware/todos.ts`, `middleware/subagentReturnState.test.ts` (new files)
+- `backends/filesystem.ts` + `backends/filesystem.test.ts` (node_modules hiding —
+  upstream did **not** touch filesystem.ts)
+- `testing/utils.ts`
+```bash
+git checkout <old-HEAD> -- \
+  libs/deepagents/src/middleware/todos.ts \
+  libs/deepagents/src/middleware/subagentReturnState.test.ts \
+  libs/deepagents/src/backends/filesystem.ts \
+  libs/deepagents/src/backends/filesystem.test.ts \
+  libs/deepagents/src/testing/utils.ts
+```
+Commit as: `chore(fork): re-land todos middleware, node_modules FS hiding, tests`.
+
+### 2. Re-port `middleware/subagents.ts` (the hard one)
+Re-apply our four logical changes onto upstream's rewritten file. Anchors in the
+current upstream file:
+
+1. **Return-state allowlist.** `returnCommandWithStateUpdate` (~L444) calls
+   `filterStateForSubagent(result)` (~L448) for the state update. Swap that call
+   to our `filterReturnState(result)` and add `RETURN_STATE_ALLOWLIST =
+   ["todos","files"]`. **Leave upstream's text-forwarding (#608) in the same
+   function untouched.** Leave the *input* path (`filterStateForSubagent`, ~L420)
+   as the denylist — allowlist out, denylist in.
+2. **Cacheable task tool.** In `createTaskTool` (~L625): default the tool's prose
+   description and the `subagent_type` `.describe()` (~L754) from our
+   `taskDescription` / `subagentTypeDescription` options (roster-free constants).
+   Validation against `subagentGraphs` (~L690) stays.
+3. **`callerId` for OCC.** At the `subagent.invoke` config (~L711, the
+   `configurable:` spread) stamp `callerId: randomUUID()`. Keep upstream's
+   sibling `metadata.lc_agent_name` (~L709).
+4. **`todo_id` + real-time writer streaming.** Add the `todo_id` tool param;
+   capture the graph stream writer **before** `subagent.invoke()` (~L716, since
+   invoke swaps the ALS context); on finish, flip the matching parent todo to
+   `completed`, merge via the reducer, and emit the `__state_patch__` immediately.
+   Re-anchor onto the native `run.subagents` path (#598), not the deleted transformer.
+
+Verify against `subagentReturnState.test.ts` after.
+
+### 3. Re-port `agent.ts`
+On upstream's new `agent.ts`:
+- swap **both** `todoListMiddleware()` call sites (~L261 and ~L341) from the
+  `langchain` import (~L7) to our `./middleware/todos.js`;
+- thread `taskDescription` / `subagentTypeDescription` from `createDeepAgent`
+  params into `createSubAgentMiddleware({...})` (~L345);
+- keep upstream's new wiring (stateSchema, cache/bedrock middleware, async subagents).
+
+### 4. Re-port the small hunks
+- `types.ts`: add the two override option types.
+- `index.ts`: export the enhanced todos middleware + its options type.
+- `middleware/fs.ts`: change the grep tool description to the "ripgrep regex"
+  wording (one string; find upstream's current grep-tool description block).
+- `agent.test-d.ts`: reapply our type-test tweak.
+- `libs/deepagents/package.json`: take upstream's zod range; keep our `callerId`
+  dep bump if any.
+
+### 5. Verify
+```bash
+pnpm install
+pnpm -C libs/deepagents build           # typecheck the re-ports
+pnpm -C libs/deepagents test -- \
+  subagentReturnState todos filesystem fs subagent   # our touched areas
+```
+Then run the **LAUNCH10.md rebase checklist** (7 items) as the acceptance gate:
+allowlist return path, `RETURN_STATE_ALLOWLIST` = reducer-backed channels only,
+both task-tool overrides thread through, todos import from `./middleware/todos.js`,
+`todo_id` + writer-captured-before-invoke, `callerId` in `configurable`, zod is v4.
+
+### 6. Verify the downstream consumer (do not skip)
+Our `callerId` is a hard dependency of `langgraph_app`:
+`langgraph_app/app/services/backends/callerContext.ts` reads it via `getConfig()`
+(`currentCallerId()`), and `virtualFilesBackend.ts` uses it for per-caller OCC
+shasum tracking. After bumping the submodule, run a parallel-coder fan-out and
+confirm no lost-update / no "LastValue can only receive one value per step" crash.
+
+### 7. Update docs
+- Bump `LAUNCH10.md` fork-point to the new upstream SHA; correct the zod section
+  (manifest is `^4.4.3`, not `3.25.76`).
+- Delete this file or fold it into the rebase-checklist once green.
+
+## Risk ranking
+1. **`subagents.ts` re-port** — high. Concentrate review here; it's where #598,
+   #608, #566 and all four of our changes collide.
+2. **`agent.ts` todos wiring** — medium (two call sites, new neighbors).
+3. Everything else — low/mechanical.

--- a/libs/deepagents/src/agent.test-d.ts
+++ b/libs/deepagents/src/agent.test-d.ts
@@ -141,6 +141,7 @@ describe("createDeepAgent types", () => {
       expectTypeOf(result).toHaveProperty("todos");
       expectTypeOf(result.todos).toEqualTypeOf<
         {
+          id?: string;
           content: string;
           status: "pending" | "in_progress" | "completed";
         }[]

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -4,12 +4,12 @@ import {
   humanInTheLoopMiddleware,
   anthropicPromptCachingMiddleware,
   bedrockPromptCachingMiddleware,
-  todoListMiddleware,
   SystemMessage,
   type AgentMiddleware,
   type AnyAgentMiddleware,
   context,
 } from "langchain";
+import { todoListMiddleware } from "./middleware/todos.js";
 import type {
   ClientTool,
   ServerTool,
@@ -176,6 +176,8 @@ export function createDeepAgent<
     stateSchema,
     middleware: customMiddleware = [],
     subagents = [],
+    taskDescription,
+    subagentTypeDescription,
     responseFormat,
     contextSchema,
     checkpointer,
@@ -348,6 +350,8 @@ export function createDeepAgent<
       defaultInterruptOn: interruptOn,
       subagents: inlineSubagents,
       generalPurposeAgent: false,
+      taskDescription,
+      subagentTypeDescription,
     }),
     // Automatically summarizes conversation history when token limits are approached.
     // Uses createSummarizationMiddleware (deepagents version) with backend support

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -42,6 +42,37 @@ describe("FilesystemBackend", () => {
     await removeDir(tmpDir);
   });
 
+  // A render pipeline may symlink a shared dependency baseline (node_modules)
+  // into the workspace for the life of a pooled dev server. fast-glob follows
+  // symlinked directories, so without an explicit ignore a broad glob would
+  // descend into ~20k dependency files — and ls would surface the link as an
+  // editable entry. Both must hide node_modules entirely.
+  it("hides node_modules (even a symlinked one) from glob, ls, and grep fallback", async () => {
+    const root = tmpDir;
+    await writeFile(path.join(root, "src", "app.ts"), "export const searchable = 1;");
+    // A "baseline" OUTSIDE the workspace, symlinked in as node_modules —
+    // exactly the render pool's shape.
+    const baseline = createTempDir();
+    await writeFile(path.join(baseline, "dep", "index.ts"), "export const searchable = 2;");
+    await fs.symlink(baseline, path.join(root, "node_modules"), "dir");
+    try {
+      const backend = new FilesystemBackend({ rootDir: root, virtualMode: true });
+
+      const globbed = await backend.glob("**/*.ts");
+      expect(globbed.files!.map((f) => f.path)).toEqual(["/src/app.ts"]);
+
+      const listed = await backend.ls("/");
+      expect(listed.files!.map((f) => f.path)).not.toContain("/node_modules/");
+      expect(listed.files!.some((f) => f.path.includes("node_modules"))).toBe(false);
+
+      const grepped = await backend.grep("searchable");
+      expect(grepped.matches!.every((m) => !m.path.includes("node_modules"))).toBe(true);
+      expect(grepped.matches!.some((m) => m.path === "/src/app.ts")).toBe(true);
+    } finally {
+      await removeDir(baseline);
+    }
+  });
+
   it("should work in normal mode with absolute paths", async () => {
     const root = tmpDir;
     const f1 = path.join(root, "a.txt");

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -119,6 +119,10 @@ export class FilesystemBackend implements BackendProtocolV2 {
         : this.cwd + path.sep;
 
       for (const entry of entries) {
+        // Hide node_modules from directory listings — the render pipeline may
+        // have a shared dependency baseline symlinked here (see glob()); it's
+        // infrastructure, not part of the agent's editable tree.
+        if (entry.name === "node_modules") continue;
         const fullPath = path.join(resolvedPath, entry.name);
 
         try {
@@ -619,12 +623,16 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const stat = await fs.stat(baseFull);
     const root = stat.isDirectory() ? baseFull : path.dirname(baseFull);
 
-    // Use fast-glob to recursively find all files
+    // Use fast-glob to recursively find all files. node_modules is ignored
+    // for the same reason as glob(): a symlinked dependency baseline may be
+    // live in the workspace, and following it would sweep ~20k dep files
+    // into a literal search.
     const files = await fg("**/*", {
       cwd: root,
       absolute: true,
       onlyFiles: true,
       dot: true,
+      ignore: ["**/node_modules/**"],
     });
 
     for (const fp of files) {
@@ -709,12 +717,17 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const results: FileInfo[] = [];
 
     try {
-      // Use fast-glob for pattern matching
+      // Use fast-glob for pattern matching.
+      // node_modules is ignored EXPLICITLY: the render pipeline symlinks a
+      // shared dependency baseline into the workspace for the life of a
+      // pooled dev server, and fast-glob follows symlinked directories — an
+      // unguarded broad glob would descend into ~20k dependency files.
       const matches = await fg(pattern, {
         cwd: resolvedSearchPath,
         absolute: true,
         onlyFiles: true,
         dot: true,
+        ignore: ["**/node_modules/**"],
       });
 
       for (const matchedPath of matches) {

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -104,6 +104,12 @@ export {
 // Export shared state values (similar to LangGraph's messagesValue pattern)
 export { filesValue } from "./values.js";
 
+// Export enhanced todoListMiddleware with ID generation and merge-by-id reducer
+export {
+  todoListMiddleware,
+  type TodoListMiddlewareOptions,
+} from "./middleware/todos.js";
+
 // Export agent memory middleware
 export {
   createAgentMemoryMiddleware,

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -529,16 +529,20 @@ export const GLOB_TOOL_DESCRIPTION = context`
 `;
 
 export const GREP_TOOL_DESCRIPTION = context`
-  Search for a text pattern across files.
+  Search file contents with a ripgrep regular expression.
 
-  Searches for literal text (not regex) and returns matching files or content based on output_mode.
-  Special characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.
+  The pattern is a regex (ripgrep syntax): alternation \`a|b\`, anchors \`^\`/\`$\`,
+  character classes, word boundaries \`\\b\`, etc. Returns the matching lines
+  grouped by file, with line numbers. An invalid regex returns an error that
+  describes the problem — read it and fix the pattern rather than guessing.
+
+  To match literal text that contains regex metacharacters, wrap it in \`\\Q…\\E\`.
 
   Examples:
-  - Search all files: \`grep(pattern="TODO")\`
-  - Search Python files only: \`grep(pattern="import", glob="*.py")\`
-  - Show matching lines: \`grep(pattern="error", output_mode="content")\`
-  - Search for code with special chars: \`grep(pattern="def __init__(self):")\`
+  - Find a symbol: \`grep(pattern="TODO")\`
+  - Either name in one pass: \`grep(pattern="LeadForm|LeadCapture")\`
+  - Imports in .tsx files: \`grep(pattern="^import", glob="*.tsx")\`
+  - Literal code with special chars: \`grep(pattern="\\Qdef __init__(self):\\E")\`
 `;
 
 export const EXECUTE_TOOL_DESCRIPTION = context`

--- a/libs/deepagents/src/middleware/subagentReturnState.test.ts
+++ b/libs/deepagents/src/middleware/subagentReturnState.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The subagent RETURN path is an allowlist: a subagent writes back only the
+ * mergeable channels it accumulates into (`todos`, `files`) plus its final
+ * message (handled separately). It must NOT echo inherited parent context
+ * (jwt, websiteId, mode, error, …) — N parallel coders each echoing the same
+ * channel in one superstep crashes any plain LastValue channel ("LastValue
+ * can only receive one value per step"; traces fe0786e3 `error`, fa4945ba
+ * `jwt`). Allowlisting kills that class at the source.
+ */
+import { describe, it, expect } from "vitest";
+import { filterReturnState, RETURN_STATE_ALLOWLIST } from "./subagents.js";
+
+describe("filterReturnState", () => {
+  it("keeps the mergeable channels a subagent contributes", () => {
+    const out = filterReturnState({
+      todos: [{ id: "1", content: "x", status: "completed" }],
+      files: { "/a.txt": "hi" },
+    });
+    expect(out).toEqual({
+      todos: [{ id: "1", content: "x", status: "completed" }],
+      files: { "/a.txt": "hi" },
+    });
+  });
+
+  it("drops inherited parent context (the fan-in crash sources)", () => {
+    const out = filterReturnState({
+      jwt: "jwt-abc",
+      websiteId: 4,
+      mode: "coding",
+      accountId: 7,
+      error: null,
+      todos: [{ id: "1", content: "x", status: "completed" }],
+    });
+    expect(out).toEqual({
+      todos: [{ id: "1", content: "x", status: "completed" }],
+    });
+    expect(out).not.toHaveProperty("jwt");
+    expect(out).not.toHaveProperty("error");
+    expect(out).not.toHaveProperty("websiteId");
+  });
+
+  it("omits allowlisted keys that are absent (no undefined echoes)", () => {
+    expect(filterReturnState({ jwt: "abc" })).toEqual({});
+  });
+
+  it("the allowlist is exactly the reducer-backed accumulators", () => {
+    expect([...RETURN_STATE_ALLOWLIST]).toEqual(["todos", "files"]);
+  });
+});

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -16,7 +16,8 @@ import {
   StructuredTool,
   context,
 } from "langchain";
-import { Command, getCurrentTaskInput } from "@langchain/langgraph";
+import { Command, getCurrentTaskInput, getWriter } from "@langchain/langgraph";
+import { randomUUID } from "crypto";
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
 import type { Runnable } from "@langchain/core/runnables";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
@@ -46,15 +47,17 @@ export const DEFAULT_SUBAGENT_PROMPT =
  *
  * When returning updates:
  * 1. The messages key is handled explicitly to ensure only the final message is included
- * 2. The todos and structuredResponse keys are excluded as they do not have a defined reducer
- *    and no clear meaning for returning them from a subagent to the main agent.
+ * 2. The structuredResponse key is excluded as it has no defined reducer and no clear meaning
+ *    for returning from a subagent to the main agent.
  * 3. The skillsMetadata and memoryContents keys are automatically excluded from subagent output
  *    to prevent parent state from leaking to child agents. Each agent loads its own skills/memory
  *    independently based on its middleware configuration.
+ *
+ * Note: todos flows through so subagents can mark their assigned parent todos as completed.
+ * The parent's todosReducer merges by id, so parallel subagent updates are safe.
  */
 const EXCLUDED_STATE_KEYS = [
   "messages",
-  "todos",
   "structuredResponse",
   "skillsMetadata",
   "memoryContents",
@@ -415,7 +418,10 @@ export const GENERAL_PURPOSE_SUBAGENT: Pick<
 } as const;
 
 /**
- * Filter state to exclude certain keys when passing to subagents
+ * Filter state to exclude certain keys when passing INTO subagents.
+ *
+ * The input path is a denylist: a subagent inherits the parent's context
+ * (jwt, ids, mode, …) minus the keys that must not leak down.
  */
 function filterStateForSubagent(
   state: Record<string, unknown>,
@@ -425,6 +431,36 @@ function filterStateForSubagent(
     if (!EXCLUDED_STATE_KEYS.includes(key as never)) {
       filtered[key] = value;
     }
+  }
+  return filtered;
+}
+
+/**
+ * Channels a subagent may write BACK to the parent on completion.
+ *
+ * The return path is an ALLOWLIST, not a denylist. A subagent's output is
+ * its final message (handled separately as a ToolMessage) plus the
+ * reducer-backed channels it legitimately accumulates into — `todos` (the
+ * parent's todosReducer merges by id) and `files` (fileDataReducer merges
+ * by path). Everything else it carries is inherited PARENT context (jwt,
+ * websiteId, mode, accountId, error, …); echoing those back means every one
+ * of N parallel coders writes the same channel in one superstep, and any
+ * plain LastValue channel throws "LastValue can only receive one value per
+ * step" (traces fe0786e3: `error`, fa4945ba: `jwt`). Allowlisting the
+ * mergeable channels stops the whole crash class at the source — no parent
+ * scalar is ever echoed, so future inherited fields can't reintroduce it.
+ */
+export const RETURN_STATE_ALLOWLIST = ["todos", "files"] as const;
+
+/**
+ * Filter a subagent's final state to only the channels it may write back.
+ */
+export function filterReturnState(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const key of RETURN_STATE_ALLOWLIST) {
+    if (key in state) filtered[key] = state[key];
   }
   return filtered;
 }
@@ -445,7 +481,7 @@ function returnCommandWithStateUpdate(
   result: Record<string, unknown>,
   toolCallId: string,
 ): Command {
-  const stateUpdate = filterStateForSubagent(result);
+  const stateUpdate = filterReturnState(result);
 
   let content: string | ContentBlock[];
 
@@ -631,6 +667,7 @@ function createTaskTool(options: {
   subagents: (SubAgent | CompiledSubAgent)[];
   generalPurposeAgent: boolean;
   taskDescription: string | null;
+  subagentTypeDescription: string | null;
 }) {
   const {
     defaultModel,
@@ -641,6 +678,7 @@ function createTaskTool(options: {
     subagents,
     generalPurposeAgent,
     taskDescription,
+    subagentTypeDescription,
   } = options;
 
   const {
@@ -682,10 +720,10 @@ function createTaskTool(options: {
 
   return tool(
     async (
-      input: { description: string; subagent_type: string },
+      input: { description: string; subagent_type: string; todo_id?: string },
       config,
     ): Promise<Command | string> => {
-      const { description, subagent_type } = input;
+      const { description, subagent_type, todo_id } = input;
 
       if (!(subagent_type in subagentGraphs)) {
         const allowedTypes = Object.keys(subagentGraphs)
@@ -698,10 +736,35 @@ function createTaskTool(options: {
 
       const subagent = selectSubagent(subagent_type, config);
 
+      // Capture the stream writer BEFORE subagent.invoke() — the subagent's
+      // graph invocation replaces the AsyncLocalStorage context, so getWriter()
+      // returns undefined after invoke() completes.
+      let streamWriter: ((data: unknown) => void) | undefined;
+      try {
+        const w = getWriter(config) ?? getWriter();
+        if (typeof w === "function") {
+          streamWriter = w;
+        } else if (
+          w &&
+          typeof (w as { write?: unknown }).write === "function"
+        ) {
+          streamWriter = (data: unknown) =>
+            (w as { write: (d: unknown) => void }).write(data);
+        }
+      } catch {
+        // writer not available outside graph streaming context
+      }
+
       const currentState = getCurrentTaskInput<Record<string, unknown>>();
       const subagentState = filterStateForSubagent(currentState);
       subagentState.messages = [new HumanMessage({ content: description })];
 
+      // callerId: a fresh per-dispatch identity (fork delta). Stock mints no
+      // stable per-sync-subagent id, so a shared backend can't tell parallel
+      // coders apart for optimistic-concurrency purposes. Stamping it here in
+      // configurable makes it ambient (readable via getConfig()) for the
+      // subagent's whole run — and each dispatch (incl. nested sub-coders)
+      // gets a distinct one, so per-caller read-shasum tracking works.
       const subagentConfig = {
         ...config,
         metadata: {
@@ -711,12 +774,40 @@ function createTaskTool(options: {
         configurable: {
           ...config.configurable,
           ls_agent_type: "subagent",
+          callerId: randomUUID(),
         },
       };
       const result = (await subagent.invoke(
         subagentState,
         subagentConfig,
       )) as Record<string, unknown>;
+
+      // Auto-mark the assigned parent todo as completed when the subagent finishes.
+      if (todo_id) {
+        const todos = (result.todos ?? currentState.todos) as
+          | Array<{ id: string; status: string; content: string }>
+          | undefined;
+        if (todos) {
+          result.todos = todos.map((t) =>
+            t.id === todo_id ? { ...t, status: "completed" } : t,
+          );
+
+          // Emit immediately via writer() — bypasses Promise.all batching so the
+          // frontend sees this todo flip to completed right away instead of all
+          // at once after every parallel subagent resolves.
+          if (streamWriter) {
+            try {
+              streamWriter({
+                id: randomUUID(),
+                event: "__state_patch__",
+                todos: result.todos,
+              });
+            } catch {
+              // emit failed — falls back to normal state update after Promise.all
+            }
+          }
+        }
+      }
 
       if (!config.toolCall?.id) {
         if (result.structuredResponse != null) {
@@ -754,7 +845,14 @@ function createTaskTool(options: {
         subagent_type: z
           .string()
           .describe(
-            `Name of the agent to use. Available: ${Object.keys(subagentGraphs).join(", ")}`,
+            subagentTypeDescription ??
+              `Name of the agent to use. Available: ${Object.keys(subagentGraphs).join(", ")}`,
+          ),
+        todo_id: z
+          .string()
+          .optional()
+          .describe(
+            "ID of the parent todo item to automatically mark as completed when this task finishes. Pass this to get real-time progress tracking.",
           ),
       }),
     },
@@ -786,6 +884,15 @@ export interface SubAgentMiddlewareOptions {
   generalPurposeAgent?: boolean;
   /** Custom description for the task tool */
   taskDescription?: string | null;
+  /**
+   * Override the `subagent_type` schema-field description. Defaults to
+   * `"Name of the agent to use. Available: <roster>"`. Pass a roster-free
+   * constant to keep the task tool's wire bytes identical across agents that
+   * register different subagent sets (cache-prefix stability); the dispatch
+   * roster can then be delivered out-of-band (e.g. a tail reminder). The name
+   * is still validated against the registered graphs at dispatch.
+   */
+  subagentTypeDescription?: string | null;
 }
 
 /**
@@ -802,6 +909,7 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     systemPrompt = TASK_SYSTEM_PROMPT,
     generalPurposeAgent = true,
     taskDescription = null,
+    subagentTypeDescription = null,
   } = options;
 
   const taskTool = createTaskTool({
@@ -813,6 +921,7 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     subagents,
     generalPurposeAgent,
     taskDescription,
+    subagentTypeDescription,
   });
 
   return createMiddleware({

--- a/libs/deepagents/src/middleware/todos.ts
+++ b/libs/deepagents/src/middleware/todos.ts
@@ -1,0 +1,166 @@
+/**
+ * Enhanced todoListMiddleware that adds:
+ * 1. Auto-generated UUIDs for todos (so parallel subagents can merge by ID)
+ * 2. A ReducedValue with merge-by-id + status-priority reducer
+ *    (so parallel subagent todo updates don't clobber each other)
+ *
+ * This replaces langchain's todoListMiddleware with a stateSchema that uses
+ * ReducedValue for proper concurrent merging.
+ */
+import { z } from "zod/v4";
+import { randomUUID } from "crypto";
+import { Command, StateSchema, ReducedValue } from "@langchain/langgraph";
+import { tool } from "@langchain/core/tools";
+import { AIMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  createMiddleware,
+  TODO_LIST_MIDDLEWARE_SYSTEM_PROMPT,
+} from "langchain";
+
+const TodoStatus = z
+  .enum(["pending", "in_progress", "completed"])
+  .describe("Status of the todo");
+
+const TodoSchema = z.object({
+  id: z.string().optional().describe("Unique identifier for the todo"),
+  content: z.string().describe("Content of the todo item"),
+  status: TodoStatus,
+});
+
+type Todo = z.infer<typeof TodoSchema>;
+
+const STATUS_PRIORITY: Record<string, number> = {
+  pending: 0,
+  in_progress: 1,
+  completed: 2,
+};
+
+/**
+ * Merge-by-id reducer with status priority.
+ * - Existing IDs are updated in-place (never downgrading status)
+ * - New IDs are appended
+ * - Status priority: completed(2) > in_progress(1) > pending(0)
+ *
+ * Parallel subagents operate on stale snapshots of the todo list, so a late
+ * update must never move a todo backwards (e.g. completed -> in_progress).
+ */
+function todosReducer(current: Todo[], update: Todo[]): Todo[] {
+  if (!update) return current || [];
+  if (!current || current.length === 0) return update;
+
+  const merged = [...current];
+  const mergedById = new Map(merged.map((t, i) => [t.id, i]));
+
+  for (const todo of update) {
+    const existingIdx = mergedById.get(todo.id);
+    if (existingIdx !== undefined) {
+      const prev = merged[existingIdx]!;
+      const prevPriority = STATUS_PRIORITY[prev.status] ?? 0;
+      const nextPriority = STATUS_PRIORITY[todo.status] ?? 0;
+      // Never downgrade status — parallel subagents have stale snapshots.
+      if (nextPriority >= prevPriority) {
+        merged[existingIdx] = todo;
+      }
+    } else {
+      mergedById.set(todo.id, merged.length);
+      merged.push(todo);
+    }
+  }
+
+  return merged;
+}
+
+const stateSchema = new StateSchema({
+  todos: new ReducedValue(z.array(TodoSchema).default([]), {
+    reducer: todosReducer,
+  }),
+});
+
+export interface TodoListMiddlewareOptions {
+  systemPrompt?: string;
+  toolDescription?: string;
+}
+
+/**
+ * Enhanced todoListMiddleware with UUID auto-generation and merge-by-id reducer.
+ */
+export function todoListMiddleware(options?: TodoListMiddlewareOptions) {
+  const writeTodos = tool(
+    ({ todos }, config) => {
+      // Auto-generate UUIDs for any todos that don't have them so the
+      // merge-by-id reducer can track them across parallel subagent updates.
+      const todosWithIds = todos.map((t) => ({
+        ...t,
+        id: t.id || randomUUID(),
+      }));
+      return new Command({
+        update: {
+          todos: todosWithIds,
+          messages: [
+            new ToolMessage({
+              content: `Updated todo list to ${JSON.stringify(todosWithIds)}`,
+              tool_call_id: config.toolCall?.id as string,
+            }),
+          ],
+        },
+      });
+    },
+    {
+      name: "write_todos",
+      description:
+        options?.toolDescription ??
+        "Create and manage a structured task list. Pass the full list of todos with their current statuses.",
+      schema: z.object({
+        todos: z.array(TodoSchema).describe("List of todo items to update"),
+      }),
+    },
+  );
+
+  return createMiddleware({
+    name: "todoListMiddleware",
+    stateSchema,
+    tools: [writeTodos],
+    wrapModelCall: (request, handler) =>
+      handler({
+        ...request,
+        systemMessage: request.systemMessage.concat(
+          `\n\n${options?.systemPrompt ?? TODO_LIST_MIDDLEWARE_SYSTEM_PROMPT}`,
+        ),
+      }),
+    afterModel: (state) => {
+      // Reject parallel write_todos calls — the list must be written atomically.
+      const messages = state.messages;
+      if (!messages || messages.length === 0) return undefined;
+
+      const lastAiMsg = [...messages]
+        .reverse()
+        .find((msg) => AIMessage.isInstance(msg));
+      if (
+        !lastAiMsg ||
+        !lastAiMsg.tool_calls ||
+        lastAiMsg.tool_calls.length === 0
+      )
+        return undefined;
+
+      const writeTodosCalls = lastAiMsg.tool_calls.filter(
+        (tc) => tc.name === writeTodos.name,
+      );
+
+      if (writeTodosCalls.length > 1) {
+        const errorMessages = writeTodosCalls.map(
+          (tc) =>
+            new ToolMessage({
+              content:
+                "Error: The `write_todos` tool should never be called multiple times " +
+                "in parallel. Please call it only once per model invocation.",
+              tool_call_id: tc.id as string,
+              status: "error",
+            }),
+        );
+        return { messages: errorMessages };
+      }
+
+      return undefined;
+    },
+  });
+}

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -559,6 +559,23 @@ export interface CreateDeepAgentParams<
    * at runtime and wired to the async SubAgent middleware.
    */
   subagents?: TSubagents;
+  /**
+   * Override the `task` tool's top-level description (the prose shown to the
+   * model). When set, replaces the default roster-bearing description built by
+   * `getTaskToolDescription`. Forwarded to `createSubAgentMiddleware`. Use a
+   * roster-free constant to keep the task tool byte-identical across agents that
+   * register different subagent sets — the prompt-cache prefix then stays stable
+   * across tiers. Deliver the actual roster out-of-band (e.g. a tail reminder).
+   */
+  taskDescription?: string | null;
+  /**
+   * Override the `task` tool's `subagent_type` schema-field description. Without
+   * this, the field embeds `"Available: <roster>"`, which diverges per agent and
+   * re-breaks the shared cache prefix one field below `taskDescription`. Pair the
+   * two and carry the roster out-of-band. `subagent_type` is still validated at
+   * dispatch, so a roster-free description does not weaken correctness.
+   */
+  subagentTypeDescription?: string | null;
   /** Structured output response format for the agent (Zod schema or other format) */
   responseFormat?: TResponse;
   /** Optional schema for context (not persisted between invocations) */


### PR DESCRIPTION
Replays our fork's logical changes on top of current upstream (was #549, now #640), keeping upstream's absorbed fixes rather than fighting them:
  - #608 subagent result → text forwarding (kept; our allowlist layers on the state half of returnCommandWithStateUpdate)
  - #598 native run.subagents (kept; writer-capture re-anchored)
  - #566 metadata.lc_agent_name (kept alongside our callerId)

Our re-applied delta:
  1. Subagent return path is an allowlist (filterReturnState / RETURN_STATE_ALLOWLIST = [todos, files]), not a denylist — kills the parallel-fan-in "LastValue can only receive one value per step" crash.
  2. Cache-prefix-stable task tool: taskDescription / subagentTypeDescription overrides thread createDeepAgent → createSubAgentMiddleware → createTaskTool.
  3. Enhanced todoListMiddleware (UUID + merge-by-id reducer) swapped in via ./middleware/todos.js.
  4. Subagent→parent todo reconciliation: todo_id param, writer captured before subagent.invoke(), __state_patch__ streamed past Promise.all.
  5. Per-dispatch callerId in configurable for shared-backend OCC.
  6. node_modules hidden from the agent FS view; grep described as ripgrep regex.

Dropped as redundant: warm-gate (net-removed in old fork), zod pin gymnastics (kept upstream ^4.3.6; monorepo override governs runtime).

Verify: tsdown build clean; 42 files / 1181 unit tests pass; LAUNCH10.md 7-item checklist all green. See UPGRADE_PLAN.md.