### PR TITLE
fix(deepagents): return recoverable errors for invalid/denied filesystem tool paths instead of throwing

### DIFF
--- a/.changeset/permission-crash-recoverable.md
+++ b/.changeset/permission-crash-recoverable.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): return recoverable errors for invalid/denied filesystem tool paths instead of throwing

--- a/libs/deepagents/src/middleware/fs.permissions.test.ts
+++ b/libs/deepagents/src/middleware/fs.permissions.test.ts
@@ -27,12 +27,24 @@ function getTool(
 }
 
 /**
- * Normalize a tool result to searchable text. Tools return a plain string
- * (ls/write/edit/glob/grep) or an array of content blocks (read_file), so
- * assertions can match against either shape.
+ * Normalize a tool result to searchable text. Errors come back as a ToolMessage
+ * (content string); successful reads may be a plain string or content-block
+ * array, so assertions can match against any shape.
  */
 function resultText(result: unknown): string {
-  return typeof result === "string" ? result : JSON.stringify(result);
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object" && "content" in result) {
+    const { content } = result as { content: unknown };
+    return typeof content === "string" ? content : JSON.stringify(content);
+  }
+  return JSON.stringify(result);
+}
+
+/** Read the ToolMessage status of a tool result, if present. */
+function resultStatus(result: unknown): string | undefined {
+  return result && typeof result === "object" && "status" in result
+    ? (result as { status?: string }).status
+    : undefined;
 }
 
 const deny = (paths: string[]) => ({
@@ -155,6 +167,7 @@ describe("fs tool permissions", () => {
           file_path: path,
         });
         expect(resultText(result)).toMatch(/error/i);
+        expect(resultStatus(result)).toBe("error");
         expect(backend.read).not.toHaveBeenCalled();
       });
 
@@ -204,6 +217,7 @@ describe("fs tool permissions", () => {
       expect(resultText(result)).toMatch(
         /permission denied for read on \/secrets\/key\.txt/,
       );
+      expect(resultStatus(result)).toBe("error");
     });
 
     it("does not call backend when path is denied", async () => {
@@ -252,6 +266,7 @@ describe("fs tool permissions", () => {
       expect(resultText(result)).toMatch(
         /permission denied for write on \/readonly\/config\.json/,
       );
+      expect(resultStatus(result)).toBe("error");
     });
 
     it("does not call backend when path is denied", async () => {

--- a/libs/deepagents/src/middleware/fs.permissions.test.ts
+++ b/libs/deepagents/src/middleware/fs.permissions.test.ts
@@ -137,9 +137,6 @@ describe("fs tool permissions", () => {
   });
 
   describe("malformed model paths do not crash the run", () => {
-    // Regression: a model-supplied `~`/relative/`..` path used to throw out of
-    // the tool and kill the entire agent run (a MiddlewareError through
-    // langgraph). It must instead return a recoverable error to the model.
     const badPaths = [
       { label: "tilde home path", path: "~/.openwiki/wiki/quickstart.md" },
       { label: "relative path", path: "quickstart.md" },

--- a/libs/deepagents/src/middleware/fs.permissions.test.ts
+++ b/libs/deepagents/src/middleware/fs.permissions.test.ts
@@ -26,6 +26,15 @@ function getTool(
   return tool;
 }
 
+/**
+ * Normalize a tool result to searchable text. Tools return a plain string
+ * (ls/write/edit/glob/grep) or an array of content blocks (read_file), so
+ * assertions can match against either shape.
+ */
+function resultText(result: unknown): string {
+  return typeof result === "string" ? result : JSON.stringify(result);
+}
+
 const deny = (paths: string[]) => ({
   operations: ["read", "write"] as const,
   paths,
@@ -117,27 +126,87 @@ describe("fs tool permissions", () => {
         permissions: [denyRead(["/secrets/**"])],
       });
 
-      await expect(
-        getTool(middleware, "read_file").invoke({
-          file_path: "secrets/key.txt",
-        }),
-      ).rejects.toThrow(/path must be absolute/i);
+      // A malformed path must not reach the backend, but it is a recoverable
+      // tool error the model can correct — never a run-ending throw.
+      const result = await getTool(middleware, "read_file").invoke({
+        file_path: "secrets/key.txt",
+      });
+      expect(resultText(result)).toMatch(/path must be absolute/i);
       expect(backend.read).not.toHaveBeenCalled();
     });
   });
 
+  describe("malformed model paths do not crash the run", () => {
+    // Regression: a model-supplied `~`/relative/`..` path used to throw out of
+    // the tool and kill the entire agent run (a MiddlewareError through
+    // langgraph). It must instead return a recoverable error to the model.
+    const badPaths = [
+      { label: "tilde home path", path: "~/.openwiki/wiki/quickstart.md" },
+      { label: "relative path", path: "quickstart.md" },
+      { label: "parent traversal", path: "/workspace/../etc/passwd" },
+    ];
+
+    for (const { label, path } of badPaths) {
+      it(`read_file returns an error (not a throw) for a ${label}`, async () => {
+        const backend = createMockBackend();
+        const middleware = createFilesystemMiddleware({
+          backend,
+          permissions: [denyRead(["/secrets/**"])],
+        });
+
+        const result = await getTool(middleware, "read_file").invoke({
+          file_path: path,
+        });
+        expect(resultText(result)).toMatch(/error/i);
+        expect(backend.read).not.toHaveBeenCalled();
+      });
+
+      it(`write_file returns an error (not a throw) for a ${label}`, async () => {
+        const backend = createMockBackend();
+        const middleware = createFilesystemMiddleware({
+          backend,
+          permissions: [denyWrite(["/readonly/**"])],
+        });
+
+        const result = await getTool(middleware, "write_file").invoke({
+          file_path: path,
+          content: "data",
+        });
+        expect(resultText(result)).toMatch(/error/i);
+        expect(backend.write).not.toHaveBeenCalled();
+      });
+    }
+
+    it("does not crash when no permissions are configured either", async () => {
+      // With empty rules the permission check is skipped entirely, so the
+      // backend receives the raw path and reports its own (recoverable) error.
+      const backend = createMockBackend();
+      backend.read = vi
+        .fn()
+        .mockResolvedValue({ error: "invalid path", content: null });
+      const middleware = createFilesystemMiddleware({ backend });
+
+      await expect(
+        getTool(middleware, "read_file").invoke({
+          file_path: "~/.openwiki/wiki/quickstart.md",
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe("read_file", () => {
-    it("throws on a denied path", async () => {
+    it("returns an error on a denied path", async () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),
         permissions: [denyRead(["/secrets/**"])],
       });
 
-      await expect(
-        getTool(middleware, "read_file").invoke({
-          file_path: "/secrets/key.txt",
-        }),
-      ).rejects.toThrow(/permission denied for read on \/secrets\/key\.txt/);
+      const result = await getTool(middleware, "read_file").invoke({
+        file_path: "/secrets/key.txt",
+      });
+      expect(resultText(result)).toMatch(
+        /permission denied for read on \/secrets\/key\.txt/,
+      );
     });
 
     it("does not call backend when path is denied", async () => {
@@ -147,11 +216,10 @@ describe("fs tool permissions", () => {
         permissions: [denyRead(["/secrets/**"])],
       });
 
-      await expect(
-        getTool(middleware, "read_file").invoke({
-          file_path: "/secrets/key.txt",
-        }),
-      ).rejects.toThrow();
+      const result = await getTool(middleware, "read_file").invoke({
+        file_path: "/secrets/key.txt",
+      });
+      expect(resultText(result)).toMatch(/permission denied/);
       expect(backend.read).not.toHaveBeenCalled();
     });
 
@@ -174,18 +242,17 @@ describe("fs tool permissions", () => {
   });
 
   describe("write_file", () => {
-    it("throws on a denied path", async () => {
+    it("returns an error on a denied path", async () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),
         permissions: [denyWrite(["/readonly/**"])],
       });
 
-      await expect(
-        getTool(middleware, "write_file").invoke({
-          file_path: "/readonly/config.json",
-          content: "data",
-        }),
-      ).rejects.toThrow(
+      const result = await getTool(middleware, "write_file").invoke({
+        file_path: "/readonly/config.json",
+        content: "data",
+      });
+      expect(resultText(result)).toMatch(
         /permission denied for write on \/readonly\/config\.json/,
       );
     });
@@ -197,12 +264,11 @@ describe("fs tool permissions", () => {
         permissions: [denyWrite(["/readonly/**"])],
       });
 
-      await expect(
-        getTool(middleware, "write_file").invoke({
-          file_path: "/readonly/config.json",
-          content: "data",
-        }),
-      ).rejects.toThrow();
+      const result = await getTool(middleware, "write_file").invoke({
+        file_path: "/readonly/config.json",
+        content: "data",
+      });
+      expect(resultText(result)).toMatch(/permission denied/);
       expect(backend.write).not.toHaveBeenCalled();
     });
 
@@ -222,19 +288,18 @@ describe("fs tool permissions", () => {
   });
 
   describe("edit_file", () => {
-    it("throws on a denied path", async () => {
+    it("returns an error on a denied path", async () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),
         permissions: [denyWrite(["/readonly/**"])],
       });
 
-      await expect(
-        getTool(middleware, "edit_file").invoke({
-          file_path: "/readonly/config.json",
-          old_string: "a",
-          new_string: "b",
-        }),
-      ).rejects.toThrow(
+      const result = await getTool(middleware, "edit_file").invoke({
+        file_path: "/readonly/config.json",
+        old_string: "a",
+        new_string: "b",
+      });
+      expect(resultText(result)).toMatch(
         /permission denied for write on \/readonly\/config\.json/,
       );
     });
@@ -246,27 +311,29 @@ describe("fs tool permissions", () => {
         permissions: [denyWrite(["/readonly/**"])],
       });
 
-      await expect(
-        getTool(middleware, "edit_file").invoke({
-          file_path: "/readonly/config.json",
-          old_string: "a",
-          new_string: "b",
-        }),
-      ).rejects.toThrow();
+      const result = await getTool(middleware, "edit_file").invoke({
+        file_path: "/readonly/config.json",
+        old_string: "a",
+        new_string: "b",
+      });
+      expect(resultText(result)).toMatch(/permission denied/);
       expect(backend.edit).not.toHaveBeenCalled();
     });
   });
 
   describe("ls", () => {
-    it("throws when base path is denied", async () => {
+    it("returns an error when base path is denied", async () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),
         permissions: [denyRead(["/secrets/**", "/secrets"])],
       });
 
-      await expect(
-        getTool(middleware, "ls").invoke({ path: "/secrets" }),
-      ).rejects.toThrow(/permission denied for read on \/secrets/);
+      const result = await getTool(middleware, "ls").invoke({
+        path: "/secrets",
+      });
+      expect(resultText(result)).toMatch(
+        /permission denied for read on \/secrets/,
+      );
     });
 
     it("post-filters denied entries from results", async () => {
@@ -305,18 +372,19 @@ describe("fs tool permissions", () => {
   });
 
   describe("glob", () => {
-    it("throws when base path is denied", async () => {
+    it("returns an error when base path is denied", async () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),
         permissions: [denyRead(["/secrets/**", "/secrets"])],
       });
 
-      await expect(
-        getTool(middleware, "glob").invoke({
-          pattern: "**/*.txt",
-          path: "/secrets",
-        }),
-      ).rejects.toThrow(/permission denied for read on \/secrets/);
+      const result = await getTool(middleware, "glob").invoke({
+        pattern: "**/*.txt",
+        path: "/secrets",
+      });
+      expect(resultText(result)).toMatch(
+        /permission denied for read on \/secrets/,
+      );
     });
 
     it("post-filters denied paths from results", async () => {
@@ -343,18 +411,19 @@ describe("fs tool permissions", () => {
   });
 
   describe("grep", () => {
-    it("throws when base path is denied", async () => {
+    it("returns an error when base path is denied", async () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),
         permissions: [denyRead(["/secrets/**", "/secrets"])],
       });
 
-      await expect(
-        getTool(middleware, "grep").invoke({
-          pattern: "password",
-          path: "/secrets",
-        }),
-      ).rejects.toThrow(/permission denied for read on \/secrets/);
+      const result = await getTool(middleware, "grep").invoke({
+        pattern: "password",
+        path: "/secrets",
+      });
+      expect(resultText(result)).toMatch(
+        /permission denied for read on \/secrets/,
+      );
     });
 
     it("post-filters denied matches from results", async () => {

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -471,6 +471,26 @@ function checkPermission(
 }
 
 /**
+ * Build an error {@link ToolMessage} for a rejected or denied path. Returning a
+ * bare string would be wrapped as a `status: "success"` message whose content
+ * merely starts with "Error:"; marking `status: "error"` reports the failure
+ * accurately (matching the Python implementation) so callers and the model can
+ * distinguish a real failure from a successful result.
+ */
+function toolError(
+  runtime: ToolRuntime,
+  toolName: string,
+  message: string,
+): ToolMessage {
+  return new ToolMessage({
+    content: message,
+    name: toolName,
+    tool_call_id: runtime.toolCall?.id as string,
+    status: "error",
+  });
+}
+
+/**
  * Filter a list of filesystem entries to those the rules permit.
  *
  * `getPath` extracts the absolute path from each entry. Entries with
@@ -690,7 +710,7 @@ function createLsTool(
         input.path ?? "/",
       );
       if (permissionError !== undefined) {
-        return permissionError;
+        return toolError(runtime, "ls", permissionError);
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
@@ -764,7 +784,7 @@ function createReadFileTool(
         input.file_path,
       );
       if (permissionError !== undefined) {
-        return [{ type: "text", text: permissionError }];
+        return toolError(runtime, "read_file", permissionError);
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
@@ -900,7 +920,7 @@ function createWriteFileTool(
         input.file_path,
       );
       if (permissionError !== undefined) {
-        return permissionError;
+        return toolError(runtime, "write_file", permissionError);
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
@@ -963,7 +983,7 @@ function createEditFileTool(
         input.file_path,
       );
       if (permissionError !== undefined) {
-        return permissionError;
+        return toolError(runtime, "edit_file", permissionError);
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
@@ -1037,7 +1057,7 @@ function createGlobTool(
         input.path ?? "/",
       );
       if (permissionError !== undefined) {
-        return permissionError;
+        return toolError(runtime, "glob", permissionError);
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
@@ -1101,7 +1121,7 @@ function createGrepTool(
         input.path ?? "/",
       );
       if (permissionError !== undefined) {
-        return permissionError;
+        return toolError(runtime, "grep", permissionError);
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -424,30 +424,57 @@ const FilesystemStateSchema = new StateSchema({
 });
 
 /**
- * Throw a permission-denied error if `path` is denied under `rules`.
+ * Check whether `path` is permitted under `rules` for `operation`.
  *
- * No-op when `rules` is empty (permissive default). Paths that fail
- * `validatePath` are silently skipped — the tool's own input validation
- * will surface a better error.
+ * Returns `undefined` when the operation is allowed (including the permissive
+ * empty-rules default). Otherwise returns a human-readable error string that
+ * the calling tool returns to the model as a recoverable tool result:
+ *
+ * - A model-supplied path that fails `validatePath` (non-absolute, or
+ *   containing `..` or `~`) yields the validation message. The path is
+ *   rejected, not normalized, so it can never bypass a deny rule or reach the
+ *   backend.
+ * - A path denied by the rules yields a permission-denied message.
+ *
+ * Crucially this never throws. Insteadm an invalid path from the model is an
+ * expected, recoverable condition, not a fatal run-ending error.
  *
  * @internal
  */
-function enforcePermission(
+/** Extract a message string from an unknown thrown value without `instanceof`. */
+function getErrorMessage(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message?: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+  return String(error);
+}
+
+function checkPermission(
   rules: FilesystemPermission[],
   operation: FilesystemOperation,
   path: string,
-): void {
+): string | undefined {
   if (rules.length === 0) {
-    return;
+    return undefined;
   }
 
-  const canonical = validatePath(path);
+  let canonical: string;
+  try {
+    canonical = validatePath(path);
+  } catch (error) {
+    return `Error: ${getErrorMessage(error)}`;
+  }
 
   if (decidePathAccess(rules, operation, canonical) === "deny") {
-    throw new Error(
-      `Error: permission denied for ${operation} on ${canonical}`,
-    );
+    return `Error: permission denied for ${operation} on ${canonical}`;
   }
+
+  return undefined;
 }
 
 /**
@@ -664,7 +691,14 @@ function createLsTool(
   const { customDescription, permissions } = options;
   return tool(
     async (input, runtime: ToolRuntime) => {
-      enforcePermission(permissions, "read", input.path ?? "/");
+      const permissionError = checkPermission(
+        permissions,
+        "read",
+        input.path ?? "/",
+      );
+      if (permissionError !== undefined) {
+        return permissionError;
+      }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
       const path = input.path || "/";
@@ -731,7 +765,14 @@ function createReadFileTool(
   const { customDescription, toolTokenLimitBeforeEvict, permissions } = options;
   return tool(
     async (input, runtime: ToolRuntime) => {
-      enforcePermission(permissions, "read", input.file_path);
+      const permissionError = checkPermission(
+        permissions,
+        "read",
+        input.file_path,
+      );
+      if (permissionError !== undefined) {
+        return [{ type: "text", text: permissionError }];
+      }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
       const {
@@ -860,7 +901,14 @@ function createWriteFileTool(
   const { customDescription, permissions } = options;
   return tool(
     async (input, runtime: ToolRuntime) => {
-      enforcePermission(permissions, "write", input.file_path);
+      const permissionError = checkPermission(
+        permissions,
+        "write",
+        input.file_path,
+      );
+      if (permissionError !== undefined) {
+        return permissionError;
+      }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
       const { file_path, content } = input;
@@ -916,7 +964,14 @@ function createEditFileTool(
   const { customDescription, permissions } = options;
   return tool(
     async (input, runtime: ToolRuntime) => {
-      enforcePermission(permissions, "write", input.file_path);
+      const permissionError = checkPermission(
+        permissions,
+        "write",
+        input.file_path,
+      );
+      if (permissionError !== undefined) {
+        return permissionError;
+      }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
       const { file_path, old_string, new_string, replace_all = false } = input;
@@ -983,7 +1038,14 @@ function createGlobTool(
   const { customDescription, permissions } = options;
   return tool(
     async (input, runtime: ToolRuntime) => {
-      enforcePermission(permissions, "read", input.path ?? "/");
+      const permissionError = checkPermission(
+        permissions,
+        "read",
+        input.path ?? "/",
+      );
+      if (permissionError !== undefined) {
+        return permissionError;
+      }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
       const { pattern, path = "/" } = input;
@@ -1040,7 +1102,14 @@ function createGrepTool(
   const { customDescription, permissions } = options;
   return tool(
     async (input, runtime: ToolRuntime) => {
-      enforcePermission(permissions, "read", input.path ?? "/");
+      const permissionError = checkPermission(
+        permissions,
+        "read",
+        input.path ?? "/",
+      );
+      if (permissionError !== undefined) {
+        return permissionError;
+      }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
       const { pattern, path = "/", glob = null } = input;

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -423,24 +423,6 @@ const FilesystemStateSchema = new StateSchema({
   ),
 });
 
-/**
- * Check whether `path` is permitted under `rules` for `operation`.
- *
- * Returns `undefined` when the operation is allowed (including the permissive
- * empty-rules default). Otherwise returns a human-readable error string that
- * the calling tool returns to the model as a recoverable tool result:
- *
- * - A model-supplied path that fails `validatePath` (non-absolute, or
- *   containing `..` or `~`) yields the validation message. The path is
- *   rejected, not normalized, so it can never bypass a deny rule or reach the
- *   backend.
- * - A path denied by the rules yields a permission-denied message.
- *
- * Crucially this never throws. Insteadm an invalid path from the model is an
- * expected, recoverable condition, not a fatal run-ending error.
- *
- * @internal
- */
 /** Extract a message string from an unknown thrown value without `instanceof`. */
 function getErrorMessage(error: unknown): string {
   if (
@@ -454,6 +436,17 @@ function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
+/**
+ * Check whether `path` is permitted under `rules` for `operation`, returning an
+ * error string to surface to the model (or `undefined` when allowed).
+ *
+ * Never throws: an invalid path (non-absolute, or containing `..` or `~`) or a
+ * denied path is a recoverable tool error, not a fatal run-ending one. Such
+ * paths are rejected, never normalized, so they cannot bypass a deny rule or
+ * reach the backend.
+ *
+ * @internal
+ */
 function checkPermission(
   rules: FilesystemPermission[],
   operation: FilesystemOperation,

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -474,8 +474,8 @@ function checkPermission(
  * Build an error {@link ToolMessage} for a rejected or denied path. Returning a
  * bare string would be wrapped as a `status: "success"` message whose content
  * merely starts with "Error:"; marking `status: "error"` reports the failure
- * accurately (matching the Python implementation) so callers and the model can
- * distinguish a real failure from a successful result.
+ * accurately so callers and the model can distinguish a real failure from a
+ * successful result.
  */
 function toolError(
   runtime: ToolRuntime,

--- a/libs/deepagents/src/middleware/subagents.permissions.test.ts
+++ b/libs/deepagents/src/middleware/subagents.permissions.test.ts
@@ -46,9 +46,14 @@ function getTool(
   return t;
 }
 
-/** Normalize a tool result (string, or read_file's content-block array) to text. */
+/** Normalize a tool result (string, or a ToolMessage's content) to text. */
 function resultText(result: unknown): string {
-  return typeof result === "string" ? result : JSON.stringify(result);
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object" && "content" in result) {
+    const { content } = result as { content: unknown };
+    return typeof content === "string" ? content : JSON.stringify(content);
+  }
+  return JSON.stringify(result);
 }
 
 /** Mirrors the expression in normalizeSubagentSpec. */

--- a/libs/deepagents/src/middleware/subagents.permissions.test.ts
+++ b/libs/deepagents/src/middleware/subagents.permissions.test.ts
@@ -46,6 +46,11 @@ function getTool(
   return t;
 }
 
+/** Normalize a tool result (string, or read_file's content-block array) to text. */
+function resultText(result: unknown): string {
+  return typeof result === "string" ? result : JSON.stringify(result);
+}
+
 /** Mirrors the expression in normalizeSubagentSpec. */
 function resolvePermissions(
   subagentPermissions: FilesystemPermission[] | undefined,
@@ -130,11 +135,12 @@ describe("createFilesystemMiddleware with effective permissions", () => {
       permissions: effective,
     });
 
-    await expect(
-      getTool(middleware, "read_file").invoke({
-        file_path: "/secrets/key.txt",
-      }),
-    ).rejects.toThrow(/permission denied for read on \/secrets\/key\.txt/);
+    const result = await getTool(middleware, "read_file").invoke({
+      file_path: "/secrets/key.txt",
+    });
+    expect(resultText(result)).toMatch(
+      /permission denied for read on \/secrets\/key\.txt/,
+    );
   });
 
   it("empty override allows reads that parent would have denied", async () => {
@@ -169,11 +175,12 @@ describe("createFilesystemMiddleware with effective permissions", () => {
       permissions: effective,
     });
 
-    await expect(
-      getTool(middleware, "read_file").invoke({
-        file_path: "/restricted/data.txt",
-      }),
-    ).rejects.toThrow(/permission denied for read on \/restricted\/data\.txt/);
+    const result = await getTool(middleware, "read_file").invoke({
+      file_path: "/restricted/data.txt",
+    });
+    expect(resultText(result)).toMatch(
+      /permission denied for read on \/restricted\/data\.txt/,
+    );
   });
 
   it("subagent-specific deny rule does not affect parent-allowed paths", async () => {

--- a/libs/deepagents/src/permissions/agent.permissions.test.ts
+++ b/libs/deepagents/src/permissions/agent.permissions.test.ts
@@ -32,9 +32,14 @@ function getTool(
   return t;
 }
 
-/** Normalize a tool result (string, or read_file's content-block array) to text. */
+/** Normalize a tool result (string, or a ToolMessage's content) to text. */
 function resultText(result: unknown): string {
-  return typeof result === "string" ? result : JSON.stringify(result);
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object" && "content" in result) {
+    const { content } = result as { content: unknown };
+    return typeof content === "string" ? content : JSON.stringify(content);
+  }
+  return JSON.stringify(result);
 }
 
 // ─── permissions flow to createFilesystemMiddleware ───────────────────────────

--- a/libs/deepagents/src/permissions/agent.permissions.test.ts
+++ b/libs/deepagents/src/permissions/agent.permissions.test.ts
@@ -32,6 +32,11 @@ function getTool(
   return t;
 }
 
+/** Normalize a tool result (string, or read_file's content-block array) to text. */
+function resultText(result: unknown): string {
+  return typeof result === "string" ? result : JSON.stringify(result);
+}
+
 // ─── permissions flow to createFilesystemMiddleware ───────────────────────────
 
 describe("permissions wired to filesystem middleware", () => {
@@ -48,11 +53,12 @@ describe("permissions wired to filesystem middleware", () => {
       ],
     });
 
-    await expect(
-      getTool(middleware, "read_file").invoke({
-        file_path: "/secrets/key.txt",
-      }),
-    ).rejects.toThrow(/permission denied for read on \/secrets\/key\.txt/);
+    const result = await getTool(middleware, "read_file").invoke({
+      file_path: "/secrets/key.txt",
+    });
+    expect(resultText(result)).toMatch(
+      /permission denied for read on \/secrets\/key\.txt/,
+    );
   });
 
   it("empty permissions array allows all operations", async () => {
@@ -91,12 +97,11 @@ describe("permissions wired to filesystem middleware", () => {
       ],
     });
 
-    await expect(
-      getTool(middleware, "write_file").invoke({
-        file_path: "/readonly/config.json",
-        content: "data",
-      }),
-    ).rejects.toThrow(
+    const writeResult = await getTool(middleware, "write_file").invoke({
+      file_path: "/readonly/config.json",
+      content: "data",
+    });
+    expect(resultText(writeResult)).toMatch(
       /permission denied for write on \/readonly\/config\.json/,
     );
 


### PR DESCRIPTION
### Summary

Invalid (non-absolute, `..`, or `~`) or denied filesystem paths passed by an agent cause the tool to throw which raises a `MiddlewareError` and causes the whole agent run to crash.

This PR replaces `enforcePermission` which was re-validating the path without a try/catch with `checkPermission` which returns the error to the model as a normal tool result so the model can correct the path and try again instead of crashing.

### Tests

Updated the three permission suites to assert an error result instead of a throw and added a regression block for `~`/relative/`..` paths that returns a recoverable error and never calls the backend.