### PR TITLE
fix(modal): modal sandboxes fail to upload files

### DIFF
--- a/.changeset/khaki-beds-sing.md
+++ b/.changeset/khaki-beds-sing.md
@@ -2,4 +2,4 @@
 "@langchain/modal": patch
 ---
 
-fix(modal): modal low level handle api `sandbox.open` has been removed
+fix(modal): modal low level file handle api `sandbox.open` has been removed

--- a/.changeset/khaki-beds-sing.md
+++ b/.changeset/khaki-beds-sing.md
@@ -1,0 +1,5 @@
+---
+"@langchain/modal": patch
+---
+
+fix(modal): modal low level handle open `sandbox.open` has been removed

--- a/.changeset/khaki-beds-sing.md
+++ b/.changeset/khaki-beds-sing.md
@@ -2,4 +2,4 @@
 "@langchain/modal": patch
 ---
 
-fix(modal): modal low level handle open `sandbox.open` has been removed
+fix(modal): modal low level handle api `sandbox.open` has been removed

--- a/libs/providers/modal/src/sandbox.test.ts
+++ b/libs/providers/modal/src/sandbox.test.ts
@@ -94,13 +94,6 @@ vi.mock("./auth.js", () => ({
 
 // Mock the modal module with factory
 vi.mock("modal", () => {
-  // Mirror the typed errors thrown by the real `sandbox.filesystem` API so
-  // `#mapError`'s instanceof checks resolve against these mock classes.
-  class SandboxFilesystemError extends Error {}
-  class SandboxFilesystemNotFoundError extends SandboxFilesystemError {}
-  class SandboxFilesystemIsADirectoryError extends SandboxFilesystemError {}
-  class SandboxFilesystemPermissionError extends SandboxFilesystemError {}
-
   /**
    * Mock Sandbox class that simulates the Modal SDK behavior.
    */
@@ -129,17 +122,17 @@ vi.mock("modal", () => {
     filesystem = {
       writeBytes: async (data: Uint8Array, remotePath: string) => {
         if (this.shouldFailOpen) {
-          throw new SandboxFilesystemPermissionError("permission denied");
+          throw new Error("File operation failed: permission denied");
         }
         this.files.set(remotePath, data);
       },
       readBytes: async (remotePath: string) => {
         if (this.shouldFailOpen) {
-          throw new SandboxFilesystemPermissionError("permission denied");
+          throw new Error("File operation failed: permission denied");
         }
         const content = this.files.get(remotePath);
         if (content === undefined) {
-          throw new SandboxFilesystemNotFoundError(`not found: ${remotePath}`);
+          throw new Error(`File not found: ${remotePath}`);
         }
         return content;
       },
@@ -258,9 +251,6 @@ vi.mock("modal", () => {
 
   return {
     ModalClient: MockModalClient,
-    SandboxFilesystemNotFoundError,
-    SandboxFilesystemIsADirectoryError,
-    SandboxFilesystemPermissionError,
   };
 });
 

--- a/libs/providers/modal/src/sandbox.test.ts
+++ b/libs/providers/modal/src/sandbox.test.ts
@@ -94,6 +94,11 @@ vi.mock("./auth.js", () => ({
 
 // Mock the modal module with factory
 vi.mock("modal", () => {
+  // Mirror the typed not-found error thrown by the real `sandbox.filesystem`
+  // API. Its message is opaque server text (no "not found"/"enoent"), so
+  // `#mapError` must classify it by type.
+  class SandboxFilesystemNotFoundError extends Error {}
+
   /**
    * Mock Sandbox class that simulates the Modal SDK behavior.
    */
@@ -132,7 +137,9 @@ vi.mock("modal", () => {
         }
         const content = this.files.get(remotePath);
         if (content === undefined) {
-          throw new Error(`File not found: ${remotePath}`);
+          throw new SandboxFilesystemNotFoundError(
+            `path does not exist: ${remotePath}`,
+          );
         }
         return content;
       },
@@ -252,6 +259,7 @@ vi.mock("modal", () => {
 
   return {
     ModalClient: MockModalClient,
+    SandboxFilesystemNotFoundError,
   };
 });
 

--- a/libs/providers/modal/src/sandbox.test.ts
+++ b/libs/providers/modal/src/sandbox.test.ts
@@ -151,9 +151,10 @@ vi.mock("modal", () => {
       };
     }
 
-    // Add file to mock filesystem
+    // Add file to mock filesystem. Keys are stored absolute to match the
+    // absolute paths the provider passes to `sandbox.filesystem`.
     addFile(path: string, content: Uint8Array) {
-      this.files.set(path, content);
+      this.files.set(path.startsWith("/") ? path : `/${path}`, content);
     }
 
     // SDK methods
@@ -375,18 +376,17 @@ describe("ModalSandbox", () => {
 
       await sandbox.initialize();
 
-      // Verify files were uploaded to the mock sandbox
-      // Note: paths are normalized (leading slash removed)
+      // Verify files were uploaded to the mock sandbox at absolute paths.
       const mockSb = mockState.sandboxInstance!;
-      expect(mockSb.files.has("test.txt")).toBe(true);
-      expect(mockSb.files.has("src/index.js")).toBe(true);
+      expect(mockSb.files.has("/test.txt")).toBe(true);
+      expect(mockSb.files.has("/src/index.js")).toBe(true);
 
       // Check content (should be Uint8Array)
       const encoder = new TextEncoder();
-      expect(mockSb.files.get("test.txt")).toEqual(
+      expect(mockSb.files.get("/test.txt")).toEqual(
         encoder.encode("Hello, World!"),
       );
-      expect(mockSb.files.get("src/index.js")).toEqual(
+      expect(mockSb.files.get("/src/index.js")).toEqual(
         encoder.encode("console.log('Hi')"),
       );
     });
@@ -403,10 +403,9 @@ describe("ModalSandbox", () => {
 
       await sandbox.initialize();
 
-      // Note: paths are normalized (leading slash removed)
       const mockSb = mockState.sandboxInstance!;
-      expect(mockSb.files.has("binary.dat")).toBe(true);
-      expect(mockSb.files.get("binary.dat")).toEqual(binaryContent);
+      expect(mockSb.files.has("/binary.dat")).toBe(true);
+      expect(mockSb.files.get("/binary.dat")).toEqual(binaryContent);
     });
 
     it("should handle initial files with mixed content types", async () => {
@@ -420,13 +419,12 @@ describe("ModalSandbox", () => {
 
       await sandbox.initialize();
 
-      // Note: paths are normalized (leading slash removed)
       const mockSb = mockState.sandboxInstance!;
-      expect(mockSb.files.has("text.txt")).toBe(true);
-      expect(mockSb.files.has("data.bin")).toBe(true);
+      expect(mockSb.files.has("/text.txt")).toBe(true);
+      expect(mockSb.files.has("/data.bin")).toBe(true);
     });
 
-    it("should normalize paths - remove leading slash", async () => {
+    it("should normalize relative paths to absolute", async () => {
       const sandbox = new ModalSandbox({
         initialFiles: {
           "/with-slash.txt": "content1",
@@ -437,9 +435,9 @@ describe("ModalSandbox", () => {
       await sandbox.initialize();
 
       const mockSb = mockState.sandboxInstance!;
-      // Both should be stored with paths (the mock stores normalized paths)
-      expect(mockSb.files.has("with-slash.txt")).toBe(true);
-      expect(mockSb.files.has("no-slash.txt")).toBe(true);
+      // Both are stored absolute; the relative key gains a leading slash.
+      expect(mockSb.files.has("/with-slash.txt")).toBe(true);
+      expect(mockSb.files.has("/no-slash.txt")).toBe(true);
     });
   });
 
@@ -512,10 +510,10 @@ describe("ModalSandbox", () => {
 
       expect(sandbox.isRunning).toBe(true);
 
-      // Verify files were uploaded
+      // Verify files were uploaded at absolute paths
       const mockSb = mockState.sandboxInstance!;
-      expect(mockSb.files.has("hello.txt")).toBe(true);
-      expect(mockSb.files.has("nested/file.js")).toBe(true);
+      expect(mockSb.files.has("/hello.txt")).toBe(true);
+      expect(mockSb.files.has("/nested/file.js")).toBe(true);
 
       // Verify content
       const results = await sandbox.downloadFiles([
@@ -640,8 +638,9 @@ describe("ModalSandbox", () => {
       const content = new TextEncoder().encode("file content");
       await sandbox.uploadFiles([["test.txt", content]]);
 
-      // writeBytes is called with (data, remotePath) to write the file
-      expect(writeSpy).toHaveBeenCalledWith(content, "test.txt");
+      // writeBytes is called with (data, remotePath); relative paths are
+      // normalized to absolute for the filesystem API.
+      expect(writeSpy).toHaveBeenCalledWith(content, "/test.txt");
     });
 
     it("should upload multiple files", async () => {

--- a/libs/providers/modal/src/sandbox.test.ts
+++ b/libs/providers/modal/src/sandbox.test.ts
@@ -34,7 +34,10 @@ interface MockSandboxType {
     args: string[],
     options: { stdout: string; stderr: string },
   ) => Promise<MockProcessType>;
-  open: (path: string, mode: string) => Promise<MockFileHandleType>;
+  filesystem: {
+    writeBytes: (data: Uint8Array, remotePath: string) => Promise<void>;
+    readBytes: (remotePath: string) => Promise<Uint8Array>;
+  };
   terminate: () => Promise<void>;
   poll: () => Promise<number | null>;
   wait: () => Promise<number>;
@@ -44,12 +47,6 @@ interface MockProcessType {
   stdout: { readText: () => Promise<string> };
   stderr: { readText: () => Promise<string> };
   wait: () => Promise<number>;
-}
-
-interface MockFileHandleType {
-  read: () => Promise<Uint8Array>;
-  write: (data: Uint8Array) => Promise<void>;
-  close: () => Promise<void>;
 }
 
 interface MockClientType {
@@ -97,6 +94,13 @@ vi.mock("./auth.js", () => ({
 
 // Mock the modal module with factory
 vi.mock("modal", () => {
+  // Mirror the typed errors thrown by the real `sandbox.filesystem` API so
+  // `#mapError`'s instanceof checks resolve against these mock classes.
+  class SandboxFilesystemError extends Error {}
+  class SandboxFilesystemNotFoundError extends SandboxFilesystemError {}
+  class SandboxFilesystemIsADirectoryError extends SandboxFilesystemError {}
+  class SandboxFilesystemPermissionError extends SandboxFilesystemError {}
+
   /**
    * Mock Sandbox class that simulates the Modal SDK behavior.
    */
@@ -120,6 +124,27 @@ vi.mock("modal", () => {
     // Error simulation flags
     shouldFailOpen = false;
 
+    // Mock of the Modal SDK `sandbox.filesystem` API. Arrow functions capture
+    // `this` so they read the live `shouldFailOpen` flag and `files` map.
+    filesystem = {
+      writeBytes: async (data: Uint8Array, remotePath: string) => {
+        if (this.shouldFailOpen) {
+          throw new SandboxFilesystemPermissionError("permission denied");
+        }
+        this.files.set(remotePath, data);
+      },
+      readBytes: async (remotePath: string) => {
+        if (this.shouldFailOpen) {
+          throw new SandboxFilesystemPermissionError("permission denied");
+        }
+        const content = this.files.get(remotePath);
+        if (content === undefined) {
+          throw new SandboxFilesystemNotFoundError(`not found: ${remotePath}`);
+        }
+        return content;
+      },
+    };
+
     constructor(sandboxId: string = "sb-mock-123") {
       this.sandboxId = sandboxId;
     }
@@ -140,46 +165,15 @@ vi.mock("modal", () => {
 
     // SDK methods
     async exec(
-      args: string[],
+      _args: string[],
       _options: { stdout: string; stderr: string },
     ): Promise<MockProcessType> {
       const result = { ...this.nextCommandResult };
-
-      // Check if this is a mkdir command - always succeed
-      if (args[0] === "mkdir") {
-        return {
-          stdout: { readText: async () => "" },
-          stderr: { readText: async () => "" },
-          wait: async () => 0,
-        };
-      }
 
       return {
         stdout: { readText: async () => result.stdout },
         stderr: { readText: async () => result.stderr },
         wait: async () => result.exitCode,
-      };
-    }
-
-    async open(path: string, _mode: string): Promise<MockFileHandleType> {
-      if (this.shouldFailOpen) {
-        throw new Error("File operation failed: permission denied");
-      }
-
-      // Capture files reference for the returned object's methods
-      const files = this.files;
-      return {
-        read: async () => {
-          const content = files.get(path);
-          if (content === undefined) {
-            throw new Error(`File not found: ${path}`);
-          }
-          return content;
-        },
-        write: async (data: Uint8Array) => {
-          files.set(path, data);
-        },
-        close: async () => {},
       };
     }
 
@@ -264,6 +258,9 @@ vi.mock("modal", () => {
 
   return {
     ModalClient: MockModalClient,
+    SandboxFilesystemNotFoundError,
+    SandboxFilesystemIsADirectoryError,
+    SandboxFilesystemPermissionError,
   };
 });
 
@@ -572,7 +569,7 @@ describe("ModalSandbox", () => {
   // ==========================================================================
 
   describe("execute", () => {
-    it("should call SDK exec with bash -c", async () => {
+    it("should call SDK exec with sh -c", async () => {
       const sandbox = await ModalSandbox.create();
 
       // Spy on exec
@@ -580,7 +577,7 @@ describe("ModalSandbox", () => {
 
       await sandbox.execute("echo hello");
 
-      expect(execSpy).toHaveBeenCalledWith(["bash", "-c", "echo hello"], {
+      expect(execSpy).toHaveBeenCalledWith(["sh", "-c", "echo hello"], {
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -645,13 +642,16 @@ describe("ModalSandbox", () => {
   describe("uploadFiles", () => {
     it("should write content to sandbox", async () => {
       const sandbox = await ModalSandbox.create();
-      const openSpy = vi.spyOn(mockState.sandboxInstance!, "open");
+      const writeSpy = vi.spyOn(
+        mockState.sandboxInstance!.filesystem,
+        "writeBytes",
+      );
 
       const content = new TextEncoder().encode("file content");
       await sandbox.uploadFiles([["test.txt", content]]);
 
-      // open is called for writing the file
-      expect(openSpy).toHaveBeenCalledWith("test.txt", "w");
+      // writeBytes is called with (data, remotePath) to write the file
+      expect(writeSpy).toHaveBeenCalledWith(content, "test.txt");
     });
 
     it("should upload multiple files", async () => {

--- a/libs/providers/modal/src/sandbox.ts
+++ b/libs/providers/modal/src/sandbox.ts
@@ -9,12 +9,7 @@
  * @packageDocumentation
  */
 
-import {
-  ModalClient,
-  SandboxFilesystemNotFoundError,
-  SandboxFilesystemIsADirectoryError,
-  SandboxFilesystemPermissionError,
-} from "modal";
+import { ModalClient } from "modal";
 import type { App, Sandbox, Image, SandboxCreateParams } from "modal";
 import {
   BaseSandbox,
@@ -569,18 +564,6 @@ export class ModalSandbox extends BaseSandbox {
    * @returns A standardized error code
    */
   #mapError(error: unknown): FileOperationError {
-    // Prefer the typed errors thrown by the `sandbox.filesystem` API.
-    if (error instanceof SandboxFilesystemNotFoundError) {
-      return "file_not_found";
-    }
-    if (error instanceof SandboxFilesystemIsADirectoryError) {
-      return "is_directory";
-    }
-    if (error instanceof SandboxFilesystemPermissionError) {
-      return "permission_denied";
-    }
-
-    // Fall back to message heuristics for errors thrown by `exec` and others.
     if (error instanceof Error) {
       const msg = error.message.toLowerCase();
 

--- a/libs/providers/modal/src/sandbox.ts
+++ b/libs/providers/modal/src/sandbox.ts
@@ -302,16 +302,11 @@ export class ModalSandbox extends BaseSandbox {
     const filesToUpload: Array<[string, Uint8Array]> = [];
 
     for (const [filePath, content] of Object.entries(files)) {
-      // Normalize the path - remove leading slash if present for consistency
-      const normalizedPath = filePath.startsWith("/")
-        ? filePath.slice(1)
-        : filePath;
-
       // Convert string content to Uint8Array
       const data =
         typeof content === "string" ? encoder.encode(content) : content;
 
-      filesToUpload.push([normalizedPath, data]);
+      filesToUpload.push([filePath, data]);
     }
 
     // Use the existing uploadFiles method
@@ -412,10 +407,12 @@ export class ModalSandbox extends BaseSandbox {
     const results: FileUploadResponse[] = [];
 
     for (const [path, content] of files) {
+      // `sandbox.filesystem` requires an absolute path.
+      const remotePath = path.startsWith("/") ? path : `/${path}`;
       try {
         // Write the file content using Modal's filesystem API. `writeBytes`
         // takes (data, remotePath) and creates parent directories as needed.
-        await sandbox.filesystem.writeBytes(content, path);
+        await sandbox.filesystem.writeBytes(content, remotePath);
 
         results.push({ path, error: null });
       } catch (error) {
@@ -452,9 +449,11 @@ export class ModalSandbox extends BaseSandbox {
     const results: FileDownloadResponse[] = [];
 
     for (const path of paths) {
+      // `sandbox.filesystem` requires an absolute path.
+      const remotePath = path.startsWith("/") ? path : `/${path}`;
       try {
         // Read the file content using Modal's filesystem API.
-        const content = await sandbox.filesystem.readBytes(path);
+        const content = await sandbox.filesystem.readBytes(remotePath);
 
         results.push({
           path,

--- a/libs/providers/modal/src/sandbox.ts
+++ b/libs/providers/modal/src/sandbox.ts
@@ -9,7 +9,12 @@
  * @packageDocumentation
  */
 
-import { ModalClient } from "modal";
+import {
+  ModalClient,
+  SandboxFilesystemNotFoundError,
+  SandboxFilesystemIsADirectoryError,
+  SandboxFilesystemPermissionError,
+} from "modal";
 import type { App, Sandbox, Image, SandboxCreateParams } from "modal";
 import {
   BaseSandbox,
@@ -413,21 +418,9 @@ export class ModalSandbox extends BaseSandbox {
 
     for (const [path, content] of files) {
       try {
-        // Ensure parent directory exists
-        const parentDir = path.substring(0, path.lastIndexOf("/"));
-        if (parentDir) {
-          await sandbox
-            .exec(["mkdir", "-p", parentDir], {
-              stdout: "pipe",
-              stderr: "pipe",
-            })
-            .then((p) => p.wait());
-        }
-
-        // Write the file content using Modal's file API
-        const writeHandle = await sandbox.open(path, "w");
-        await writeHandle.write(content);
-        await writeHandle.close();
+        // Write the file content using Modal's filesystem API. `writeBytes`
+        // takes (data, remotePath) and creates parent directories as needed.
+        await sandbox.filesystem.writeBytes(content, path);
 
         results.push({ path, error: null });
       } catch (error) {
@@ -465,10 +458,8 @@ export class ModalSandbox extends BaseSandbox {
 
     for (const path of paths) {
       try {
-        // Read the file content using Modal's file API
-        const readHandle = await sandbox.open(path, "r");
-        const content = await readHandle.read();
-        await readHandle.close();
+        // Read the file content using Modal's filesystem API.
+        const content = await sandbox.filesystem.readBytes(path);
 
         results.push({
           path,
@@ -578,6 +569,18 @@ export class ModalSandbox extends BaseSandbox {
    * @returns A standardized error code
    */
   #mapError(error: unknown): FileOperationError {
+    // Prefer the typed errors thrown by the `sandbox.filesystem` API.
+    if (error instanceof SandboxFilesystemNotFoundError) {
+      return "file_not_found";
+    }
+    if (error instanceof SandboxFilesystemIsADirectoryError) {
+      return "is_directory";
+    }
+    if (error instanceof SandboxFilesystemPermissionError) {
+      return "permission_denied";
+    }
+
+    // Fall back to message heuristics for errors thrown by `exec` and others.
     if (error instanceof Error) {
       const msg = error.message.toLowerCase();
 

--- a/libs/providers/modal/src/sandbox.ts
+++ b/libs/providers/modal/src/sandbox.ts
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 
-import { ModalClient } from "modal";
+import { ModalClient, SandboxFilesystemNotFoundError } from "modal";
 import type { App, Sandbox, Image, SandboxCreateParams } from "modal";
 import {
   BaseSandbox,
@@ -563,6 +563,12 @@ export class ModalSandbox extends BaseSandbox {
    * @returns A standardized error code
    */
   #mapError(error: unknown): FileOperationError {
+    // The filesystem API's not-found error carries an opaque server-side
+    // message, so classify it by type rather than by message substring.
+    if (error instanceof SandboxFilesystemNotFoundError) {
+      return "file_not_found";
+    }
+
     if (error instanceof Error) {
       const msg = error.message.toLowerCase();
 


### PR DESCRIPTION
### Summary

Modal v0.8.0 released the following breaking change:
```
Breaking: Removed the deprecated low-level file-handle API: Sandbox.Open / SandboxFile (Go), and sandbox.open / SandboxFile (JS). Use the Sandbox Filesystem API instead: sandbox.Filesystem() (Go) / sandbox.filesystem (JS).
```
Ref: https://github.com/modal-labs/modal-client/blob/main/CHANGELOG_GO_JS.md

This PR updates our implementation to use the sandbox filesystem api

### Tests

Updated `sandbox.test.ts` mocks to model `sandbox.filesystem`