### PR TITLE
fix(daytona): classify DaytonaNotFoundError as file_not_found

### DIFF
--- a/.changeset/daytona-maperror-enoent.md
+++ b/.changeset/daytona-maperror-enoent.md
@@ -1,0 +1,5 @@
+---
+"@langchain/daytona": patch
+---
+
+fix(daytona): classify DaytonaNotFoundError as file_not_found so missing files degrade gracefully

--- a/libs/providers/daytona/src/sandbox.ts
+++ b/libs/providers/daytona/src/sandbox.ts
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 
-import { Daytona, type Sandbox } from "@daytona/sdk";
+import { Daytona, DaytonaNotFoundError, type Sandbox } from "@daytona/sdk";
 import {
   BaseSandbox,
   type ExecuteResponse,
@@ -627,16 +627,27 @@ export class DaytonaSandbox extends BaseSandbox {
    * @returns A standardized error code
    */
   #mapError(error: unknown): FileOperationError {
+    // The Daytona SDK maps a 404 to a typed DaytonaNotFoundError, so classify
+    // missing paths directly instead of relying on the error message wording
+    // (mirrors the modal provider's SandboxFilesystemNotFoundError check).
+    if (error instanceof DaytonaNotFoundError) {
+      return "file_not_found";
+    }
     if (error instanceof Error) {
       const msg = error.message.toLowerCase();
 
-      if (msg.includes("not found") || msg.includes("enoent")) {
+      // Check for "no such file or directory" first (contains both "file" and "directory")
+      if (
+        msg.includes("not found") ||
+        msg.includes("enoent") ||
+        msg.includes("no such file")
+      ) {
         return "file_not_found";
       }
       if (msg.includes("permission") || msg.includes("eacces")) {
         return "permission_denied";
       }
-      if (msg.includes("directory") || msg.includes("eisdir")) {
+      if (msg.includes("is a directory") || msg.includes("eisdir")) {
         return "is_directory";
       }
     }


### PR DESCRIPTION
## Summary

`DaytonaSandbox.#mapError` classified filesystem errors purely from the error-message text, checking `msg.includes("directory")` before matching file-not-found. The Daytona SDK maps a 404 to a typed `DaytonaNotFoundError`, so a missing path could be misclassified as `is_directory` depending on the message wording.

Callers that treat `file_not_found` as expected — e.g. the optional memory files in the deepagents fs middleware, which skip on `file_not_found` but throw on any other code — would then throw `Failed to download <path>: is_directory` instead of degrading gracefully.

The `modal` provider already classifies missing paths by type (`error instanceof SandboxFilesystemNotFoundError` → `file_not_found`); this aligns `daytona` with it.

## Changes

- Check `error instanceof DaytonaNotFoundError` first → `file_not_found` (robust to message wording, mirrors modal).
- Align the message fallback with modal: match `"no such file"`, and narrow the directory check from `"directory"` to `"is a directory"`.

## Test plan

- Classification-only change; no behavior change beyond the error mapping.
- I didn't test this locally; CI runs the `@langchain/daytona` unit tests.
