### PR TITLE
fix(deepagents): backend adapter drops route prefixes

### DIFF
--- a/.changeset/dark-squids-bathe.md
+++ b/.changeset/dark-squids-bathe.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): backend adapter drops route prefixes

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -645,6 +645,33 @@ describe("adaptBackendProtocol", () => {
     });
   });
 
+  describe("routePrefixes preservation", () => {
+    it("should forward routePrefixes from a composite-like backend", () => {
+      const v2 = createV2Backend() as any;
+      v2.routePrefixes = ["/skills/"];
+      const adapted = adaptBackendProtocol(v2) as any;
+      expect(adapted.routePrefixes).toEqual(["/skills/"]);
+    });
+
+    it("should preserve routePrefixes through adaptSandboxProtocol", () => {
+      const v2 = createV2Backend() as any;
+      v2.execute = (cmd: string) => ({
+        output: cmd,
+        exitCode: 0,
+        truncated: false,
+      });
+      Object.defineProperty(v2, "id", { value: "sb", enumerable: true });
+      v2.routePrefixes = ["/skills/", "/mnt/"];
+      const adapted = adaptSandboxProtocol(v2) as any;
+      expect(adapted.routePrefixes).toEqual(["/skills/", "/mnt/"]);
+    });
+
+    it("should not add routePrefixes for a non-composite backend", () => {
+      const adapted = adaptBackendProtocol(createV2Backend()) as any;
+      expect(adapted.routePrefixes).toBeUndefined();
+    });
+  });
+
   describe("optional methods", () => {
     it("should preserve uploadFiles when present", () => {
       const v1 = createV1Backend();

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -952,6 +952,18 @@ export function adaptBackendProtocol(
     },
   };
 
+  // Preserve `routePrefixes` so `CompositeBackend.isInstance` still detects
+  // composites after adaptation and the execute-tool permission guard stays
+  // correct; without it, scoped filesystem permissions wrongly disable execute.
+  const routePrefixes = (backend as { routePrefixes?: unknown }).routePrefixes;
+  if (Array.isArray(routePrefixes)) {
+    Object.defineProperty(adapted, "routePrefixes", {
+      get: () => (backend as { routePrefixes: string[] }).routePrefixes,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
   return adapted;
 }
 

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -958,7 +958,7 @@ export function adaptBackendProtocol(
   const routePrefixes = (backend as { routePrefixes?: unknown }).routePrefixes;
   if (Array.isArray(routePrefixes)) {
     Object.defineProperty(adapted, "routePrefixes", {
-      get: () => (backend as { routePrefixes: string[] }).routePrefixes,
+      value: routePrefixes,
       enumerable: true,
       configurable: true,
     });


### PR DESCRIPTION
### Summary

`adaptBackendProtocol` rebuilds the backend into a v2 backend protocol but drops its `routePrefixes`. Since `resolveBackend` runs every backend through the adapter, a resolved `CompositeBackend` was no longer detected as composite. That made the execute tool's guard fail at invocation and disable the execute tool even when filesystem permissions were correctly scoped to composite routes.

This PR fixes this by forwarding `routePrefixes` through `adaptBackendProtocol` instead of dropping them.

### Tests

Added unit tests in backends/utils.test.ts to verify that `routePrefixes` is forwarded through `adaptBackendProtocol` and `adaptSandboxProtocol` and not added for non-composite backends.