### PR TITLE
fix(deepagents): fast-glob follows directory symlink cycles leading to `ELOOP` crashes

### DIFF
--- a/.changeset/deep-experts-thank.md
+++ b/.changeset/deep-experts-thank.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): fast-glob follows directory symlink cycles leading to ELOOP crashes

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -532,3 +532,83 @@ describe("FilesystemBackend", () => {
     });
   });
 });
+
+/**
+ * Returns true when the platform lets an unprivileged process create symlinks
+ */
+function symlinksSupported(): boolean {
+  const probe = fsSync.mkdtempSync(
+    path.join(os.tmpdir(), "deepagents-symlink-probe-"),
+  );
+  try {
+    fsSync.symlinkSync("target", path.join(probe, "link"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(probe, { recursive: true, force: true });
+  }
+}
+const CAN_SYMLINK = symlinksSupported();
+
+describe("FilesystemBackend symlink cycle handling", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(async () => {
+    await removeDir(tmpDir);
+  });
+
+  /**
+   * Build a tree with a real file plus an `ln -s . sub/sub` cycle.
+   */
+  async function buildCycle(root: string) {
+    await writeFile(path.join(root, "real.txt"), "needle-content");
+    await writeFile(path.join(root, "sub", "inner.txt"), "needle-content");
+    await fs.symlink(".", path.join(root, "sub", "sub"));
+  }
+
+  // A file reached by following the cycle looks like `.../sub/sub/inner.txt`;
+  // the real file is only ever `.../sub/inner.txt`.
+  const followedCycle = (p: string) => /sub[\\/]sub/.test(p);
+
+  it.skipIf(!CAN_SYMLINK)(
+    "glob does not descend into a directory symlink cycle",
+    async () => {
+      await buildCycle(tmpDir);
+      const backend = new FilesystemBackend({
+        rootDir: tmpDir,
+        virtualMode: false,
+      });
+
+      const result = await backend.glob("**/*", tmpDir);
+
+      expect(result.error).toBeUndefined();
+      const paths = result.files!.map((f) => f.path);
+      expect(paths.some((p) => p.endsWith("inner.txt"))).toBe(true);
+      expect(paths.some((p) => p.endsWith("real.txt"))).toBe(true);
+      expect(paths.some(followedCycle)).toBe(false);
+    },
+  );
+
+  it.skipIf(!CAN_SYMLINK)(
+    "grep does not descend into a directory symlink cycle",
+    async () => {
+      await buildCycle(tmpDir);
+      const backend = new FilesystemBackend({
+        rootDir: tmpDir,
+        virtualMode: false,
+      });
+
+      const result = await backend.grep("needle-content", tmpDir);
+
+      expect(result.error).toBeUndefined();
+      const paths = (result.matches ?? []).map((m) => m.path);
+      expect(paths.some((p) => p.endsWith("inner.txt"))).toBe(true);
+      expect(paths.some(followedCycle)).toBe(false);
+    },
+  );
+});

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs/promises";
 import * as fsSync from "fs";
 import * as path from "path";
@@ -615,6 +615,41 @@ describe("FilesystemBackend symlink cycle handling", () => {
       const paths = (result.matches ?? []).map((m) => m.path);
       expect(paths.some((p) => p.endsWith("inner.txt"))).toBe(true);
       expect(paths.some(followedCycle)).toBe(false);
+    },
+  );
+
+  it.skipIf(!CAN_SYMLINK)(
+    "grep fallback does not follow a symlink out of the search root",
+    async () => {
+      // A secret file OUTSIDE the workspace, reachable only via an in-tree
+      // symlink. Reading through the link would leak it past the root.
+      const outside = createTempDir();
+      try {
+        await writeFile(path.join(outside, "secret.txt"), "EXFIL_MARKER");
+        await writeFile(path.join(tmpDir, "normal.txt"), "nothing here");
+        await fs.symlink(
+          path.join(outside, "secret.txt"),
+          path.join(tmpDir, "alias.txt"),
+        );
+
+        const backend = new FilesystemBackend({
+          rootDir: tmpDir,
+          virtualMode: true,
+        });
+        // Force the non-ripgrep path; that fallback is what this guards.
+        vi.spyOn(
+          backend as unknown as { ripgrepSearch: () => Promise<null> },
+          "ripgrepSearch",
+        ).mockResolvedValue(null);
+
+        const result = await backend.grep("EXFIL_MARKER", "/");
+
+        // The marker exists only in the out-of-tree file; the fallback must not
+        // read it through the symlink.
+        expect(result.matches ?? []).toHaveLength(0);
+      } finally {
+        await removeDir(outside);
+      }
     },
   );
 });

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -563,12 +563,15 @@ describe("FilesystemBackend symlink cycle handling", () => {
   });
 
   /**
-   * Build a tree with a real file plus an `ln -s . sub/sub` cycle.
+   * Build a tree with real files, an `ln -s . sub/sub` cycle (must not be
+   * descended into), and a symlink-to-file `alias.txt -> real.txt` (must still
+   * be reported).
    */
   async function buildCycle(root: string) {
     await writeFile(path.join(root, "real.txt"), "needle-content");
     await writeFile(path.join(root, "sub", "inner.txt"), "needle-content");
     await fs.symlink(".", path.join(root, "sub", "sub"));
+    await fs.symlink(path.join(root, "real.txt"), path.join(root, "alias.txt"));
   }
 
   // A file reached by following the cycle looks like `.../sub/sub/inner.txt`;
@@ -590,6 +593,9 @@ describe("FilesystemBackend symlink cycle handling", () => {
       const paths = result.files!.map((f) => f.path);
       expect(paths.some((p) => p.endsWith("inner.txt"))).toBe(true);
       expect(paths.some((p) => p.endsWith("real.txt"))).toBe(true);
+      // A symlink pointing at a regular file must still be reported (not
+      // silently dropped by `onlyFiles` + `followSymbolicLinks: false`).
+      expect(paths.some((p) => p.endsWith("alias.txt"))).toBe(true);
       expect(paths.some(followedCycle)).toBe(false);
     },
   );

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -619,12 +619,16 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const stat = await fs.stat(baseFull);
     const root = stat.isDirectory() ? baseFull : path.dirname(baseFull);
 
-    // Use fast-glob to recursively find all files
+    // Use fast-glob to recursively find all files. `followSymbolicLinks: false`
+    // prevents descending into symlinked directories: fast-glob follows links
+    // by default, so a self-referential directory symlink (e.g. `sub/sub -> .`)
+    // would be walked recursively until the OS throws ELOOP.
     const files = await fg("**/*", {
       cwd: root,
       absolute: true,
       onlyFiles: true,
       dot: true,
+      followSymbolicLinks: false,
     });
 
     for (const fp of files) {
@@ -715,6 +719,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
         absolute: true,
         onlyFiles: true,
         dot: true,
+        followSymbolicLinks: false,
       });
 
       for (const matchedPath of matches) {

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -619,11 +619,15 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const stat = await fs.stat(baseFull);
     const root = stat.isDirectory() ? baseFull : path.dirname(baseFull);
 
-    // Use fast-glob to recursively find all files
+    // `followSymbolicLinks: false` avoids ELOOP on self-referential directory
+    // symlinks. `onlyFiles: false` keeps symlinks-to-files in the results
+    // (fast-glob's `onlyFiles` filter uses lstat and would drop them); the
+    // `stat().isFile()` guard in the loop follows each link and skips anything
+    // that is not a regular file.
     const files = await fg("**/*", {
       cwd: root,
       absolute: true,
-      onlyFiles: true,
+      onlyFiles: false,
       dot: true,
       followSymbolicLinks: false,
     });
@@ -644,8 +648,12 @@ export class FilesystemBackend implements BackendProtocolV2 {
           continue;
         }
 
-        // Check file size
+        // Check file size. `fs.stat` follows symlinks, so a symlink-to-file is
+        // searched while directories (real or symlinked) are skipped here.
         const stat = await fs.stat(fp);
+        if (!stat.isFile()) {
+          continue;
+        }
         if (stat.size > this.maxFileSizeBytes) {
           continue;
         }
@@ -710,11 +718,18 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const results: FileInfo[] = [];
 
     try {
-      // Use fast-glob for pattern matching
+      // `followSymbolicLinks: false` stops fast-glob from descending into
+      // symlinked directories, which otherwise loop forever on a self-
+      // referential symlink (e.g. `sub/sub -> .`) until the OS throws ELOOP.
+      // `onlyFiles: false` (rather than `true`) is deliberate: fast-glob's
+      // `onlyFiles` filter uses lstat and would drop symlinks-to-files entirely,
+      // regressing results like `alias.ts -> real.ts`. The `stat().isFile()`
+      // check below follows each link to re-include those files while excluding
+      // directories.
       const matches = await fg(pattern, {
         cwd: resolvedSearchPath,
         absolute: true,
-        onlyFiles: true,
+        onlyFiles: false,
         dot: true,
         followSymbolicLinks: false,
       });

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -618,7 +618,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const results: Record<string, Array<[number, string]>> = {};
     const stat = await fs.stat(baseFull);
     const root = stat.isDirectory() ? baseFull : path.dirname(baseFull);
-    
+
     // Use fast-glob for pattern matching
     const files = await fg("**/*", {
       cwd: root,

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -619,10 +619,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const stat = await fs.stat(baseFull);
     const root = stat.isDirectory() ? baseFull : path.dirname(baseFull);
 
-    // Use fast-glob to recursively find all files. `followSymbolicLinks: false`
-    // prevents descending into symlinked directories: fast-glob follows links
-    // by default, so a self-referential directory symlink (e.g. `sub/sub -> .`)
-    // would be walked recursively until the OS throws ELOOP.
+    // Use fast-glob to recursively find all files
     const files = await fg("**/*", {
       cwd: root,
       absolute: true,

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -619,11 +619,15 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const stat = await fs.stat(baseFull);
     const root = stat.isDirectory() ? baseFull : path.dirname(baseFull);
 
-    // Use fast-glob for pattern matching
+    // `onlyFiles: true` with `followSymbolicLinks: false` drops symlink entries
+    // at enumeration, so we never `readFile` a symlink target (which would
+    // bypass the O_NOFOLLOW protection used by read()/write()/edit() and escape
+    // the search root). This matches ripgrep's default no-follow behavior, so
+    // the fallback and primary grep paths return the same files.
     const files = await fg("**/*", {
       cwd: root,
       absolute: true,
-      onlyFiles: false,
+      onlyFiles: true,
       dot: true,
       followSymbolicLinks: false,
     });
@@ -644,12 +648,8 @@ export class FilesystemBackend implements BackendProtocolV2 {
           continue;
         }
 
-        // Check file size. `fs.stat` follows symlinks, so a symlink-to-file is
-        // searched while directories (real or symlinked) are skipped here.
+        // Check file size
         const stat = await fs.stat(fp);
-        if (!stat.isFile()) {
-          continue;
-        }
         if (stat.size > this.maxFileSizeBytes) {
           continue;
         }

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -618,12 +618,8 @@ export class FilesystemBackend implements BackendProtocolV2 {
     const results: Record<string, Array<[number, string]>> = {};
     const stat = await fs.stat(baseFull);
     const root = stat.isDirectory() ? baseFull : path.dirname(baseFull);
-
-    // `followSymbolicLinks: false` avoids ELOOP on self-referential directory
-    // symlinks. `onlyFiles: false` keeps symlinks-to-files in the results
-    // (fast-glob's `onlyFiles` filter uses lstat and would drop them); the
-    // `stat().isFile()` guard in the loop follows each link and skips anything
-    // that is not a regular file.
+    
+    // Use fast-glob for pattern matching
     const files = await fg("**/*", {
       cwd: root,
       absolute: true,

--- a/libs/deepagents/src/backends/local-shell.test.ts
+++ b/libs/deepagents/src/backends/local-shell.test.ts
@@ -434,20 +434,35 @@ describe("LocalShellBackend symlink cycle handling", () => {
     "glob does not descend into a directory symlink cycle",
     async () => {
       await fs.mkdir(path.join(tmpDir, "sub"), { recursive: true });
+      await fs.writeFile(path.join(tmpDir, "real.txt"), "x", "utf-8");
       await fs.writeFile(path.join(tmpDir, "sub", "inner.txt"), "x", "utf-8");
+      // symlink -> file (must be reported as a file)
+      await fs.symlink(
+        path.join(tmpDir, "real.txt"),
+        path.join(tmpDir, "alias.txt"),
+      );
+      // symlink -> dir (must be listed as a directory, but not descended into)
+      await fs.symlink(path.join(tmpDir, "sub"), path.join(tmpDir, "linkdir"));
+      // self-referential cycle (must not be descended into)
       await fs.symlink(".", path.join(tmpDir, "sub", "sub"));
 
       const backend = new LocalShellBackend({ rootDir: tmpDir });
       const result = await backend.glob("**/*", tmpDir);
 
       expect(result.error).toBeUndefined();
+      const files = result.files!;
+      const filePaths = files.filter((f) => !f.is_dir).map((f) => f.path);
+      const dirPaths = files.filter((f) => f.is_dir).map((f) => f.path);
 
-      const filePaths = result
-        .files!.filter((f) => !f.is_dir)
-        .map((f) => f.path);
-
+      // Real files and the symlink-to-file are all reported as files.
+      expect(filePaths.some((p) => p.endsWith("real.txt"))).toBe(true);
       expect(filePaths.some((p) => p.endsWith("inner.txt"))).toBe(true);
-      expect(filePaths.some((p) => /sub[\\/]sub/.test(p))).toBe(false);
+      expect(filePaths.some((p) => p.endsWith("alias.txt"))).toBe(true);
+      // The symlinked directory is listed...
+      expect(dirPaths.some((p) => p.endsWith("linkdir"))).toBe(true);
+      // ...but nothing is reached *through* it or through the cycle.
+      expect(filePaths.some((p) => /linkdir[\\/]/.test(p))).toBe(false);
+      expect(filePaths.some((p) => /sub[\\/]sub[\\/]/.test(p))).toBe(false);
     },
   );
 });

--- a/libs/deepagents/src/backends/local-shell.test.ts
+++ b/libs/deepagents/src/backends/local-shell.test.ts
@@ -400,3 +400,54 @@ describe("LocalShellBackend", () => {
     });
   });
 });
+
+/**
+ * Returns true when the platform lets an unprivileged process create symlinks
+ */
+function symlinksSupported(): boolean {
+  const probe = fsSync.mkdtempSync(
+    path.join(os.tmpdir(), "deepagents-symlink-probe-"),
+  );
+  try {
+    fsSync.symlinkSync("target", path.join(probe, "link"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(probe, { recursive: true, force: true });
+  }
+}
+const CAN_SYMLINK = symlinksSupported();
+
+describe("LocalShellBackend symlink cycle handling", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(async () => {
+    await removeDir(tmpDir);
+  });
+
+  it.skipIf(!CAN_SYMLINK)(
+    "glob does not descend into a directory symlink cycle",
+    async () => {
+      await fs.mkdir(path.join(tmpDir, "sub"), { recursive: true });
+      await fs.writeFile(path.join(tmpDir, "sub", "inner.txt"), "x", "utf-8");
+      await fs.symlink(".", path.join(tmpDir, "sub", "sub"));
+
+      const backend = new LocalShellBackend({ rootDir: tmpDir });
+      const result = await backend.glob("**/*", tmpDir);
+
+      expect(result.error).toBeUndefined();
+
+      const filePaths = result
+        .files!.filter((f) => !f.is_dir)
+        .map((f) => f.path);
+
+      expect(filePaths.some((p) => p.endsWith("inner.txt"))).toBe(true);
+      expect(filePaths.some((p) => /sub[\\/]sub/.test(p))).toBe(false);
+    },
+  );
+});

--- a/libs/deepagents/src/backends/local-shell.ts
+++ b/libs/deepagents/src/backends/local-shell.ts
@@ -302,7 +302,12 @@ export class LocalShellBackend
 
     const formatPath = (rel: string) => (this.virtualMode ? `/${rel}` : rel);
 
-    const globOpts = { cwd: resolvedSearchPath, absolute: false, dot: true };
+    const globOpts = {
+      cwd: resolvedSearchPath,
+      absolute: false,
+      dot: true,
+      followSymbolicLinks: false,
+    };
     const [fileMatches, dirMatches] = await Promise.all([
       fg(pattern, { ...globOpts, onlyFiles: true }),
       fg(pattern, { ...globOpts, onlyDirectories: true }),

--- a/libs/deepagents/src/backends/local-shell.ts
+++ b/libs/deepagents/src/backends/local-shell.ts
@@ -302,18 +302,21 @@ export class LocalShellBackend
 
     const formatPath = (rel: string) => (this.virtualMode ? `/${rel}` : rel);
 
-    const globOpts = {
+    // `followSymbolicLinks: false` avoids ELOOP on self-referential directory
+    // symlinks. A single `onlyFiles: false` pass returns files, directories,
+    // and symlink entries without descending into symlinked dirs; `fs.stat`
+    // below follows each entry to classify it by its target, so symlinks-to-
+    // files are reported as files and symlinks-to-dirs as directories — matching
+    // the pre-fix behavior while no longer walking cycles.
+    const matches = await fg(pattern, {
       cwd: resolvedSearchPath,
       absolute: false,
       dot: true,
+      onlyFiles: false,
       followSymbolicLinks: false,
-    };
-    const [fileMatches, dirMatches] = await Promise.all([
-      fg(pattern, { ...globOpts, onlyFiles: true }),
-      fg(pattern, { ...globOpts, onlyDirectories: true }),
-    ]);
+    });
 
-    const statFile = async (match: string): Promise<FileInfo | null> => {
+    const classify = async (match: string): Promise<FileInfo | null> => {
       try {
         const entryStat = await fs.stat(path.join(resolvedSearchPath, match));
         if (entryStat.isFile()) {
@@ -324,15 +327,6 @@ export class LocalShellBackend
             modified_at: entryStat.mtime.toISOString(),
           };
         }
-      } catch {
-        /* skip unstatable entries */
-      }
-      return null;
-    };
-
-    const statDir = async (match: string): Promise<FileInfo | null> => {
-      try {
-        const entryStat = await fs.stat(path.join(resolvedSearchPath, match));
         if (entryStat.isDirectory()) {
           return {
             path: formatPath(match),
@@ -342,19 +336,13 @@ export class LocalShellBackend
           };
         }
       } catch {
-        /* skip unstatable entries */
+        /* skip unstatable entries (e.g. broken symlinks) */
       }
       return null;
     };
 
-    const [fileInfos, dirInfos] = await Promise.all([
-      Promise.all(fileMatches.map(statFile)),
-      Promise.all(dirMatches.map(statDir)),
-    ]);
-
-    const results = [...fileInfos, ...dirInfos].filter(
-      (info): info is FileInfo => info !== null,
-    );
+    const infos = await Promise.all(matches.map(classify));
+    const results = infos.filter((info): info is FileInfo => info !== null);
     results.sort((a, b) => a.path.localeCompare(b.path));
     return { files: results };
   }

--- a/libs/deepagents/src/backends/local-shell.ts
+++ b/libs/deepagents/src/backends/local-shell.ts
@@ -302,12 +302,6 @@ export class LocalShellBackend
 
     const formatPath = (rel: string) => (this.virtualMode ? `/${rel}` : rel);
 
-    // `followSymbolicLinks: false` avoids ELOOP on self-referential directory
-    // symlinks. A single `onlyFiles: false` pass returns files, directories,
-    // and symlink entries without descending into symlinked dirs; `fs.stat`
-    // below follows each entry to classify it by its target, so symlinks-to-
-    // files are reported as files and symlinks-to-dirs as directories — matching
-    // the pre-fix behavior while no longer walking cycles.
     const matches = await fg(pattern, {
       cwd: resolvedSearchPath,
       absolute: false,


### PR DESCRIPTION
### Summary

`fast-glob` follows symbolic links by default so the `glob`/`grep` tools in `FilesystemBackend` and `LocalShellBackend` walked directory symlink cycles recursively causing `ELOOP` crashes. and aborted the run over a target repo.

This PR fixes by adding`followSymbolicLinks: false` to all four `fast-glob` calls. Bonus: this keeps traversal inside the search root.

### Tests
Unit tests in `filesystem.test.ts` and `local-shell.test.ts` verifying that a `sub/sub -> .` cycle now traverses cleanly without traversing symlinks.

This is an upstream fix for: https://github.com/langchain-ai/openwiki/issues/72