### PR TITLE
fix(deepagents): degrade unsupported binaries in read_file instead of crashing the run

### DIFF
--- a/.changeset/read-file-unsupported-binaries.md
+++ b/.changeset/read-file-unsupported-binaries.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): degrade unsupported binary files in read_file instead of crashing the run
+
+`read_file` returned every non-text, non-image/audio/video binary as a `{ type: "file" }` content block. For any MIME type other than `application/pdf` this produces a provider request that is rejected — Anthropic fails the whole turn with `messages.N...document.source.base64.media_type: Input should be 'application/pdf'`, and OpenAI/OpenRouter only accept PDF (and images) via `input_file`. As a result, reading a `.docx`/`.pptx`/`.xlsx` (or any `application/octet-stream` file) aborted the entire agent run. `read_file` now emits a `file` block only for PDFs — the one document type accepted across providers — and degrades other binaries to a short text note, so the agent can keep going.

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1050,6 +1050,81 @@ describe("createFilesystemMiddleware", () => {
     });
   });
 
+  describe("read_file binary handling", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    function makeReadFileTool(readResult: unknown) {
+      const mockBackend = createMockBackend();
+      mockBackend.read = vi.fn().mockResolvedValue(readResult);
+      vi.mocked(getCurrentTaskInput).mockReturnValue({
+        messages: [],
+        files: {},
+      });
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+      return middleware.tools!.find((t: any) => t.name === "read_file") as any;
+    }
+
+    it("degrades an unsupported binary (office doc) to a text note, not a file block", async () => {
+      // Office docs (.pptx/.docx/.xlsx) are zips; their mime type is not
+      // application/pdf, so they cannot be sent as a base64 document to
+      // Anthropic (400) nor as input_file to OpenAI/OpenRouter.
+      const readFileTool = makeReadFileTool({
+        content: new Uint8Array([0x50, 0x4b, 0x03, 0x04]), // "PK.." zip header
+      });
+
+      const result = await readFileTool.invoke({ file_path: "/deck.pptx" });
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("text");
+      expect(result[0].text).toContain("deck.pptx");
+      expect(result[0].text).toContain("presentationml");
+      // The whole point: no `file` block that would 400 the provider.
+      expect(result.some((block: any) => block.type === "file")).toBe(false);
+    });
+
+    it("degrades an unknown binary (octet-stream) to a text note", async () => {
+      const readFileTool = makeReadFileTool({
+        content: new Uint8Array([0x00, 0x01, 0x02, 0x03]),
+      });
+
+      const result = await readFileTool.invoke({ file_path: "/blob.bin" });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("text");
+      expect(result[0].text).toContain("application/octet-stream");
+    });
+
+    it("still returns a file block for PDFs, which providers accept", async () => {
+      const readFileTool = makeReadFileTool({
+        content: new Uint8Array([0x25, 0x50, 0x44, 0x46]), // "%PDF"
+      });
+
+      const result = await readFileTool.invoke({ file_path: "/manual.pdf" });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("file");
+      expect(result[0].mimeType).toBe("application/pdf");
+      expect(typeof result[0].data).toBe("string");
+    });
+
+    it("still returns an image block for images", async () => {
+      const readFileTool = makeReadFileTool({
+        content: new Uint8Array([0x89, 0x50, 0x4e, 0x47]), // PNG magic
+      });
+
+      const result = await readFileTool.invoke({ file_path: "/logo.png" });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("image");
+      expect(result[0].mimeType).toBe("image/png");
+    });
+  });
+
   describe("tool result truncation integration", () => {
     beforeEach(() => {
       vi.clearAllMocks();

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -739,7 +739,30 @@ function createReadFileTool(
         if (mimeType.startsWith("video/")) {
           return [{ type: "video", mimeType, data: base64Data }];
         }
-        return [{ type: "file", mimeType, data: base64Data }];
+        // PDF is the only binary document type accepted as a `file`/document
+        // content block across the major providers: Anthropic requires
+        // media_type "application/pdf" for base64 document sources, and
+        // OpenAI/OpenRouter only accept PDF (and images) via `input_file`.
+        // Emitting a `file` block for any other binary (e.g. .docx/.pptx/.xlsx
+        // or application/octet-stream) produces a request the provider rejects
+        // — Anthropic, for instance, fails the whole turn with
+        // "messages.N...document.source.base64.media_type: Input should be
+        // 'application/pdf'". Degrade unsupported binaries to an informative
+        // text note so the agent can keep going instead of crashing the run.
+        if (mimeType === "application/pdf") {
+          return [{ type: "file", mimeType, data: base64Data }];
+        }
+        const sizeKb = Math.max(1, Math.round(sizeBytes / 1024));
+        return [
+          {
+            type: "text",
+            text:
+              `Note: '${file_path}' is a binary ${mimeType} file (~${sizeKb} KB). ` +
+              `Its bytes are not text and it is not a model-readable document type ` +
+              `(only PDF and images can be embedded), so its contents were not read. ` +
+              `Use shell/execute tools (e.g. \`unzip\`, \`file\`, \`strings\`) if you need to inspect it.`,
+          },
+        ];
       }
 
       let content =


### PR DESCRIPTION
## Problem

The built-in `read_file` tool (in `createFilesystemMiddleware`) returns any non-text binary that isn't image/audio/video as a `{ type: "file", mimeType, data }` content block:

```ts
// libs/deepagents/src/middleware/fs.ts (before)
return [{ type: "file", mimeType, data: base64Data }];
```

For every MIME type except `application/pdf`, that block cannot be delivered to the model provider:

- **Anthropic** wraps it as a base64 `document`, whose `media_type` must be `application/pdf`. It returns a hard `400` and the whole turn fails:
  > `messages.N...tool_result.content.0.document.source.base64.media_type: Input should be 'application/pdf'`
- **OpenAI** and **OpenRouter** only accept PDF (and images) via `input_file`, so they reject it too.

So the moment a deep agent reads a `.docx` / `.pptx` / `.xlsx` — or any file that resolves to `application/octet-stream` — the entire run aborts. This is easy to hit in practice (e.g. an agent documenting a repository that happens to contain office files). It surfaced downstream in [`openwiki`](https://www.npmjs.com/package/openwiki), which uses the stock `read_file` tool.

## Fix

Keep emitting a `file` block only for `application/pdf` — the one binary document type accepted across providers — and degrade any other binary to a short text note (path, MIME type, size). The agent gets a model-safe, useful result and continues instead of crashing. As a bonus, this avoids pushing large, unusable base64 blobs into the context window.

## Tests

Added a `read_file binary handling` suite:

- office doc (`.pptx`) → text note, **no** `file` block
- unknown binary (`application/octet-stream`) → text note
- PDF → still a `file` block
- image → still an `image` block

`vitest run src/middleware/fs.test.ts` → **63 passed**, no type errors. `oxlint` and `oxfmt --check` clean. Changeset included (`deepagents: patch`).
