### PR TITLE
fix(modal): pass explicit auth credentials to ModalClient

### DIFF
--- a/.changeset/modal-auth-credentials.md
+++ b/.changeset/modal-auth-credentials.md
@@ -1,0 +1,5 @@
+---
+"@langchain/modal": patch
+---
+
+fix(modal): pass explicit auth credentials to ModalClient

--- a/libs/providers/modal/src/sandbox.ts
+++ b/libs/providers/modal/src/sandbox.ts
@@ -20,7 +20,7 @@ import {
   type FileUploadResponse,
 } from "deepagents";
 
-import { getAuthCredentials } from "./auth.js";
+import { getAuthCredentials, type ModalCredentials } from "./auth.js";
 import { ModalSandboxError, type ModalSandboxOptions } from "./types.js";
 
 /**
@@ -199,9 +199,10 @@ export class ModalSandbox extends BaseSandbox {
       );
     }
 
-    // Validate authentication credentials exist
+    // Validate and resolve authentication credentials
+    let credentials: ModalCredentials;
     try {
-      getAuthCredentials(this.#options.auth);
+      credentials = getAuthCredentials(this.#options.auth);
     } catch (error) {
       throw new ModalSandboxError(
         "Failed to authenticate with Modal. Check your token configuration.",
@@ -212,7 +213,10 @@ export class ModalSandbox extends BaseSandbox {
 
     try {
       // Create Modal client
-      this.#client = new ModalClient();
+      this.#client = new ModalClient({
+        tokenId: credentials.tokenId,
+        tokenSecret: credentials.tokenSecret,
+      });
 
       // Get or create the app
       this.#app = await this.#client.apps.fromName(
@@ -636,9 +640,10 @@ export class ModalSandbox extends BaseSandbox {
     sandboxId: string,
     options?: Pick<ModalSandboxOptions, "auth">,
   ): Promise<ModalSandbox> {
-    // Validate authentication credentials exist
+    // Validate and resolve authentication credentials
+    let credentials: ModalCredentials;
     try {
-      getAuthCredentials(options?.auth);
+      credentials = getAuthCredentials(options?.auth);
     } catch (error) {
       throw new ModalSandboxError(
         "Failed to authenticate with Modal. Check your token configuration.",
@@ -648,7 +653,10 @@ export class ModalSandbox extends BaseSandbox {
     }
 
     try {
-      const client = new ModalClient();
+      const client = new ModalClient({
+        tokenId: credentials.tokenId,
+        tokenSecret: credentials.tokenSecret,
+      });
       const existingSandbox = await client.sandboxes.fromId(sandboxId);
 
       const modalSandbox = new ModalSandbox(options);
@@ -683,9 +691,10 @@ export class ModalSandbox extends BaseSandbox {
     sandboxName: string,
     options?: Pick<ModalSandboxOptions, "auth">,
   ): Promise<ModalSandbox> {
-    // Validate authentication credentials exist
+    // Validate and resolve authentication credentials
+    let credentials: ModalCredentials;
     try {
-      getAuthCredentials(options?.auth);
+      credentials = getAuthCredentials(options?.auth);
     } catch (error) {
       throw new ModalSandboxError(
         "Failed to authenticate with Modal. Check your token configuration.",
@@ -695,7 +704,10 @@ export class ModalSandbox extends BaseSandbox {
     }
 
     try {
-      const client = new ModalClient();
+      const client = new ModalClient({
+        tokenId: credentials.tokenId,
+        tokenSecret: credentials.tokenSecret,
+      });
       const existingSandbox = await client.sandboxes.fromName(
         appName,
         sandboxName,


### PR DESCRIPTION
## Summary

`ModalSandbox` validates auth credentials but never passes them to the client. `initialize()`, `fromId()`, and `fromName()` call `getAuthCredentials(...)` only to confirm credentials exist, discard the return value, and construct `new ModalClient()` with no arguments.

As a result, credentials supplied through the documented `auth: { tokenId, tokenSecret }` option are ignored — `ModalClient` falls back to `MODAL_TOKEN_*` env vars / `.modal.toml`. If no env/config profile is present, the first API call fails with "Profile is missing token_id or token_secret" despite valid credentials having been provided.

## Changes

- Capture the resolved credentials from `getAuthCredentials(...)` and pass them to `new ModalClient({ tokenId, tokenSecret })` in `initialize()`, `fromId()`, and `fromName()`.

## Test plan

- The `auth` option now reaches the Modal client; env-var auth is unchanged.
- I didn't test this locally; CI runs the `@langchain/modal` unit tests.
