### PR TITLE
feat(deepagents): allow write_file to overwrite files

### DIFF
--- a/.changeset/node-vfs-write-overwrite.md
+++ b/.changeset/node-vfs-write-overwrite.md
@@ -1,0 +1,5 @@
+---
+"@langchain/node-vfs": patch
+---
+
+fix: allow `VfsBackend.write` to overwrite existing files while continuing to reject symlinks

--- a/.changeset/sandbox-standard-tests-write-overwrite.md
+++ b/.changeset/sandbox-standard-tests-write-overwrite.md
@@ -1,5 +1,0 @@
----
-"@langchain/sandbox-standard-tests": minor
----
-
-feat: require sandbox providers to replace an existing file's contents when `write()` is called

--- a/.changeset/sandbox-standard-tests-write-overwrite.md
+++ b/.changeset/sandbox-standard-tests-write-overwrite.md
@@ -1,0 +1,5 @@
+---
+"@langchain/sandbox-standard-tests": minor
+---
+
+feat: require sandbox providers to replace an existing file's contents when `write()` is called

--- a/.changeset/write-file-overwrites.md
+++ b/.changeset/write-file-overwrites.md
@@ -1,0 +1,5 @@
+---
+"deepagents": minor
+---
+
+feat(filesystem): allow write_file to overwrite existing files

--- a/.changeset/write-file-overwrites.md
+++ b/.changeset/write-file-overwrites.md
@@ -2,4 +2,4 @@
 "deepagents": minor
 ---
 
-feat(filesystem): allow write_file to overwrite existing files
+feat(filesystem): allow `write_file` to create missing files or completely replace existing files

--- a/evals/files/index.ts
+++ b/evals/files/index.ts
@@ -40,6 +40,12 @@ export function filesSuite(runner: EvalRunner): void {
         initialFiles: { "/note.md": "old content\n" },
       });
 
+      expect(result).toHaveAgentSteps(2);
+      expect(result).toHaveToolCallRequests(1);
+      expect(result).toHaveToolCallInStep(1, {
+        name: "write_file",
+        argsContains: { file_path: "/note.md", content: "new content" },
+      });
       expect(result.files["/note.md"]).toBe("new content");
       expect(result).toHaveFinalTextContaining("DONE");
       ls.logFeedback({
@@ -62,6 +68,12 @@ export function filesSuite(runner: EvalRunner): void {
         initialFiles: { "/log.txt": "stale line\n" },
       });
 
+      expect(result).toHaveAgentSteps(2);
+      expect(result).toHaveToolCallRequests(1);
+      expect(result).toHaveToolCallInStep(1, {
+        name: "write_file",
+        argsContains: { file_path: "/log.txt", content: "fresh line" },
+      });
       expect(result.files["/log.txt"]).toContain("fresh line");
       expect(result.files["/log.txt"]).not.toContain("stale");
       expect(result).toHaveFinalTextContaining("DONE");
@@ -85,6 +97,16 @@ export function filesSuite(runner: EvalRunner): void {
         initialFiles: { "/note.md": "cat dog bird\n" },
       });
 
+      expect(result).toHaveAgentSteps(2);
+      expect(result).toHaveToolCallRequests(1);
+      expect(result).toHaveToolCallInStep(1, {
+        name: "edit_file",
+        argsContains: {
+          file_path: "/note.md",
+          old_string: "cat",
+          new_string: "lion",
+        },
+      });
       expect(result.files["/note.md"]).toBe("lion dog bird\n");
       expect(result.files["/note.md"]).not.toContain("cat");
       expect(result).toHaveFinalTextContaining("DONE");

--- a/evals/files/index.ts
+++ b/evals/files/index.ts
@@ -27,6 +27,75 @@ export function filesSuite(runner: EvalRunner): void {
   );
 
   ls.test(
+    "write file overwrites existing",
+    {
+      inputs: {
+        query:
+          'Rewrite /note.md so it contains only "new content". Reply with DONE only.',
+      },
+    },
+    async ({ inputs }) => {
+      const result = await runner.run({
+        query: inputs.query,
+        initialFiles: { "/note.md": "old content\n" },
+      });
+
+      expect(result.files["/note.md"]).toBe("new content");
+      expect(result).toHaveFinalTextContaining("DONE");
+      ls.logFeedback({
+        key: "agent_steps",
+        score: result.steps.length,
+      });
+    },
+  );
+
+  ls.test(
+    "write file overwrite drops old content",
+    {
+      inputs: {
+        query: 'Write "fresh line" to /log.txt. Reply with DONE only.',
+      },
+    },
+    async ({ inputs }) => {
+      const result = await runner.run({
+        query: inputs.query,
+        initialFiles: { "/log.txt": "stale line\n" },
+      });
+
+      expect(result.files["/log.txt"]).toContain("fresh line");
+      expect(result.files["/log.txt"]).not.toContain("stale");
+      expect(result).toHaveFinalTextContaining("DONE");
+      ls.logFeedback({
+        key: "agent_steps",
+        score: result.steps.length,
+      });
+    },
+  );
+
+  ls.test(
+    "write file prefers edit for targeted change",
+    {
+      inputs: {
+        query: "In /note.md, replace 'cat' with 'lion'. Reply with DONE only.",
+      },
+    },
+    async ({ inputs }) => {
+      const result = await runner.run({
+        query: inputs.query,
+        initialFiles: { "/note.md": "cat dog bird\n" },
+      });
+
+      expect(result.files["/note.md"]).toBe("lion dog bird\n");
+      expect(result.files["/note.md"]).not.toContain("cat");
+      expect(result).toHaveFinalTextContaining("DONE");
+      ls.logFeedback({
+        key: "agent_steps",
+        score: result.steps.length,
+      });
+    },
+  );
+
+  ls.test(
     "write file simple",
     {
       inputs: {

--- a/examples/sandbox/daytona-sandbox.ts
+++ b/examples/sandbox/daytona-sandbox.ts
@@ -57,7 +57,7 @@ You can execute shell commands to:
 - **execute**: Run any shell command and see the output
 - **ls**: List directory contents
 - **read_file**: Read file contents
-- **write_file**: Create new files
+- **write_file**: Create or fully replace files
 - **edit_file**: Modify existing files
 - **grep**: Search for patterns in files
 - **glob**: Find files matching patterns
@@ -68,7 +68,7 @@ You can execute shell commands to:
 2. Use the right tool for the job:
    - Use \`execute\` for complex commands, pipelines, and running programs
    - Use \`read_file\` for viewing file contents
-   - Use \`write_file\` for creating new files
+   - Use \`write_file\` for creating new files or replacing an entire file
 3. Chain commands when needed: \`execute("npm install && npm run build")\`
 4. Check exit codes to verify success
 

--- a/examples/sandbox/deno-sandbox.ts
+++ b/examples/sandbox/deno-sandbox.ts
@@ -57,7 +57,7 @@ You can execute shell commands to:
 - **execute**: Run any shell command and see the output
 - **ls**: List directory contents
 - **read_file**: Read file contents
-- **write_file**: Create new files
+- **write_file**: Create or fully replace files
 - **edit_file**: Modify existing files
 - **grep**: Search for patterns in files
 - **glob**: Find files matching patterns
@@ -68,7 +68,7 @@ You can execute shell commands to:
 2. Use the right tool for the job:
    - Use \`execute\` for complex commands, pipelines, and running programs
    - Use \`read_file\` for viewing file contents
-   - Use \`write_file\` for creating new files
+   - Use \`write_file\` for creating new files or replacing an entire file
 3. Chain commands when needed: \`execute("deno install && deno run build.ts")\`
 4. Check exit codes to verify success
 

--- a/examples/sandbox/langsmith-sandbox.ts
+++ b/examples/sandbox/langsmith-sandbox.ts
@@ -48,7 +48,7 @@ You can execute shell commands to:
 - **execute**: Run any shell command and see the output
 - **ls**: List directory contents
 - **read_file**: Read file contents
-- **write_file**: Create new files
+- **write_file**: Create or fully replace files
 - **edit_file**: Modify existing files
 - **grep**: Search for patterns in files
 - **glob**: Find files matching patterns

--- a/examples/sandbox/local-sandbox.ts
+++ b/examples/sandbox/local-sandbox.ts
@@ -235,7 +235,7 @@ You can execute shell commands to:
 - **execute**: Run any shell command and see the output
 - **ls**: List directory contents
 - **read_file**: Read file contents
-- **write_file**: Create new files
+- **write_file**: Create or fully replace files
 - **edit_file**: Modify existing files
 - **grep**: Search for patterns in files
 - **glob**: Find files matching patterns
@@ -246,7 +246,7 @@ You can execute shell commands to:
 2. Use the right tool for the job:
    - Use \`execute\` for complex commands, pipelines, and running programs
    - Use \`read_file\` for viewing file contents
-   - Use \`write_file\` for creating new files
+   - Use \`write_file\` for creating new files or replacing an entire file
 3. Chain commands when needed: \`execute("npm install && npm test")\`
 4. Check exit codes to verify success
 

--- a/examples/sandbox/modal-sandbox.ts
+++ b/examples/sandbox/modal-sandbox.ts
@@ -58,7 +58,7 @@ You can execute shell commands to:
 - **execute**: Run any shell command and see the output
 - **ls**: List directory contents
 - **read_file**: Read file contents
-- **write_file**: Create new files
+- **write_file**: Create or fully replace files
 - **edit_file**: Modify existing files
 - **grep**: Search for patterns in files
 - **glob**: Find files matching patterns
@@ -69,7 +69,7 @@ You can execute shell commands to:
 2. Use the right tool for the job:
    - Use \`execute\` for complex commands, pipelines, and running programs
    - Use \`read_file\` for viewing file contents
-   - Use \`write_file\` for creating new files
+   - Use \`write_file\` for creating new files or replacing an entire file
 3. Chain commands when needed: \`execute("npm install && npm run build")\`
 4. Check exit codes to verify success
 

--- a/examples/sandbox/vfs-backend.ts
+++ b/examples/sandbox/vfs-backend.ts
@@ -43,7 +43,7 @@ You can inspect and modify files safely inside this virtual workspace.
 
 - **ls**: List directory contents
 - **read_file**: Read file contents
-- **write_file**: Create new files
+- **write_file**: Create or fully replace files
 - **edit_file**: Modify existing files
 - **grep**: Search for patterns in files
 - **glob**: Find files matching patterns
@@ -53,7 +53,7 @@ You can inspect and modify files safely inside this virtual workspace.
 1. Start by exploring the workspace: \`ls\`
 2. Use the right tool for the job:
    - Use \`read_file\` for viewing file contents
-   - Use \`write_file\` for creating new files
+   - Use \`write_file\` for creating new files or replacing an entire file
 3. Prefer focused file edits and verification steps
 
 You're working in an isolated in-memory file system, so feel free to experiment.

--- a/libs/deepagents/src/backends/composite.ts
+++ b/libs/deepagents/src/backends/composite.ts
@@ -342,7 +342,7 @@ export class CompositeBackend implements BackendProtocolV2 {
   }
 
   /**
-   * Create a new file, routing to appropriate backend.
+   * Write content to a file, routing to appropriate backend.
    *
    * @param filePath - Absolute file path
    * @param content - File content as string

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -86,6 +86,21 @@ describe("FilesystemBackend", () => {
     expect(globResults.files!.some((i) => i.path === f2)).toBe(true);
   });
 
+  it("should overwrite existing files in normal mode", async () => {
+    const root = tmpDir;
+    const filePath = path.join(root, "existing.txt");
+    await writeFile(filePath, "old content");
+
+    const backend = new FilesystemBackend({
+      rootDir: root,
+      virtualMode: false,
+    });
+
+    const result = await backend.write(filePath, "new content");
+    expect(result.error).toBeUndefined();
+    expect(await fs.readFile(filePath, "utf-8")).toBe("new content");
+  });
+
   it("should work in virtual mode with sandboxed paths", async () => {
     const root = tmpDir;
     const f1 = path.join(root, "a.txt");
@@ -133,6 +148,22 @@ describe("FilesystemBackend", () => {
     const traversalError = await backend.read("/../a.txt");
     expect(traversalError.error).toBeDefined();
     expect(traversalError.error).toContain("Path traversal not allowed");
+  });
+
+  it("should overwrite existing files in virtual mode", async () => {
+    const root = tmpDir;
+    await writeFile(path.join(root, "existing.txt"), "old content");
+
+    const backend = new FilesystemBackend({
+      rootDir: root,
+      virtualMode: true,
+    });
+
+    const result = await backend.write("/existing.txt", "new content");
+    expect(result.error).toBeUndefined();
+    expect(await fs.readFile(path.join(root, "existing.txt"), "utf-8")).toBe(
+      "new content",
+    );
   });
 
   it("should list nested directories correctly in virtual mode", async () => {
@@ -411,6 +442,11 @@ describe("FilesystemBackend", () => {
 
     const readResult = await backend.read(symlinkFile);
     expect(readResult.error).toBeDefined();
+
+    const writeResult = await backend.write(symlinkFile, "replacement");
+    expect(writeResult.error).toBeDefined();
+    expect(writeResult.error).toContain("symlink");
+    expect(await fs.readFile(targetFile, "utf-8")).toBe("target content");
   });
 
   describe("binary file handling", () => {

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -335,7 +335,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
   }
 
   /**
-   * Create a new file with content.
+   * Write content to a file, creating it or overwriting it if it already exists.
    * Returns WriteResult. External storage sets filesUpdate=null.
    */
   async write(filePath: string, content: string): Promise<WriteResult> {
@@ -352,9 +352,6 @@ export class FilesystemBackend implements BackendProtocolV2 {
             error: `Cannot write to ${filePath} because it is a symlink. Symlinks are not allowed.`,
           };
         }
-        return {
-          error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`,
-        };
       } catch {
         // File doesn't exist, good to proceed
       }

--- a/libs/deepagents/src/backends/langsmith.test.ts
+++ b/libs/deepagents/src/backends/langsmith.test.ts
@@ -546,14 +546,15 @@ describe("LangSmithSandbox", () => {
       expect(cmd).toContain("find");
     });
 
-    it("write() delegates to uploadFiles() (not execute)", async () => {
+    it("write() uploads replacements without a download preflight", async () => {
       const sandbox = makeSandbox();
-      // write() first checks if file exists via downloadFiles, then uploads
-      // For a non-existent file: downloadFiles returns file_not_found, then uploadFiles is called
-      mockRead.mockRejectedValue(new MockLangSmithResourceNotFoundError());
+      // write() uploads directly, so replacing an existing path requires no download.
+
       mockWrite.mockResolvedValue(undefined);
 
-      await sandbox.write("/tmp/new.txt", "content");
+      await sandbox.write("/tmp/existing.txt", "replacement");
+
+      expect(mockRead).not.toHaveBeenCalled();
 
       expect(mockWrite).toHaveBeenCalledOnce();
       expect(mockRun).not.toHaveBeenCalled();

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -313,13 +313,13 @@ describe("BaseSandbox", () => {
       expect(sandbox.executedCommands.length).toBe(0);
     });
 
-    it("should return error if file already exists", async () => {
+    it("should overwrite existing files", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/existing.txt", "old content");
 
-      const result = await sandbox.write("/existing.txt", "content");
-      expect(result.error).toBeDefined();
-      expect(result.error).toContain("already exists");
+      const result = await sandbox.write("/existing.txt", "new content");
+      expect(result.error).toBeUndefined();
+      expect(sandbox.getFile("/existing.txt")).toBe("new content");
     });
 
     describe("binary files", () => {

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -506,24 +506,11 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
   }
 
   /**
-   * Create a new file with content.
+   * Write content to a file, creating it or overwriting it if it already exists.
    *
-   * Uses downloadFiles() to check existence and uploadFiles() to write.
-   * No runtime needed on the sandbox host.
+   * Uses uploadFiles() to write. No runtime needed on the sandbox host.
    */
   async write(filePath: string, content: string): Promise<WriteResult> {
-    // Check if file already exists
-    try {
-      const existCheck = await this.downloadFiles([filePath]);
-      if (existCheck[0].content !== null && existCheck[0].error === null) {
-        return {
-          error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`,
-        };
-      }
-    } catch {
-      // File doesn't exist, which is what we want for write
-    }
-
     const mimeType = getMimeType(filePath);
     let fileContent: Uint8Array;
 

--- a/libs/deepagents/src/backends/state.test.ts
+++ b/libs/deepagents/src/backends/state.test.ts
@@ -130,6 +130,21 @@ describe("StateBackend", () => {
     expect(readRes.content).toBe("y");
   });
 
+  it("should honor v1 format for binary-path writes", () => {
+    const { state, runtime } = makeConfig();
+    const backend = new StateBackend(runtime, { fileFormat: "v1" });
+    const content = "AQID";
+
+    const result = backend.write("/image.png", content);
+
+    expect(result.error).toBeUndefined();
+    Object.assign(state.files, result.filesUpdate);
+    const raw = backend.readRaw("/image.png");
+    expect(raw.data).toBeDefined();
+    expect(raw.data!.content).toEqual([content]);
+    expect("mimeType" in raw.data!).toBe(false);
+  });
+
   it("should overwrite existing binary files with decoded bytes", () => {
     const oldBytes = new Uint8Array([1, 2, 3]);
     const newBytes = new Uint8Array([4, 5, 6]);

--- a/libs/deepagents/src/backends/state.test.ts
+++ b/libs/deepagents/src/backends/state.test.ts
@@ -130,6 +130,32 @@ describe("StateBackend", () => {
     expect(readRes.content).toBe("y");
   });
 
+  it("should overwrite existing binary files with decoded bytes", () => {
+    const oldBytes = new Uint8Array([1, 2, 3]);
+    const newBytes = new Uint8Array([4, 5, 6]);
+    const { state, runtime } = makeConfig({
+      "/image.png": {
+        content: oldBytes,
+        mimeType: "image/png",
+        created_at: "2024-01-01T00:00:00.000Z",
+        modified_at: "2024-01-01T00:00:00.000Z",
+      },
+    });
+    const backend = new StateBackend(runtime);
+
+    const result = backend.write(
+      "/image.png",
+      Buffer.from(newBytes).toString("base64"),
+    );
+
+    expect(result.error).toBeUndefined();
+    Object.assign(state.files, result.filesUpdate);
+    const raw = backend.readRaw("/image.png");
+    expect(raw.data).toBeDefined();
+    expect(raw.data!.content).toEqual(newBytes);
+    expect(raw.data!.created_at).toBe("2024-01-01T00:00:00.000Z");
+  });
+
   it("should list nested directories correctly", () => {
     const { state, runtime } = makeConfig();
     const backend = new StateBackend(runtime);

--- a/libs/deepagents/src/backends/state.test.ts
+++ b/libs/deepagents/src/backends/state.test.ts
@@ -121,9 +121,13 @@ describe("StateBackend", () => {
     expect(writeRes.filesUpdate).toBeDefined();
     Object.assign(state.files, writeRes.filesUpdate);
 
-    const dupErr = backend.write("/dup.txt", "y");
-    expect(dupErr.error).toBeDefined();
-    expect(dupErr.error).toContain("already exists");
+    const overwriteRes = backend.write("/dup.txt", "y");
+    expect(overwriteRes.error).toBeUndefined();
+    expect(overwriteRes.filesUpdate).toBeDefined();
+    Object.assign(state.files, overwriteRes.filesUpdate);
+
+    const readRes = backend.read("/dup.txt");
+    expect(readRes.content).toBe("y");
   });
 
   it("should list nested directories correctly", () => {

--- a/libs/deepagents/src/backends/state.ts
+++ b/libs/deepagents/src/backends/state.ts
@@ -247,25 +247,17 @@ export class StateBackend implements BackendProtocolV2 {
   }
 
   /**
-   * Create a new file with content.
+   * Write content to a file, creating it or overwriting it if it already exists.
    * Returns WriteResult with filesUpdate to update LangGraph state.
    */
   write(filePath: string, content: string): WriteResult {
     const files = this.files;
-
-    if (filePath in files) {
-      return {
-        error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`,
-      };
-    }
+    const existing = files[filePath];
 
     const mimeType = getMimeType(filePath);
-    const newFileData = createFileData(
-      content,
-      undefined,
-      this.fileFormat,
-      mimeType,
-    );
+    const newFileData = existing
+      ? updateFileData(existing, content)
+      : createFileData(content, undefined, this.fileFormat, mimeType);
 
     const update = { [filePath]: newFileData };
 

--- a/libs/deepagents/src/backends/state.ts
+++ b/libs/deepagents/src/backends/state.ts
@@ -20,6 +20,7 @@ import type {
 } from "./protocol.js";
 import {
   createFileData,
+  createWriteFileData,
   fileDataToString,
   getMimeType,
   globSearchFiles,
@@ -254,10 +255,12 @@ export class StateBackend implements BackendProtocolV2 {
     const files = this.files;
     const existing = files[filePath];
 
-    const mimeType = getMimeType(filePath);
-    const newFileData = existing
-      ? updateFileData(existing, content)
-      : createFileData(content, undefined, this.fileFormat, mimeType);
+    const newFileData = createWriteFileData(
+      filePath,
+      content,
+      this.fileFormat,
+      existing,
+    );
 
     const update = { [filePath]: newFileData };
 

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -180,6 +180,20 @@ describe("StoreBackend", () => {
     expect(readRes.content).toBe("y");
   });
 
+  it("should honor v1 format for binary-path writes", async () => {
+    const { runtime } = makeConfig();
+    const backend = new StoreBackend(runtime, { fileFormat: "v1" });
+    const content = "AQID";
+
+    const result = await backend.write("/image.png", content);
+
+    expect(result.error).toBeUndefined();
+    const raw = await backend.readRaw("/image.png");
+    expect(raw.data).toBeDefined();
+    expect(raw.data!.content).toEqual([content]);
+    expect("mimeType" in raw.data!).toBe(false);
+  });
+
   it("should overwrite existing binary files with decoded bytes", async () => {
     const { runtime } = makeConfig();
     const backend = new StoreBackend(runtime);

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -180,6 +180,36 @@ describe("StoreBackend", () => {
     expect(readRes.content).toBe("y");
   });
 
+  it("should overwrite existing binary files with decoded bytes", async () => {
+    const { runtime } = makeConfig();
+    const backend = new StoreBackend(runtime);
+    const oldBytes = new Uint8Array([1, 2, 3]);
+    const newBytes = new Uint8Array([4, 5, 6]);
+
+    await backend.write("/image.png", Buffer.from(oldBytes).toString("base64"));
+    const result = await backend.write(
+      "/image.png",
+      Buffer.from(newBytes).toString("base64"),
+    );
+
+    expect(result.error).toBeUndefined();
+    const raw = await backend.readRaw("/image.png");
+    expect(raw.data).toBeDefined();
+    expect(raw.data!.content).toEqual(newBytes);
+  });
+
+  it("should replace malformed existing store values", async () => {
+    const { runtime, store } = makeConfig();
+    const backend = new StoreBackend(runtime);
+    await store.put(["filesystem"], "/bad.txt", { unexpected: "shape" });
+
+    const result = await backend.write("/bad.txt", "replacement");
+
+    expect(result.error).toBeUndefined();
+    const readRes = await backend.read("/bad.txt");
+    expect(readRes.content).toBe("replacement");
+  });
+
   it("should handle read with offset and limit", async () => {
     const { runtime } = makeConfig();
     const backend = new StoreBackend(runtime);

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -173,9 +173,11 @@ describe("StoreBackend", () => {
     const writeRes = await backend.write("/dup.txt", "x");
     expect(writeRes.error).toBeUndefined();
 
-    const dupErr = await backend.write("/dup.txt", "y");
-    expect(dupErr.error).toBeDefined();
-    expect(dupErr.error).toContain("already exists");
+    const overwriteRes = await backend.write("/dup.txt", "y");
+    expect(overwriteRes.error).toBeUndefined();
+
+    const readRes = await backend.read("/dup.txt");
+    expect(readRes.content).toBe("y");
   });
 
   it("should handle read with offset and limit", async () => {

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -212,16 +212,16 @@ describe("StoreBackend", () => {
     expect(raw.data!.content).toEqual(newBytes);
   });
 
-  it("should replace malformed existing store values", async () => {
+  it("should preserve conversion errors for malformed existing store values", async () => {
     const { runtime, store } = makeConfig();
     const backend = new StoreBackend(runtime);
     await store.put(["filesystem"], "/bad.txt", { unexpected: "shape" });
 
-    const result = await backend.write("/bad.txt", "replacement");
+    await expect(backend.write("/bad.txt", "replacement")).rejects.toThrow();
 
-    expect(result.error).toBeUndefined();
-    const readRes = await backend.read("/bad.txt");
-    expect(readRes.content).toBe("replacement");
+    const stored = await store.get(["filesystem"], "/bad.txt");
+
+    expect(stored?.value).toEqual({ unexpected: "shape" });
   });
 
   it("should handle read with offset and limit", async () => {

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -585,15 +585,9 @@ export class StoreBackend implements BackendProtocolV2 {
     const namespace = this.getNamespace();
 
     const existing = await store.get(namespace, filePath);
-    let existingFileData: FileData | undefined;
-    if (existing) {
-      try {
-        existingFileData = this.convertStoreItemToFileData(existing);
-      } catch {
-        // Treat invalid/corrupt existing values as replaceable.
-        existingFileData = undefined;
-      }
-    }
+    const existingFileData = existing
+      ? this.convertStoreItemToFileData(existing)
+      : undefined;
 
     const fileData = createWriteFileData(
       filePath,

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -27,6 +27,7 @@ import type {
 } from "./protocol.js";
 import {
   createFileData,
+  createWriteFileData,
   fileDataToString,
   getMimeType,
   globSearchFiles,
@@ -584,10 +585,22 @@ export class StoreBackend implements BackendProtocolV2 {
     const namespace = this.getNamespace();
 
     const existing = await store.get(namespace, filePath);
-    const mimeType = getMimeType(filePath);
-    const fileData = existing
-      ? updateFileData(this.convertStoreItemToFileData(existing), content)
-      : createFileData(content, undefined, this.fileFormat, mimeType);
+    let existingFileData: FileData | undefined;
+    if (existing) {
+      try {
+        existingFileData = this.convertStoreItemToFileData(existing);
+      } catch {
+        // Treat invalid/corrupt existing values as replaceable.
+        existingFileData = undefined;
+      }
+    }
+
+    const fileData = createWriteFileData(
+      filePath,
+      content,
+      this.fileFormat,
+      existingFileData,
+    );
     const storeValue = this.convertFileDataToStoreValue(fileData);
     await store.put(namespace, filePath, storeValue);
     return { path: filePath, filesUpdate: null };

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -576,29 +576,18 @@ export class StoreBackend implements BackendProtocolV2 {
   }
 
   /**
-   * Create a new file with content.
+   * Write content to a file, creating it or overwriting it if it already exists.
    * Returns WriteResult. External storage sets filesUpdate=null.
    */
   async write(filePath: string, content: string): Promise<WriteResult> {
     const store = this.getStore();
     const namespace = this.getNamespace();
 
-    // Check if file exists
     const existing = await store.get(namespace, filePath);
-    if (existing) {
-      return {
-        error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`,
-      };
-    }
-
-    // Create new file
     const mimeType = getMimeType(filePath);
-    const fileData = createFileData(
-      content,
-      undefined,
-      this.fileFormat,
-      mimeType,
-    );
+    const fileData = existing
+      ? updateFileData(this.convertStoreItemToFileData(existing), content)
+      : createFileData(content, undefined, this.fileFormat, mimeType);
     const storeValue = this.convertFileDataToStoreValue(fileData);
     await store.put(namespace, filePath, storeValue);
     return { path: filePath, filesUpdate: null };

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -369,12 +369,14 @@ export function createWriteFileData(
   const createdAt = existing?.created_at;
 
   if (!isTextMimeType(mimeType)) {
-    return createFileData(
-      decodeBase64ToBytes(content),
-      createdAt,
-      "v2",
-      mimeType,
-    );
+    return fileFormat === "v1"
+      ? createFileData(content, createdAt, "v1", mimeType)
+      : createFileData(
+          decodeBase64ToBytes(content),
+          createdAt,
+          "v2",
+          mimeType,
+        );
   }
 
   return existing

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -341,6 +341,35 @@ export function updateFileData(fileData: FileData, content: string): FileData {
 }
 
 /**
+ * Build FileData for write semantics.
+ *
+ * Text writes preserve an existing file's creation timestamp. Binary writes
+ * accept base64 text input and store decoded bytes with the path's MIME type.
+ */
+export function createWriteFileData(
+  filePath: string,
+  content: string,
+  fileFormat: "v1" | "v2" = "v2",
+  existing?: FileData,
+): FileData {
+  const mimeType = getMimeType(filePath);
+  const createdAt = existing?.created_at;
+
+  if (!isTextMimeType(mimeType)) {
+    return createFileData(
+      new Uint8Array(Buffer.from(content, "base64")),
+      createdAt,
+      "v2",
+      mimeType,
+    );
+  }
+
+  return existing
+    ? updateFileData(existing, content)
+    : createFileData(content, undefined, fileFormat, mimeType);
+}
+
+/**
  * Format file data for read response with line numbers.
  *
  * @param fileData - FileData object

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -371,12 +371,7 @@ export function createWriteFileData(
   if (!isTextMimeType(mimeType)) {
     return fileFormat === "v1"
       ? createFileData(content, createdAt, "v1", mimeType)
-      : createFileData(
-          decodeBase64ToBytes(content),
-          createdAt,
-          "v2",
-          mimeType,
-        );
+      : createFileData(decodeBase64ToBytes(content), createdAt, "v2", mimeType);
   }
 
   return existing

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -346,6 +346,19 @@ export function updateFileData(fileData: FileData, content: string): FileData {
  * Text writes preserve an existing file's creation timestamp. Binary writes
  * accept base64 text input and store decoded bytes with the path's MIME type.
  */
+function decodeBase64ToBytes(base64: string): Uint8Array {
+  const trimmed = base64.trim();
+  const payload = trimmed.startsWith("data:")
+    ? trimmed.slice(trimmed.indexOf(",") + 1)
+    : trimmed;
+  const binary = atob(payload.replace(/\s/g, ""));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
 export function createWriteFileData(
   filePath: string,
   content: string,
@@ -357,7 +370,7 @@ export function createWriteFileData(
 
   if (!isTextMimeType(mimeType)) {
     return createFileData(
-      new Uint8Array(Buffer.from(content, "base64")),
+      decodeBase64ToBytes(content),
       createdAt,
       "v2",
       mimeType,

--- a/libs/deepagents/src/backends/v1/protocol.ts
+++ b/libs/deepagents/src/backends/v1/protocol.ts
@@ -87,7 +87,7 @@ export interface BackendProtocolV1 {
   globInfo(pattern: string, path?: string): MaybePromise<FileInfo[]>;
 
   /**
-   * Create a new file.
+   * Write content to a file, creating it or overwriting it if it already exists.
    *
    * @param filePath - Absolute file path
    * @param content - File content as string

--- a/libs/deepagents/src/backends/v2/protocol.ts
+++ b/libs/deepagents/src/backends/v2/protocol.ts
@@ -14,6 +14,7 @@ import type {
   MaybePromise,
   ReadRawResult,
   ReadResult,
+  WriteResult,
 } from "../protocol.js";
 
 /**
@@ -68,6 +69,15 @@ export interface BackendProtocolV2 extends Omit<
    * @returns ReadRawResult with raw file data on success or error on failure
    */
   readRaw(filePath: string): MaybePromise<ReadRawResult>;
+
+  /**
+   * Write content to a file, creating it or overwriting it if it already exists.
+   *
+   * @param filePath - Absolute file path
+   * @param content - File content as string
+   * @returns WriteResult with error populated on failure
+   */
+  write(filePath: string, content: string): MaybePromise<WriteResult>;
 
   /**
    * Search file contents for a literal text pattern.

--- a/libs/deepagents/src/middleware/fs.int.test.ts
+++ b/libs/deepagents/src/middleware/fs.int.test.ts
@@ -726,7 +726,9 @@ describe("Filesystem Middleware Integration Tests", () => {
       expect(writeMessage).toBeDefined();
       expect(writeMessage!.content.toString()).toContain("Successfully wrote");
       expect(writeMessage!.content.toString()).not.toContain("already exists");
-      expect(response.files?.["/existing.txt"]?.content).toContain("new content");
+      expect(response.files?.["/existing.txt"]?.content).toContain(
+        "new content",
+      );
       expect(response.files?.["/existing.txt"]?.content).not.toContain(
         "Already exists",
       );

--- a/libs/deepagents/src/middleware/fs.int.test.ts
+++ b/libs/deepagents/src/middleware/fs.int.test.ts
@@ -445,7 +445,7 @@ describe("Filesystem Middleware Integration Tests", () => {
   );
 
   it.concurrent(
-    "should fail to write to existing store file",
+    "should overwrite existing store file",
     { timeout: 90 * 1000 }, // 90s
     async () => {
       const checkpointer = new MemorySaver();
@@ -487,7 +487,15 @@ describe("Filesystem Middleware Integration Tests", () => {
       );
 
       expect(writeMessage).toBeDefined();
-      expect(writeMessage!.content.toString()).toContain("already exists");
+      expect(writeMessage!.content.toString()).toContain("Successfully wrote");
+      expect(writeMessage!.content.toString()).not.toContain("already exists");
+
+      const overwritten = await store.get(["filesystem"], "/existing.txt");
+      expect(overwritten).toBeDefined();
+      const overwrittenContent = (overwritten!.value as { content?: unknown })
+        .content;
+      expect(overwrittenContent).toContain("new data");
+      expect(overwrittenContent).not.toContain("Already exists");
     },
   );
 
@@ -675,7 +683,7 @@ describe("Filesystem Middleware Integration Tests", () => {
   );
 
   it.concurrent(
-    "should fail to write to existing local file",
+    "should overwrite existing local file",
     { timeout: 90 * 1000 }, // 90s
     async () => {
       const checkpointer = new MemorySaver();
@@ -716,7 +724,12 @@ describe("Filesystem Middleware Integration Tests", () => {
       );
 
       expect(writeMessage).toBeDefined();
-      expect(writeMessage!.content.toString()).toContain("already exists");
+      expect(writeMessage!.content.toString()).toContain("Successfully wrote");
+      expect(writeMessage!.content.toString()).not.toContain("already exists");
+      expect(response.files?.["/existing.txt"]?.content).toContain("new content");
+      expect(response.files?.["/existing.txt"]?.content).not.toContain(
+        "Already exists",
+      );
     },
   );
 

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1030,6 +1030,31 @@ describe("createFilesystemMiddleware", () => {
       expect(parsed.content).toBe("");
     });
 
+    it("write_file tool should return success for backend overwrites", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.write = vi.fn().mockResolvedValue({
+        path: "/doc.txt",
+        filesUpdate: null,
+      });
+      const middleware = createFilesystemMiddleware({ backend: mockBackend });
+
+      const writeFileTool = middleware.tools!.find(
+        (tool) => tool.name === "write_file",
+      );
+      expect(writeFileTool).toBeDefined();
+      const result = await writeFileTool!.invoke({
+        file_path: "/doc.txt",
+        content: "new content",
+      });
+
+      expect(mockBackend.write).toHaveBeenCalledWith("/doc.txt", "new content");
+      expect(ToolMessage.isInstance(result)).toBe(true);
+      if (ToolMessage.isInstance(result)) {
+        expect(result.content).toContain("Successfully wrote");
+        expect(result.content).not.toContain("already exists");
+      }
+    });
+
     it("all tool schema properties should be included in the required array", () => {
       const middleware = createFilesystemMiddleware({
         backend: () => createMockBackend(),

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1023,6 +1023,9 @@ describe("createFilesystemMiddleware", () => {
         (t: any) => t.name === "write_file",
       ) as any;
       expect(writeFileTool).toBeDefined();
+      expect(writeFileTool!.description).toContain(
+        "Creates the file if it does not exist; replaces it entirely if it does.",
+      );
 
       // Parse with only file_path, no content — simulates the model omitting it
       const parsed = writeFileTool.schema.parse({ file_path: "/app/test.c" });
@@ -1042,6 +1045,9 @@ describe("createFilesystemMiddleware", () => {
         (tool) => tool.name === "write_file",
       );
       expect(writeFileTool).toBeDefined();
+      expect(writeFileTool!.description).toContain(
+        "Creates the file if it does not exist; replaces it entirely if it does.",
+      );
       const result = await writeFileTool!.invoke({
         file_path: "/doc.txt",
         content: "new content",

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -867,7 +867,7 @@ function createWriteFileTool(
             .string()
             .default("")
             .describe(
-              "The text content to write to the file. This parameter is required.",
+              "The text content to write to the file. Defaults to empty.",
             ),
         }),
       ),

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -518,10 +518,10 @@ export const READ_FILE_TOOL_DESCRIPTION = context`
 `;
 
 export const WRITE_FILE_TOOL_DESCRIPTION = context`
-  Writes to a new file in the filesystem.
+  Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.
 
   Usage:
-  - The write_file tool will create a new file.
+  - Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.
   - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 `;
 
@@ -858,11 +858,17 @@ function createWriteFileTool(
       schema: z.preprocess(
         normalizeFilePathInput,
         z.object({
-          file_path: z.string().describe("Absolute path to the file to write"),
+          file_path: z
+            .string()
+            .describe(
+              "Absolute path where the file should be written. Must be absolute, not relative.",
+            ),
           content: z
             .string()
             .default("")
-            .describe("Content to write to the file"),
+            .describe(
+              "The text content to write to the file. This parameter is required.",
+            ),
         }),
       ),
     },

--- a/libs/providers/node-vfs/src/backend.test.ts
+++ b/libs/providers/node-vfs/src/backend.test.ts
@@ -212,7 +212,7 @@ describe("VfsBackend", () => {
       });
     });
 
-    it("should overwrite existing files", async () => {
+    it("should overwrite existing text files", async () => {
       const result = await sandbox.write("/existing.txt", "new content");
       expect(result.error).toBeUndefined();
 
@@ -222,6 +222,21 @@ describe("VfsBackend", () => {
         "new content",
       );
     });
+  });
+
+  it("should reject writes through symlinks", async () => {
+    sandbox = await VfsBackend.create();
+    sandbox.instance.writeFileSync("/workspace/target.txt", "original");
+    sandbox.instance.symlinkSync(
+      "/workspace/target.txt",
+      "/workspace/link.txt",
+    );
+
+    const result = await sandbox.write("/link.txt", "replacement");
+
+    expect(result.error).toContain("is a symlink");
+    const target = await sandbox.downloadFiles(["/target.txt"]);
+    expect(new TextDecoder().decode(target[0].content!)).toBe("original");
   });
 
   describe("readRaw", () => {

--- a/libs/providers/node-vfs/src/backend.test.ts
+++ b/libs/providers/node-vfs/src/backend.test.ts
@@ -203,6 +203,27 @@ describe("VfsBackend", () => {
     });
   });
 
+  describe("write", () => {
+    beforeEach(async () => {
+      sandbox = await VfsBackend.create({
+        initialFiles: {
+          "/existing.txt": "old content",
+        },
+      });
+    });
+
+    it("should overwrite existing files", async () => {
+      const result = await sandbox.write("/existing.txt", "new content");
+      expect(result.error).toBeUndefined();
+
+      const downloaded = await sandbox.downloadFiles(["/existing.txt"]);
+      expect(downloaded[0].error).toBeNull();
+      expect(new TextDecoder().decode(downloaded[0].content!)).toBe(
+        "new content",
+      );
+    });
+  });
+
   describe("readRaw", () => {
     beforeEach(async () => {
       sandbox = await VfsBackend.create({

--- a/libs/providers/node-vfs/src/backend.ts
+++ b/libs/providers/node-vfs/src/backend.ts
@@ -780,7 +780,7 @@ export class VfsBackend implements BackendProtocolV2 {
   }
 
   /**
-   * Create a new file with content.
+   * Write content to a file, creating it or overwriting it if it already exists.
    */
   async write(filePath: string, content: string): Promise<WriteResult> {
     this.#ensureInitialized();
@@ -791,12 +791,6 @@ export class VfsBackend implements BackendProtocolV2 {
     }
 
     try {
-      if (this.instance.existsSync(resolvedPath)) {
-        return {
-          error: `Cannot write to ${filePath} because it already exists. Read and then make an edit, or write to a new path.`,
-        };
-      }
-
       this.instance.mkdirSync(path.posix.dirname(resolvedPath), {
         recursive: true,
       });

--- a/libs/providers/node-vfs/src/backend.ts
+++ b/libs/providers/node-vfs/src/backend.ts
@@ -791,6 +791,15 @@ export class VfsBackend implements BackendProtocolV2 {
     }
 
     try {
+      if (
+        this.instance.existsSync(resolvedPath) &&
+        this.instance.lstatSync(resolvedPath).isSymbolicLink()
+      ) {
+        return {
+          error: `Cannot write to ${filePath} because it is a symlink. Symlinks are not allowed.`,
+        };
+      }
+
       this.instance.mkdirSync(path.posix.dirname(resolvedPath), {
         recursive: true,
       });

--- a/libs/standard-tests/src/sandbox.ts
+++ b/libs/standard-tests/src/sandbox.ts
@@ -17,7 +17,7 @@
  * - Sandbox lifecycle (create, isRunning, close, two-step initialization)
  * - Command execution (echo, exit codes, multiline output, stderr, env vars)
  * - File operations (upload, download, read, write, edit, multiple files)
- * - write() (new file, parent dirs, existing file, special chars, unicode, long content)
+ * - write() (new file, parent dirs, existing file overwrite, special chars, unicode, long content)
  * - read() (basic, nonexistent, offset, limit, offset+limit, unicode, chunked)
  * - edit() (single/multi occurrence, replaceAll, not found, special chars, multiline, unicode)
  * - ls() (basic listing, empty dir, hidden files, large dir, absolute paths)

--- a/libs/standard-tests/src/tests/write.ts
+++ b/libs/standard-tests/src/tests/write.ts
@@ -1,7 +1,7 @@
 import type { AnySandboxInstance, StandardTestsConfig } from "../types.js";
 
 /**
- * Register detailed write() tests (new file, parent dirs, existing file,
+ * Register detailed write() tests (new file, parent dirs, existing file overwrite,
  * special chars, empty, spaces, unicode, slashes, long content, newlines).
  */
 export function registerWriteTests<T extends AnySandboxInstance>(
@@ -51,23 +51,19 @@ export function registerWriteTests<T extends AnySandboxInstance>(
     );
 
     it(
-      "should fail when writing to an existing file",
+      "should overwrite an existing file",
       async () => {
         const shared = getShared();
         const filePath = config.resolvePath("wt-existing.txt");
 
-        // Create file first
         await shared.write(filePath, "First content");
 
-        // Try to write again
         const result = await shared.write(filePath, "Second content");
 
-        expect(result.error).toBeDefined();
-        expect(result.error!.toLowerCase()).toContain("already exists");
+        expect(result.error).toBeUndefined();
 
-        // Verify original content unchanged
         const execResult = await shared.execute(`cat ${filePath}`);
-        expect(execResult.output.trim()).toBe("First content");
+        expect(execResult.output.trim()).toBe("Second content");
       },
       timeout,
     );


### PR DESCRIPTION
## Summary

`write_file` now creates missing files and replaces existing files entirely, removing the previous create-only error path while preserving write permissions and symlink protections.

## Changes

### deepagents filesystem backends

- Updated `FilesystemBackend`, `StateBackend`, `StoreBackend`, `BaseSandbox`, and `node-vfs` write behavior to allow full-file replacement on existing paths.
- Preserved path safety and symlink protections in filesystem-backed writes.
- Removed the sandbox existence precheck so writes rely on the upload/write transport.

### Tool prompts and examples

- Aligned the `write_file` tool description and schema text with the Python SDK wording.
- Updated sandbox example prompts so `write_file` is described as creating or fully replacing files.

### Tests and evals

- Updated backend, middleware, and shared sandbox standard tests that previously expected an existing-file error.
- Added overwrite coverage for filesystem, sandbox, state, store, middleware, node-vfs, and file-operation evals.

### Release

- Added a changeset for `deepagents` documenting the new overwrite behavior.
