### PR TITLE
fix(deepagents): normalize skill frontmatter text variants

### DIFF
--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -1490,6 +1490,59 @@ Content
     expect(result?.description).toBe("A test skill");
   });
 
+  it("should parse quoted frontmatter with CRLF line endings", () => {
+    const content = [
+      "---",
+      "name: test-skill",
+      'description: "A quoted test skill"',
+      "---",
+      "",
+      "Content",
+    ].join("\r\n");
+    const result = parseSkillMetadataFromContent(
+      content,
+      "/skills/test-skill/SKILL.md",
+      "test-skill",
+    );
+
+    expect(result?.description).toBe("A quoted test skill");
+  });
+
+  it("should parse quoted frontmatter with CR line endings", () => {
+    const content = [
+      "---",
+      "name: test-skill",
+      "description: 'A quoted test skill'",
+      "---",
+      "",
+      "Content",
+    ].join("\r");
+    const result = parseSkillMetadataFromContent(
+      content,
+      "/skills/test-skill/SKILL.md",
+      "test-skill",
+    );
+
+    expect(result?.description).toBe("A quoted test skill");
+  });
+
+  it("should parse frontmatter after a UTF-8 BOM", () => {
+    const content = `\uFEFF---
+name: test-skill
+description: "A quoted test skill"
+---
+
+Content
+`;
+    const result = parseSkillMetadataFromContent(
+      content,
+      "/skills/test-skill/SKILL.md",
+      "test-skill",
+    );
+
+    expect(result?.description).toBe("A quoted test skill");
+  });
+
   it("should reject whitespace-only description", () => {
     const content = `---
 name: test-skill

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -438,9 +438,14 @@ export function parseSkillMetadataFromContent(
     return null;
   }
 
+  // Normalize common text-file variants before matching and parsing frontmatter.
+  const normalizedContent = content
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n?/g, "\n");
+
   // Match YAML frontmatter between --- delimiters
   const frontmatterPattern = /^---\s*\n([\s\S]*?)\n---\s*\n/;
-  const match = content.match(frontmatterPattern);
+  const match = normalizedContent.match(frontmatterPattern);
 
   if (!match) {
     console.warn(`Skipping ${skillPath}: no valid YAML frontmatter found`);


### PR DESCRIPTION
## Summary

- strip a leading UTF-8 BOM before matching SKILL.md frontmatter
- normalize CRLF and CR line endings before YAML parsing
- add regression coverage for quoted YAML values across these text variants

The normalization is intentionally limited to BOM and line endings. Other control characters remain untouched so parsing does not silently alter YAML values.

## Tests

- `pnpm --filter deepagents exec vitest run src/middleware/skills.test.ts` (141 passed)
- `pnpm exec oxfmt --check libs/deepagents/src/middleware/skills.ts libs/deepagents/src/middleware/skills.test.ts`

Fixes #583