### PR TITLE
fix(deepagents): add ABAP/SAP extensions to MIME_TYPES

### DIFF
--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -463,6 +463,26 @@ describe("getMimeType", () => {
     expect(getMimeType("/compiled.pyc")).toBe("application/octet-stream");
     expect(getMimeType("/package.jar")).toBe("application/octet-stream");
   });
+
+  it("should return text/plain for ABAP/SAP extensions", () => {
+    // Simple .abap
+    expect(getMimeType("/foo.abap")).toBe("text/plain");
+    // Compound abapGit names — extname() returns only the last segment
+    expect(getMimeType("/ZCL_MY_CLASS.clas.abap")).toBe("text/plain");
+    expect(getMimeType("/ZREPORT.prog.abap")).toBe("text/plain");
+    expect(getMimeType("/ZFM_FUNC.fugr.abap")).toBe("text/plain");
+    // CDS and DDL extensions
+    expect(getMimeType("/ZI_MYVIEW.asddls")).toBe("text/plain");
+    expect(getMimeType("/ZI_MYVIEW.asdtmd")).toBe("text/plain");
+    expect(getMimeType("/ZI_MYVIEW.ddls")).toBe("text/plain");
+    expect(getMimeType("/ZI_MYVIEW.ddlx")).toBe("text/plain");
+  });
+
+  it("isTextMimeType should return true for ABAP files via getMimeType", () => {
+    expect(isTextMimeType(getMimeType("teste.clas.abap"))).toBe(true);
+    expect(isTextMimeType(getMimeType("teste.prog.abap"))).toBe(true);
+    expect(isTextMimeType(getMimeType("ZI_VIEW.asddls"))).toBe(true);
+  });
 });
 
 describe("isTextMimeType", () => {

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -465,13 +465,10 @@ describe("getMimeType", () => {
   });
 
   it("should return text/plain for ABAP/SAP extensions", () => {
-    // Simple .abap
     expect(getMimeType("/foo.abap")).toBe("text/plain");
-    // Compound abapGit names — extname() returns only the last segment
     expect(getMimeType("/ZCL_MY_CLASS.clas.abap")).toBe("text/plain");
     expect(getMimeType("/ZREPORT.prog.abap")).toBe("text/plain");
     expect(getMimeType("/ZFM_FUNC.fugr.abap")).toBe("text/plain");
-    // CDS and DDL extensions
     expect(getMimeType("/ZI_MYVIEW.asddls")).toBe("text/plain");
     expect(getMimeType("/ZI_MYVIEW.asdtmd")).toBe("text/plain");
     expect(getMimeType("/ZI_MYVIEW.ddls")).toBe("text/plain");

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -136,14 +136,11 @@ const MIME_TYPES: Record<string, string> = {
   ".dockerignore": "text/plain",
   ".editorconfig": "text/plain",
 
-  // ABAP / SAP (abapGit)
-  // path.extname() on compound names like "foo.clas.abap" returns only the
-  // last segment (.abap), so a single entry covers all ABAP source objects.
   ".abap": "text/plain",
-  ".asddls": "text/plain", // CDS view definitions
-  ".asdtmd": "text/plain", // CDS metadata extensions
-  ".ddls": "text/plain", // Data Definition Language (CDS alternative)
-  ".ddlx": "text/plain", // CDS access control extensions
+  ".asddls": "text/plain",
+  ".asdtmd": "text/plain",
+  ".ddls": "text/plain",
+  ".ddlx": "text/plain",
 };
 
 function basename(filePath: string): string {

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -135,6 +135,15 @@ const MIME_TYPES: Record<string, string> = {
   ".gitignore": "text/plain",
   ".dockerignore": "text/plain",
   ".editorconfig": "text/plain",
+
+  // ABAP / SAP (abapGit)
+  // path.extname() on compound names like "foo.clas.abap" returns only the
+  // last segment (.abap), so a single entry covers all ABAP source objects.
+  ".abap": "text/plain",
+  ".asddls": "text/plain", // CDS view definitions
+  ".asdtmd": "text/plain", // CDS metadata extensions
+  ".ddls": "text/plain", // Data Definition Language (CDS alternative)
+  ".ddlx": "text/plain", // CDS access control extensions
 };
 
 function basename(filePath: string): string {


### PR DESCRIPTION
## Problem

`getMimeType()` looks up file extensions in a fixed `MIME_TYPES` dictionary and
falls back to `"application/octet-stream"` for unknown extensions.

`path.extname()` on compound abapGit filenames (e.g. `ZCL_MY_CLASS.clas.abap`,
`ZREPORT.prog.abap`) returns only the **last** segment — `.abap` — which was not
in `MIME_TYPES`. As a result, `isTextMimeType()` returned `false` for all ABAP
source files, causing `read_file` to return a binary `{"type":"file"}` content
block instead of plain text.

This breaks any provider that does not support file content blocks. Concretely,
Bedrock via LiteLLM raises:

```
litellm.BadRequestError: BedrockException - 'file'
```

## Solution

Add the missing ABAP/SAP extensions, all mapped to `"text/plain"`:

| Extension | Description |
|-----------|-------------|
| `.abap` | All ABAP source objects (covers `*.clas.abap`, `*.prog.abap`, `*.fugr.abap`, etc.) |
| `.asddls` | CDS view definitions |
| `.asdtmd` | CDS metadata extensions |
| `.ddls` | Data Definition Language (CDS alternative) |
| `.ddlx` | CDS access control extensions |

Note: other abapGit object types (`.doma`, `.dtel`, `.tabl`, etc.) are always
paired with a `.xml` suffix in abapGit repos, so `extname()` resolves to `.xml`,
which is already mapped. No additional entries are needed for those.

## Testing

New test cases added to `utils.test.ts` under `getMimeType`:

- Simple `.abap` files
- Compound abapGit names (`*.clas.abap`, `*.prog.abap`, `*.fugr.abap`)
- CDS/DDL extensions (`.asddls`, `.asdtmd`, `.ddls`, `.ddlx`)
- End-to-end: `isTextMimeType(getMimeType("teste.clas.abap")) === true`