### PR TITLE
fix(deepagents): handle dotfile MIME detection

### DIFF
--- a/.changeset/plain-config-mime.md
+++ b/.changeset/plain-config-mime.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Fix MIME detection for extensionless and dotfile text config files such as `.env.example`.

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -446,6 +446,17 @@ describe("getMimeType", () => {
     expect(getMimeType("/page.html")).toBe("text/html");
   });
 
+  it("should return text/plain for known text filenames without normal extensions", () => {
+    expect(getMimeType("/.env.example")).toBe("text/plain");
+    expect(getMimeType("/.env.local")).toBe("text/plain");
+    expect(getMimeType("/.gitignore")).toBe("text/plain");
+    expect(getMimeType("/.dockerignore")).toBe("text/plain");
+    expect(getMimeType("/.editorconfig")).toBe("text/plain");
+    expect(getMimeType("/Dockerfile")).toBe("text/plain");
+    expect(getMimeType("/Makefile")).toBe("text/plain");
+    expect(getMimeType("/LICENSE")).toBe("text/plain");
+  });
+
   it("should return application/json for .json files", () => {
     expect(getMimeType("/data.json")).toBe("application/json");
   });

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -827,6 +827,21 @@ export function formatGrepMatches(
  * @returns MIME type string (e.g., "image/png", "application/octet-stream")
  */
 export function getMimeType(filePath: string): string {
+  const name = basename(filePath).toLocaleLowerCase();
+  const nameMimeType = MIME_TYPES[name];
+  if (nameMimeType) {
+    return nameMimeType;
+  }
+
+  if (
+    /^\.env(?:[.-].*)?$/.test(name) ||
+    name === "dockerfile" ||
+    name === "makefile" ||
+    name === "license"
+  ) {
+    return "text/plain";
+  }
+
   const ext = extname(filePath).toLocaleLowerCase();
   return MIME_TYPES[ext] || "application/octet-stream";
 }


### PR DESCRIPTION
## Summary

Fix MIME detection for text config files whose names do not have normal extensions, including `.env.example`, `.env.local`, `.gitignore`, `.dockerignore`, `.editorconfig`, `Dockerfile`, `Makefile`, and `LICENSE`.

## Root cause

`getMimeType()` only checked `extname(filePath)`. For filenames like `.env.example`, the detected extension is `.example`, so DeepAgents treated the file as `application/octet-stream`. When `read_file` returned that as a generic file content block, Anthropic-compatible model adapters could forward it as a non-PDF document and hit provider validation errors.

## Changes

- Check known full basenames before falling back to extension-based MIME detection.
- Treat `.env` variants and common extensionless config filenames as `text/plain`.
- Add regression coverage for these filenames.
- Add a patch changeset for `deepagents`.

## Validation

- `corepack pnpm --filter deepagents exec vitest run src/backends/utils.test.ts`
- `corepack pnpm --filter deepagents exec vitest run src/backends/utils.test.ts src/backends/filesystem.test.ts src/backends/local-shell.test.ts`
- `corepack pnpm --filter @langchain/sandbox-standard-tests build`
- `corepack pnpm --filter deepagents typecheck`
- `corepack pnpm format:check`
- `corepack pnpm --filter deepagents test:unit`
- `corepack pnpm lint`
- `corepack pnpm --filter deepagents build`