### PR TITLE
feat(deepagents): implement delete across backends

### DIFF
--- a/.changeset/tidy-buckets-delete.md
+++ b/.changeset/tidy-buckets-delete.md
@@ -1,7 +1,8 @@
 ---
 "deepagents": minor
+"@langchain/node-vfs": patch
 ---
 
 feat(backends): add delete protocol support
 
-Adds a `DeleteResult` type and optional backend `delete` method, preserves delete through backend protocol adaptation, and implements file deletion across the built-in state, store, filesystem, composite, context hub, and sandbox backends.
+Adds a `DeleteResult` type and optional backend `delete` method, preserves delete through backend protocol adaptation, and implements file deletion across the built-in state, store, filesystem, composite, context hub, sandbox, and node-vfs backends.

--- a/.changeset/tidy-buckets-delete.md
+++ b/.changeset/tidy-buckets-delete.md
@@ -4,4 +4,4 @@
 
 feat(backends): add delete protocol support
 
-Adds a `DeleteResult` type and optional backend `delete` method, preserves delete through backend protocol adaptation, and implements StateBackend deletion through Pregel file-state updates.
+Adds a `DeleteResult` type and optional backend `delete` method, preserves delete through backend protocol adaptation, and implements file deletion across the built-in state, store, filesystem, composite, context hub, and sandbox backends.

--- a/libs/deepagents/src/backends/composite.test.ts
+++ b/libs/deepagents/src/backends/composite.test.ts
@@ -789,6 +789,42 @@ describe("CompositeBackend", () => {
     });
   });
 
+  describe("delete", () => {
+    it("should route deletes to the correct backend and restore original paths", async () => {
+      const { runtime } = makeConfig();
+      const composite = new CompositeBackend(new StoreBackend(runtime), {
+        "/store/": new StoreBackend(runtime),
+      });
+
+      await composite.write("/local.txt", "local");
+      await composite.write("/store/remote.txt", "remote");
+
+      const localDelete = await composite.delete("/local.txt");
+      expect(localDelete.error).toBeUndefined();
+      expect(localDelete.path).toBe("/local.txt");
+      expect((await composite.read("/local.txt")).error).toContain("not found");
+
+      const routedDelete = await composite.delete("/store/remote.txt");
+      expect(routedDelete.error).toBeUndefined();
+      expect(routedDelete.path).toBe("/store/remote.txt");
+      expect((await composite.read("/store/remote.txt")).error).toContain(
+        "not found",
+      );
+    });
+
+    it("should return routed backend errors for missing files", async () => {
+      const { runtime } = makeConfig();
+      const composite = new CompositeBackend(new StoreBackend(runtime), {
+        "/store/": new StoreBackend(runtime),
+      });
+
+      const result = await composite.delete("/store/missing.txt");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("not found");
+    });
+  });
+
   describe("uploadFiles", () => {
     it("should route uploads to correct backend based on path", async () => {
       const { runtime } = makeConfig();

--- a/libs/deepagents/src/backends/composite.ts
+++ b/libs/deepagents/src/backends/composite.ts
@@ -5,6 +5,7 @@
 import type {
   AnyBackendProtocol,
   BackendProtocolV2,
+  DeleteResult,
   EditResult,
   ExecuteResponse,
   FileDownloadResponse,
@@ -370,6 +371,22 @@ export class CompositeBackend implements BackendProtocolV2 {
   ): Promise<EditResult> {
     const [backend, strippedKey] = this.getBackendAndKey(filePath);
     return await backend.edit(strippedKey, oldString, newString, replaceAll);
+  }
+
+  /**
+   * Delete a file, routing to the appropriate backend.
+   */
+  async delete(filePath: string): Promise<DeleteResult> {
+    const [backend, strippedKey] = this.getBackendAndKey(filePath);
+    if (!backend.delete) {
+      return { error: "Backend does not support delete" };
+    }
+
+    const result = await backend.delete(strippedKey);
+    if (result.path !== undefined) {
+      return { ...result, path: filePath };
+    }
+    return result;
   }
 
   /**

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -261,6 +261,58 @@ describe("ContextHubBackend", () => {
     expect(client.pullAgent).toHaveBeenCalledTimes(2);
   });
 
+  it("delete commits a null entry", async () => {
+    const { backend, client } = makeBackend({
+      "a.md": { type: "file", content: "bye" },
+    });
+
+    const result = await backend.delete("/a.md");
+
+    expect(result.error).toBeUndefined();
+    expect(result.path).toBe("/a.md");
+    expect(client.pushAgent).toHaveBeenCalledTimes(1);
+    const [, options] = client.pushAgent.mock.calls[0];
+    expect(options.files).toHaveProperty("a.md");
+    expect(options.files["a.md"]).toBeNull();
+    expect(options.parentCommit).toBe(COMMIT_HASH);
+  });
+
+  it("delete returns not found without committing when target file is missing", async () => {
+    const { backend, client } = makeBackend();
+
+    const result = await backend.delete("/ghost.md");
+
+    expect(result.path).toBeUndefined();
+    expect(result.error).toContain("not found");
+    expect(client.pushAgent).not.toHaveBeenCalled();
+  });
+
+  it("delete updates cache after commit", async () => {
+    const { backend } = makeBackend({
+      "a.md": { type: "file", content: "bye" },
+    });
+
+    expect((await backend.read("/a.md")).error).toBeUndefined();
+    await backend.delete("/a.md");
+
+    expect((await backend.read("/a.md")).error).toContain("not found");
+  });
+
+  it("delete failures invalidate cache and re-pull on next read", async () => {
+    const { backend, client } = makeBackend({
+      "a.md": { type: "file", content: "a" },
+    });
+    client.pushAgent.mockRejectedValue(
+      makeLangSmithError("500", { name: "LangSmithAPIError", status: 500 }),
+    );
+
+    const result = await backend.delete("/a.md");
+    expect(result.error).toContain("Hub unavailable");
+
+    await backend.read("/a.md");
+    expect(client.pullAgent).toHaveBeenCalledTimes(2);
+  });
+
   it("edit replaces a single occurrence", async () => {
     const { backend, client } = makeBackend({
       "a.md": { type: "file", content: "hello world" },

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -7,6 +7,7 @@ import { Client } from "langsmith";
 import type { AgentContext, Entry } from "langsmith/schemas";
 import type {
   BackendProtocolV2,
+  DeleteResult,
   EditResult,
   FileDownloadResponse,
   FileInfo,
@@ -197,14 +198,14 @@ export class ContextHubBackend implements BackendProtocolV2 {
     return this.cache;
   }
 
-  private async commit(files: Record<string, string>): Promise<void> {
-    if (Object.keys(files).length === 0) {
+  private async commit(changes: Record<string, string | null>): Promise<void> {
+    if (Object.keys(changes).length === 0) {
       return;
     }
 
     const payload: Record<string, Entry | null> = {};
-    for (const [path, content] of Object.entries(files)) {
-      payload[path] = { type: "file", content };
+    for (const [path, content] of Object.entries(changes)) {
+      payload[path] = content === null ? null : { type: "file", content };
     }
 
     const url = await this.client.pushAgent(this.identifier, {
@@ -218,9 +219,22 @@ export class ContextHubBackend implements BackendProtocolV2 {
     }
 
     if (this.cache !== null) {
-      for (const [path, content] of Object.entries(files)) {
-        this.cache[path] = content;
-      }
+      const deletions = new Set(
+        Object.entries(changes)
+          .filter(([, content]) => content === null)
+          .map(([path]) => path),
+      );
+      const updates = Object.fromEntries(
+        Object.entries(changes).filter(
+          (entry): entry is [string, string] => entry[1] !== null,
+        ),
+      );
+      this.cache = {
+        ...Object.fromEntries(
+          Object.entries(this.cache).filter(([path]) => !deletions.has(path)),
+        ),
+        ...updates,
+      };
     }
   }
 
@@ -445,6 +459,26 @@ export class ContextHubBackend implements BackendProtocolV2 {
         filesUpdate: null,
         occurrences,
       };
+    } catch (error) {
+      if (isLangSmithError(error)) {
+        this.cache = null;
+        return { error: ContextHubBackend.toHubUnavailableError(error) };
+      }
+      throw error;
+    }
+  }
+
+  async delete(filePath: string): Promise<DeleteResult> {
+    const hubPath = ContextHubBackend.stripPrefix(filePath);
+
+    try {
+      const cache = await this.ensureCache();
+      if (!(hubPath in cache)) {
+        return { error: `Error: File '${filePath}' not found` };
+      }
+
+      await this.commit({ [hubPath]: null });
+      return { path: filePath };
     } catch (error) {
       if (isLangSmithError(error)) {
         this.cache = null;

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -413,6 +413,79 @@ describe("FilesystemBackend", () => {
     expect(readResult.error).toBeDefined();
   });
 
+  describe("delete", () => {
+    it("should delete an existing file", async () => {
+      const root = tmpDir;
+      const filePath = path.join(root, "drop.txt");
+      await writeFile(filePath, "drop");
+      const backend = new FilesystemBackend({
+        rootDir: root,
+        virtualMode: false,
+      });
+
+      const result = await backend.delete(filePath);
+
+      expect(result.error).toBeUndefined();
+      expect(result.path).toBe(filePath);
+      await expect(fs.stat(filePath)).rejects.toThrow();
+    });
+
+    it("should return an error for missing files", async () => {
+      const backend = new FilesystemBackend({
+        rootDir: tmpDir,
+        virtualMode: true,
+      });
+
+      const result = await backend.delete("/missing.txt");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("not found");
+    });
+
+    it("should reject directories", async () => {
+      await fs.mkdir(path.join(tmpDir, "sub"));
+      const backend = new FilesystemBackend({
+        rootDir: tmpDir,
+        virtualMode: true,
+      });
+
+      const result = await backend.delete("/sub");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("directory");
+      await expect(fs.stat(path.join(tmpDir, "sub"))).resolves.toBeDefined();
+    });
+
+    it("should only remove the target file", async () => {
+      await writeFile(path.join(tmpDir, "keep.txt"), "keep");
+      await writeFile(path.join(tmpDir, "drop.txt"), "drop");
+      const backend = new FilesystemBackend({
+        rootDir: tmpDir,
+        virtualMode: true,
+      });
+
+      const result = await backend.delete("/drop.txt");
+
+      expect(result.error).toBeUndefined();
+      await expect(fs.stat(path.join(tmpDir, "drop.txt"))).rejects.toThrow();
+      await expect(
+        fs.stat(path.join(tmpDir, "keep.txt")),
+      ).resolves.toBeDefined();
+    });
+
+    it("should reject virtual-mode path traversal", async () => {
+      const backend = new FilesystemBackend({
+        rootDir: tmpDir,
+        virtualMode: true,
+      });
+
+      const result = await backend.delete("/../outside.txt");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("Path traversal not allowed");
+    });
+  });
+
   describe("binary file handling", () => {
     it("should read binary files as Uint8Array", async () => {
       const root = tmpDir;

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -484,6 +484,31 @@ describe("FilesystemBackend", () => {
       expect(result.path).toBeUndefined();
       expect(result.error).toContain("Path traversal not allowed");
     });
+
+    it("should reject symlinked parent directories in virtual mode", async () => {
+      const outsideDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "deepagents-outside-"),
+      );
+      const outsideFile = path.join(outsideDir, "secret.txt");
+      await writeFile(outsideFile, "secret");
+      try {
+        await fs.symlink(outsideDir, path.join(tmpDir, "link"), "dir");
+      } catch {
+        await removeDir(outsideDir);
+        return;
+      }
+      const backend = new FilesystemBackend({
+        rootDir: tmpDir,
+        virtualMode: true,
+      });
+
+      const result = await backend.delete("/link/secret.txt");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("Symlink parent not allowed");
+      await expect(fs.stat(outsideFile)).resolves.toBeDefined();
+      await removeDir(outsideDir);
+    });
   });
 
   describe("binary file handling", () => {

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -17,6 +17,7 @@ import fg from "fast-glob";
 import micromatch from "micromatch";
 import type {
   BackendProtocolV2,
+  DeleteResult,
   EditResult,
   FileDownloadResponse,
   FileInfo,
@@ -37,6 +38,27 @@ import {
 } from "./utils.js";
 
 const SUPPORTS_NOFOLLOW = fsSync.constants.O_NOFOLLOW !== undefined;
+
+function getErrorMessage(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message?: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+  return String(error);
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
 
 /**
  * Backend that reads and writes files directly from the filesystem.
@@ -468,6 +490,37 @@ export class FilesystemBackend implements BackendProtocolV2 {
       return { path: filePath, filesUpdate: null, occurrences: occurrences };
     } catch (e: any) {
       return { error: `Error editing file '${filePath}': ${e.message}` };
+    }
+  }
+
+  /**
+   * Delete a file from the filesystem.
+   */
+  async delete(filePath: string): Promise<DeleteResult> {
+    let resolvedPath: string;
+    try {
+      resolvedPath = this.resolvePath(filePath);
+    } catch (error: unknown) {
+      return {
+        error: `Error deleting file '${filePath}': ${getErrorMessage(error)}`,
+      };
+    }
+
+    try {
+      const stat = await fs.lstat(resolvedPath);
+      if (stat.isDirectory()) {
+        return { error: `Error: '${filePath}' is a directory, not a file` };
+      }
+
+      await fs.unlink(resolvedPath);
+      return { path: filePath };
+    } catch (error: unknown) {
+      if (hasErrorCode(error, "ENOENT")) {
+        return { error: `Error: File '${filePath}' not found` };
+      }
+      return {
+        error: `Error deleting file '${filePath}': ${getErrorMessage(error)}`,
+      };
     }
   }
 

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -118,6 +118,43 @@ export class FilesystemBackend implements BackendProtocolV2 {
   }
 
   /**
+   * Resolve the concrete path to unlink for a virtual delete operation.
+   *
+   * Virtual-mode path containment is lexical in resolvePath(), so deleting via
+   * that path could follow a symlinked parent outside the virtual root. Resolve
+   * and validate the real parent, then unlink through that real parent path so a
+   * replacement of the original lexical parent cannot redirect the unlink.
+   */
+  private async resolveDeletePath(
+    resolvedPath: string,
+    filePath: string,
+  ): Promise<string> {
+    if (!this.virtualMode) {
+      return resolvedPath;
+    }
+
+    const relative = path.relative(this.cwd, resolvedPath);
+    const segments = relative.split(path.sep).filter(Boolean);
+    let current = this.cwd;
+    for (const segment of segments.slice(0, -1)) {
+      current = path.join(current, segment);
+      const stat = await fs.lstat(current);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Symlink parent not allowed: ${filePath}`);
+      }
+    }
+
+    const realRoot = await fs.realpath(this.cwd);
+    const realParent = await fs.realpath(path.dirname(resolvedPath));
+    const realRelative = path.relative(realRoot, realParent);
+    if (realRelative.startsWith("..") || path.isAbsolute(realRelative)) {
+      throw new Error(`Path '${filePath}' resolves outside root directory`);
+    }
+
+    return path.join(realParent, path.basename(resolvedPath));
+  }
+
+  /**
    * List files and directories in the specified directory (non-recursive).
    *
    * @param dirPath - Absolute directory path to list files from
@@ -507,12 +544,13 @@ export class FilesystemBackend implements BackendProtocolV2 {
     }
 
     try {
-      const stat = await fs.lstat(resolvedPath);
+      const deletePath = await this.resolveDeletePath(resolvedPath, filePath);
+      const stat = await fs.lstat(deletePath);
       if (stat.isDirectory()) {
         return { error: `Error: '${filePath}' is a directory, not a file` };
       }
 
-      await fs.unlink(resolvedPath);
+      await fs.unlink(deletePath);
       return { path: filePath };
     } catch (error: unknown) {
       if (hasErrorCode(error, "ENOENT")) {

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -734,6 +734,51 @@ describe("BaseSandbox", () => {
     });
   });
 
+  describe("delete", () => {
+    it("should delete with rm -f and report success on exit 0", async () => {
+      const sandbox = new MockSandbox();
+
+      const result = await sandbox.delete("/file.txt");
+
+      expect(result.error).toBeUndefined();
+      expect(result.path).toBe("/file.txt");
+      expect(sandbox.executedCommands[0]).toContain("rm -f");
+      expect(sandbox.executedCommands[0]).toContain("'/file.txt'");
+    });
+
+    it("should treat missing files as success when rm -f exits 0", async () => {
+      const sandbox = new MockSandbox();
+
+      const result = await sandbox.delete("/missing.txt");
+
+      expect(result.error).toBeUndefined();
+      expect(result.path).toBe("/missing.txt");
+    });
+
+    it("should report stderr on non-zero rm exit", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.execute = vi.fn().mockResolvedValue({
+        output: "rm: cannot remove '/some/dir': Is a directory",
+        exitCode: 1,
+        truncated: false,
+      });
+
+      const result = await sandbox.delete("/some/dir");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("Error deleting file");
+      expect(result.error).toContain("Is a directory");
+    });
+
+    it("should shell-quote paths", async () => {
+      const sandbox = new MockSandbox();
+
+      await sandbox.delete("/file's.txt");
+
+      expect(sandbox.executedCommands[0]).toContain("'/file'\\''s.txt'");
+    });
+  });
+
   describe("uploadFiles", () => {
     it("should upload files successfully", async () => {
       const sandbox = new MockSandbox();

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -14,6 +14,7 @@
  */
 
 import type {
+  DeleteResult,
   EditResult,
   ExecuteResponse,
   FileDownloadResponse,
@@ -662,5 +663,26 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
     }
 
     return { path: filePath, filesUpdate: null, occurrences: count };
+  }
+
+  /**
+   * Delete a file from the sandbox via a server-side rm.
+   *
+   * Uses rm -f, so deleting a path that does not exist succeeds silently.
+   */
+  async delete(filePath: string): Promise<DeleteResult> {
+    // shellQuote passes the path as a single literal shell argument. It is not
+    // a sandbox boundary: whatever the sandbox shell can reach, this can delete.
+    const result = await this.execute(`rm -f ${shellQuote(filePath)}`);
+
+    if (result.exitCode === 0) {
+      return { path: filePath };
+    }
+
+    return {
+      error: `Error deleting file '${filePath}': ${
+        result.output.trim() || "unknown error"
+      }`,
+    };
   }
 }

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -242,6 +242,62 @@ describe("StoreBackend", () => {
     expect(readRes.content).toBe("");
   });
 
+  it("should delete files by exact store key", async () => {
+    const { runtime } = makeConfig();
+    const backend = new StoreBackend(runtime);
+
+    await backend.write("/docs/readme.md", "hello store");
+    const result = await backend.delete("/docs/readme.md");
+
+    expect(result.error).toBeUndefined();
+    expect(result.path).toBe("/docs/readme.md");
+    expect((await backend.read("/docs/readme.md")).error).toContain(
+      "not found",
+    );
+  });
+
+  it("should return an error when deleting a missing store key", async () => {
+    const { runtime } = makeConfig();
+    const backend = new StoreBackend(runtime);
+
+    const result = await backend.delete("/missing.md");
+
+    expect(result.path).toBeUndefined();
+    expect(result.error).toContain("not found");
+  });
+
+  it("should treat wildcard-looking delete paths as literal store keys", async () => {
+    const { runtime } = makeConfig();
+    const backend = new StoreBackend(runtime);
+
+    await backend.write("/a.md", "a");
+    await backend.write("/b.md", "b");
+    await backend.write("*", "literal star");
+
+    const result = await backend.delete("*");
+
+    expect(result.error).toBeUndefined();
+    expect(result.path).toBe("*");
+    expect((await backend.read("/a.md")).error).toBeUndefined();
+    expect((await backend.read("/b.md")).error).toBeUndefined();
+    expect((await backend.read("*")).error).toContain("not found");
+  });
+
+  it("should not expand wildcard-looking missing delete paths", async () => {
+    const { runtime } = makeConfig();
+    const backend = new StoreBackend(runtime);
+
+    await backend.write("/a.md", "a");
+    await backend.write("/b.md", "b");
+
+    const result = await backend.delete("*");
+
+    expect(result.path).toBeUndefined();
+    expect(result.error).toContain("not found");
+    expect((await backend.read("/a.md")).error).toBeUndefined();
+    expect((await backend.read("/b.md")).error).toBeUndefined();
+  });
+
   it("should use assistantId-based namespace when no custom namespace provided", async () => {
     const { store } = makeConfig();
     const runtimeWithAssistant = {

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -12,6 +12,7 @@ import type { BaseStore } from "@langchain/langgraph-checkpoint";
 import type {
   BackendOptions,
   BackendProtocolV2,
+  DeleteResult,
   EditResult,
   FileData,
   FileDownloadResponse,
@@ -647,6 +648,25 @@ export class StoreBackend implements BackendProtocolV2 {
     } catch (e: any) {
       return { error: `Error: ${e.message}` };
     }
+  }
+
+  /**
+   * Delete a file from the store.
+   *
+   * The file path is used as an exact store key. Wildcards are treated
+   * literally and do not expand to multiple entries.
+   */
+  async delete(filePath: string): Promise<DeleteResult> {
+    const store = this.getStore();
+    const namespace = this.getNamespace();
+
+    const existing = await store.get(namespace, filePath);
+    if (!existing) {
+      return { error: `Error: File '${filePath}' not found` };
+    }
+
+    await store.delete(namespace, filePath);
+    return { path: filePath };
   }
 
   /**

--- a/libs/providers/node-vfs/src/backend.test.ts
+++ b/libs/providers/node-vfs/src/backend.test.ts
@@ -143,6 +143,48 @@ describe("VfsBackend", () => {
     });
   });
 
+  describe("delete", () => {
+    beforeEach(async () => {
+      sandbox = await VfsBackend.create({
+        initialFiles: {
+          "/keep.txt": "keep",
+          "/drop.txt": "drop",
+          "/dir/nested.txt": "nested",
+        },
+      });
+    });
+
+    it("should delete an existing file", async () => {
+      const result = await sandbox.delete("/drop.txt");
+
+      expect(result.error).toBeUndefined();
+      expect(result.path).toBe("/drop.txt");
+      const downloaded = await sandbox.downloadFiles(["/drop.txt"]);
+      expect(downloaded[0].error).toBe("file_not_found");
+    });
+
+    it("should return an error for missing files", async () => {
+      const result = await sandbox.delete("/missing.txt");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("not found");
+    });
+
+    it("should reject directories", async () => {
+      const result = await sandbox.delete("/dir");
+
+      expect(result.path).toBeUndefined();
+      expect(result.error).toContain("directory");
+    });
+
+    it("should only delete the target file", async () => {
+      await sandbox.delete("/drop.txt");
+
+      const downloaded = await sandbox.downloadFiles(["/keep.txt"]);
+      expect(downloaded[0].error).toBeNull();
+    });
+  });
+
   describe("downloadFiles", () => {
     beforeEach(async () => {
       sandbox = await VfsBackend.create({

--- a/libs/providers/node-vfs/src/backend.ts
+++ b/libs/providers/node-vfs/src/backend.ts
@@ -17,6 +17,7 @@ import type { Stats } from "node:fs";
 
 import {
   type BackendProtocolV2,
+  type DeleteResult,
   type EditResult,
   type FileDownloadResponse,
   type FileOperationError,
@@ -875,6 +876,34 @@ export class VfsBackend implements BackendProtocolV2 {
     } catch (error) {
       return {
         error: `Error editing file '${filePath}': ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+  }
+
+  /**
+   * Delete a file.
+   */
+  async delete(filePath: string): Promise<DeleteResult> {
+    this.#ensureInitialized();
+
+    const resolvedPath = this.#resolvePath(filePath);
+    if (!resolvedPath || !this.instance.existsSync(resolvedPath)) {
+      return { error: `Error: File '${filePath}' not found` };
+    }
+
+    try {
+      const stat = this.instance.statSync(resolvedPath);
+      if (!stat.isFile()) {
+        return { error: `Error: '${filePath}' is a directory, not a file` };
+      }
+
+      this.instance.unlinkSync(resolvedPath);
+      return { path: filePath };
+    } catch (error) {
+      return {
+        error: `Error deleting file '${filePath}': ${
           error instanceof Error ? error.message : String(error)
         }`,
       };


### PR DESCRIPTION
## Summary

Implements the optional backend `delete` protocol across the built-in backend implementations now that the delete protocol surface is available. This keeps delete behavior backend-local and does not expose a new filesystem tool to agents.

## Changes

### deepagents

- Implements `delete(filePath)` for filesystem, store, composite, context hub, and sandbox backends.
- Uses backend-specific safety semantics: filesystem deletion goes through existing path resolution and only unlinks files, store deletion treats paths as exact keys, context hub deletion commits null entries, and sandbox deletion uses shell-quoted `rm -f`.
- Adds tests covering successful deletion, missing paths, directory rejection where applicable, composite route path restoration, store wildcard literal behavior, and context hub cache updates/failure handling.

### @langchain/node-vfs

- Implements `delete(filePath)` for the VFS backend.
- Adds tests for file deletion, missing paths, directory rejection, and preserving non-target files.
