### PR TITLE
fix(deepagents): default unknown file extensions to text/plain

### DIFF
--- a/.changeset/few-doors-doubt.md
+++ b/.changeset/few-doors-doubt.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): default unknown file extensions to text/plain

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -454,14 +454,18 @@ describe("getMimeType", () => {
     expect(getMimeType("/app.js")).toBe("application/javascript");
   });
 
-  it("should return application/octet-stream for unknown extensions", () => {
-    expect(getMimeType("/unknown.xyz")).toBe("application/octet-stream");
-    expect(getMimeType("/archive.zip")).toBe("application/octet-stream");
-    expect(getMimeType("/binary.exe")).toBe("application/octet-stream");
-    expect(getMimeType("/data.wasm")).toBe("application/octet-stream");
-    expect(getMimeType("/db.sqlite")).toBe("application/octet-stream");
-    expect(getMimeType("/compiled.pyc")).toBe("application/octet-stream");
-    expect(getMimeType("/package.jar")).toBe("application/octet-stream");
+  it("should default to text/plain for unknown extensions", () => {
+    // Matches Python deepagents, which classifies unrecognized extensions as
+    // text. Unknown extensions (including uncommon source files and genuine
+    // binaries with no explicit mapping) read as text rather than being
+    // base64-encoded into document blocks.
+    expect(getMimeType("/unknown.xyz")).toBe("text/plain");
+    expect(getMimeType("/config.properties")).toBe("text/plain");
+    expect(getMimeType("/style.scss")).toBe("text/plain");
+    expect(getMimeType("/main.hcl")).toBe("text/plain");
+    expect(getMimeType("/pnpm-lock.lock")).toBe("text/plain");
+    expect(getMimeType("/Dockerfile")).toBe("text/plain");
+    expect(getMimeType("/mvnw")).toBe("text/plain");
   });
 });
 

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -69,8 +69,9 @@ const MIME_TYPES: Record<string, string> = {
   ".pptx":
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 
-  // text / code — explicit entries so these don't fall through to the
-  // "application/octet-stream" default meant for truly unknown binaries.
+  // text / code — explicit entries give a specific MIME type (e.g.
+  // text/markdown, text/css, application/json) rather than the generic
+  // "text/plain" default that unknown extensions fall through to.
   ".txt": "text/plain",
   ".md": "text/markdown",
   ".markdown": "text/markdown",
@@ -818,17 +819,21 @@ export function formatGrepMatches(
 /**
  * Determine MIME type from a file path's extension.
  *
- * Returns "application/octet-stream" for unknown extensions so that
- * binary files are not accidentally treated as text (grep, read_file,
- * etc. rely on {@link isTextMimeType} which would return true for
- * "text/plain").
+ * Defaults to "text/plain" for unknown extensions, matching the Python
+ * deepagents behavior where `_get_file_type` classifies unrecognized
+ * extensions as text. Only the known non-text formats above (images, audio,
+ * video, PDF/PPT) are treated as binary by {@link isTextMimeType}; everything
+ * else — source files with uncommon extensions (.properties, .scss, .tf) and
+ * extension-less files (Dockerfile, mvnw) — reads as text. This avoids
+ * base64-encoding text into document blocks, which the model can't read and
+ * which the Anthropic provider rejects with a 400.
  *
  * @param filePath - File path to inspect
- * @returns MIME type string (e.g., "image/png", "application/octet-stream")
+ * @returns MIME type string (e.g., "image/png", "text/plain")
  */
 export function getMimeType(filePath: string): string {
   const ext = extname(filePath).toLocaleLowerCase();
-  return MIME_TYPES[ext] || "application/octet-stream";
+  return MIME_TYPES[ext] || "text/plain";
 }
 
 /**

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -819,14 +819,13 @@ export function formatGrepMatches(
 /**
  * Determine MIME type from a file path's extension.
  *
- * Defaults to "text/plain" for unknown extensions, matching the Python
- * deepagents behavior where `_get_file_type` classifies unrecognized
- * extensions as text. Only the known non-text formats above (images, audio,
- * video, PDF/PPT) are treated as binary by {@link isTextMimeType}; everything
- * else — source files with uncommon extensions (.properties, .scss, .tf) and
- * extension-less files (Dockerfile, mvnw) — reads as text. This avoids
- * base64-encoding text into document blocks, which the model can't read and
- * which the Anthropic provider rejects with a 400.
+ * Defaults to "text/plain" for unknown extensions. Only the known non-text
+ * formats above (images, audio, video, PDF/PPT) are treated as binary by
+ * {@link isTextMimeType}; everything else reads as text, including source files
+ * with uncommon extensions (.properties, .scss, .tf) and extension-less files
+ * (Dockerfile, mvnw). This avoids base64-encoding text into document blocks,
+ * which the model can't read and which the Anthropic provider rejects with a
+ * 400.
  *
  * @param filePath - File path to inspect
  * @returns MIME type string (e.g., "image/png", "text/plain")


### PR DESCRIPTION
### Summary

`read_file` couldn't read many common text files and with Anthropic it crashes the whole run. `getMimeType()` mapped any unrecognized extension to `application/octet-stream`, which `isTextMimeType()` treats as binary, so the file got base64-encoded into a document block.

This defaults unknown extensions to `text/plain` instead. Known binaries (images, audio, video, PDF/PPT) stay explicitly mapped, so image and PDF handling is unchanged. Files like `.properties`, `.scss`, `.tf`, `.lock`, and extension-less files like `Dockerfile` now read as text.

  ### Tests
  
Flipped the unknown-extension unit test to expect `text/plain`.
