### PR TITLE
ci: route integration tests through LangSmith LLM Gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,10 @@ jobs:
       - name: Run Integration Tests
         run: pnpm test:int
         env:
+          # LLM calls are routed through LangSmith LLM Gateway when this is set
+          # (see scripts/vitest-setup-langsmith-gateway.ts).
+          LANGSMITH_GATEWAY_KEY: ${{ secrets.LANGSMITH_GATEWAY_KEY }}
+          # Fallback for local/provider-direct runs if gateway secret is unset.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}

--- a/libs/acp/package.json
+++ b/libs/acp/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
+    "dotenv": "^17.2.4",
     "tsdown": "^0.22.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",

--- a/libs/acp/vitest.config.ts
+++ b/libs/acp/vitest.config.ts
@@ -4,10 +4,6 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
-import { configureLangSmithGateway } from "../../scripts/vitest-setup-langsmith-gateway.js";
-
-// Side-effect import already loads root .env + gateway; call again is idempotent.
-configureLangSmithGateway();
 
 const gatewaySetup = path.resolve(
   __dirname,

--- a/libs/acp/vitest.config.ts
+++ b/libs/acp/vitest.config.ts
@@ -1,8 +1,18 @@
+import path from "node:path";
 import {
   configDefaults,
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
+import { configureLangSmithGateway } from "../../scripts/vitest-setup-langsmith-gateway.js";
+
+// Side-effect import already loads root .env + gateway; call again is idempotent.
+configureLangSmithGateway();
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../scripts/vitest-setup-langsmith-gateway.ts",
+);
 
 export default defineConfig((env) => {
   const common: ViteUserConfigExport = {
@@ -27,6 +37,7 @@ export default defineConfig((env) => {
         exclude: configDefaults.exclude,
         include: ["src/**/*.int.test.ts"],
         name: "int",
+        setupFiles: [gatewaySetup],
       },
     } satisfies ViteUserConfigExport;
   }
@@ -40,6 +51,7 @@ export default defineConfig((env) => {
         exclude: configDefaults.exclude,
         include: ["src/**/*.test.ts", "src/**/*.int.test.ts"],
         name: "all",
+        setupFiles: [gatewaySetup],
       },
     } satisfies ViteUserConfigExport;
   }

--- a/libs/deepagents/vitest.config.ts
+++ b/libs/deepagents/vitest.config.ts
@@ -4,10 +4,6 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
-import { configureLangSmithGateway } from "../../scripts/vitest-setup-langsmith-gateway.js";
-
-// Loads repo-root .env and remaps provider keys onto the LangSmith LLM Gateway.
-configureLangSmithGateway();
 
 const gatewaySetup = path.resolve(
   __dirname,
@@ -39,7 +35,6 @@ export default defineConfig((env) => {
         exclude: configDefaults.exclude,
         include: ["**/*.int.test.ts"],
         name: "int",
-        // Re-apply after worker dotenv so provider keys stay on the gateway.
         setupFiles: [gatewaySetup],
       },
     } satisfies ViteUserConfigExport;

--- a/libs/deepagents/vitest.config.ts
+++ b/libs/deepagents/vitest.config.ts
@@ -4,10 +4,15 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
-import dotenv from "dotenv";
+import { configureLangSmithGateway } from "../../scripts/vitest-setup-langsmith-gateway.js";
 
-// Load .env from workspace root (two levels up from libs/deepagents)
-dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+// Loads repo-root .env and remaps provider keys onto the LangSmith LLM Gateway.
+configureLangSmithGateway();
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../scripts/vitest-setup-langsmith-gateway.ts",
+);
 
 export default defineConfig((env) => {
   const common: ViteUserConfigExport = {
@@ -34,6 +39,8 @@ export default defineConfig((env) => {
         exclude: configDefaults.exclude,
         include: ["**/*.int.test.ts"],
         name: "int",
+        // Re-apply after worker dotenv so provider keys stay on the gateway.
+        setupFiles: [gatewaySetup],
       },
     } satisfies ViteUserConfigExport;
   }

--- a/libs/providers/daytona/vitest.config.ts
+++ b/libs/providers/daytona/vitest.config.ts
@@ -4,10 +4,14 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
+import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
 
-// Load .env from workspace root
-import dotenv from "dotenv";
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+configureLangSmithGateway();
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../../scripts/vitest-setup-langsmith-gateway.ts",
+);
 
 export default defineConfig((env) => {
   const common: ViteUserConfigExport = {
@@ -34,6 +38,7 @@ export default defineConfig((env) => {
         include: ["**/*.int.test.ts"],
         name: "int",
         sequence: { concurrent: false },
+        setupFiles: [gatewaySetup],
       },
     } satisfies ViteUserConfigExport;
   }

--- a/libs/providers/daytona/vitest.config.ts
+++ b/libs/providers/daytona/vitest.config.ts
@@ -4,9 +4,6 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
-import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
-
-configureLangSmithGateway();
 
 const gatewaySetup = path.resolve(
   __dirname,

--- a/libs/providers/deno/vitest.config.ts
+++ b/libs/providers/deno/vitest.config.ts
@@ -4,9 +4,6 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
-import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
-
-configureLangSmithGateway();
 
 const gatewaySetup = path.resolve(
   __dirname,
@@ -23,7 +20,7 @@ export default defineConfig((env) => {
       hookTimeout: 60_000,
       teardownTimeout: 60_000,
       exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
-      setupFiles: ["dotenv/config", gatewaySetup],
+      setupFiles: ["dotenv/config"],
     },
   };
 

--- a/libs/providers/deno/vitest.config.ts
+++ b/libs/providers/deno/vitest.config.ts
@@ -1,8 +1,17 @@
+import path from "node:path";
 import {
   configDefaults,
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
+import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
+
+configureLangSmithGateway();
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../../scripts/vitest-setup-langsmith-gateway.ts",
+);
 
 export default defineConfig((env) => {
   const common: ViteUserConfigExport = {
@@ -14,7 +23,7 @@ export default defineConfig((env) => {
       hookTimeout: 60_000,
       teardownTimeout: 60_000,
       exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
-      setupFiles: ["dotenv/config"],
+      setupFiles: ["dotenv/config", gatewaySetup],
     },
   };
 
@@ -28,6 +37,8 @@ export default defineConfig((env) => {
         include: ["**/*.int.test.ts"],
         name: "int",
         sequence: { concurrent: false },
+        // gatewaySetup last so it wins over dotenv/config provider keys
+        setupFiles: ["dotenv/config", gatewaySetup],
       },
     } satisfies ViteUserConfigExport;
   }

--- a/libs/providers/modal/vitest.config.ts
+++ b/libs/providers/modal/vitest.config.ts
@@ -4,9 +4,6 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
-import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
-
-configureLangSmithGateway();
 
 const gatewaySetup = path.resolve(
   __dirname,
@@ -23,7 +20,7 @@ export default defineConfig((env) => {
       hookTimeout: 60_000,
       teardownTimeout: 60_000,
       exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
-      setupFiles: ["dotenv/config", gatewaySetup],
+      setupFiles: ["dotenv/config"],
     },
   };
 

--- a/libs/providers/modal/vitest.config.ts
+++ b/libs/providers/modal/vitest.config.ts
@@ -1,8 +1,17 @@
+import path from "node:path";
 import {
   configDefaults,
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
+import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
+
+configureLangSmithGateway();
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../../scripts/vitest-setup-langsmith-gateway.ts",
+);
 
 export default defineConfig((env) => {
   const common: ViteUserConfigExport = {
@@ -14,7 +23,7 @@ export default defineConfig((env) => {
       hookTimeout: 60_000,
       teardownTimeout: 60_000,
       exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
-      setupFiles: ["dotenv/config"],
+      setupFiles: ["dotenv/config", gatewaySetup],
     },
   };
 
@@ -28,6 +37,7 @@ export default defineConfig((env) => {
         include: ["**/*.int.test.ts"],
         name: "int",
         sequence: { concurrent: false },
+        setupFiles: ["dotenv/config", gatewaySetup],
       },
     } satisfies ViteUserConfigExport;
   }

--- a/libs/providers/node-vfs/package.json
+++ b/libs/providers/node-vfs/package.json
@@ -49,6 +49,7 @@
     "@tsconfig/recommended": "^1.0.13",
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.0.18",
+    "dotenv": "^17.2.4",
     "tsdown": "^0.22.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",

--- a/libs/providers/node-vfs/vitest.config.ts
+++ b/libs/providers/node-vfs/vitest.config.ts
@@ -1,4 +1,13 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
+
+configureLangSmithGateway();
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../../scripts/vitest-setup-langsmith-gateway.ts",
+);
 
 export default defineConfig(({ mode }) => ({
   test: {
@@ -6,6 +15,7 @@ export default defineConfig(({ mode }) => ({
     environment: "node",
     include: mode === "int" ? ["src/**/*.int.test.ts"] : ["src/**/*.test.ts"],
     exclude: mode === "int" ? [] : ["src/**/*.int.test.ts"],
+    setupFiles: mode === "int" ? [gatewaySetup] : undefined,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/libs/providers/node-vfs/vitest.config.ts
+++ b/libs/providers/node-vfs/vitest.config.ts
@@ -1,8 +1,5 @@
 import path from "node:path";
 import { defineConfig } from "vitest/config";
-import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
-
-configureLangSmithGateway();
 
 const gatewaySetup = path.resolve(
   __dirname,

--- a/libs/providers/quickjs/vitest.config.ts
+++ b/libs/providers/quickjs/vitest.config.ts
@@ -4,9 +4,6 @@ import {
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
-import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
-
-configureLangSmithGateway();
 
 const gatewaySetup = path.resolve(
   __dirname,
@@ -23,7 +20,7 @@ export default defineConfig((env) => {
       hookTimeout: 60_000,
       teardownTimeout: 60_000,
       exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
-      setupFiles: ["dotenv/config", gatewaySetup],
+      setupFiles: ["dotenv/config"],
     },
   };
 

--- a/libs/providers/quickjs/vitest.config.ts
+++ b/libs/providers/quickjs/vitest.config.ts
@@ -1,8 +1,17 @@
+import path from "node:path";
 import {
   configDefaults,
   defineConfig,
   type ViteUserConfigExport,
 } from "vitest/config";
+import { configureLangSmithGateway } from "../../../scripts/vitest-setup-langsmith-gateway.js";
+
+configureLangSmithGateway();
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../../scripts/vitest-setup-langsmith-gateway.ts",
+);
 
 export default defineConfig((env) => {
   const common: ViteUserConfigExport = {
@@ -14,7 +23,7 @@ export default defineConfig((env) => {
       hookTimeout: 60_000,
       teardownTimeout: 60_000,
       exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
-      setupFiles: ["dotenv/config"],
+      setupFiles: ["dotenv/config", gatewaySetup],
     },
   };
 
@@ -28,6 +37,7 @@ export default defineConfig((env) => {
         include: ["**/*.int.test.ts"],
         name: "int",
         sequence: { concurrent: false },
+        setupFiles: ["dotenv/config", gatewaySetup],
       },
     } satisfies ViteUserConfigExport;
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.29.8",
     "@tsconfig/recommended": "^1.0.13",
+    "dotenv": "^17.4.2",
     "eslint-plugin-no-instanceof": "^1.0.1",
     "globals": "^17.3.0",
     "jiti": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.13
         version: 1.0.13
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint-plugin-no-instanceof:
         specifier: ^1.0.1
         version: 1.0.1
@@ -603,6 +606,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.0.18
         version: 4.1.10(vitest@4.1.10)
+      dotenv:
+        specifier: ^17.2.4
+        version: 17.4.2
       tsdown:
         specifier: ^0.22.1
         version: 0.22.8(tsx@4.22.4)(typescript@6.0.3)
@@ -824,6 +830,9 @@ importers:
       deepagents:
         specifier: workspace:*
         version: link:../../deepagents
+      dotenv:
+        specifier: ^17.2.4
+        version: 17.4.2
       tsdown:
         specifier: ^0.22.1
         version: 0.22.8(tsx@4.22.4)(typescript@6.0.3)

--- a/scripts/vitest-setup-langsmith-gateway.ts
+++ b/scripts/vitest-setup-langsmith-gateway.ts
@@ -1,0 +1,93 @@
+/**
+ * Route integration-test LLM calls through the LangSmith LLM Gateway.
+ *
+ * When `LANGSMITH_GATEWAY_KEY` (or `LC_GATEWAY_KEY`) is set, provider SDKs are
+ * pointed at `https://gateway.smith.langchain.com` and authenticate with that
+ * key. Provider secrets stay in LangSmith; local `ANTHROPIC_API_KEY` /
+ * `OPENAI_API_KEY` values are overridden for the test process.
+ *
+ * @see https://docs.langchain.com/langsmith/llm-gateway-quickstart
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_GATEWAY_BASE_URL = "https://gateway.smith.langchain.com";
+
+/** Load repo-root `.env` without overriding vars already present in the process. */
+function loadRootEnv(): void {
+  const rootEnv = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../.env",
+  );
+  if (!fs.existsSync(rootEnv)) {
+    return;
+  }
+
+  for (const rawLine of fs.readFileSync(rootEnv, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const eq = line.indexOf("=");
+    if (eq <= 0) {
+      continue;
+    }
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      continue;
+    }
+    if (process.env[key] !== undefined) {
+      continue;
+    }
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+/**
+ * Configure process.env so Anthropic/OpenAI/Gemini/etc. clients use the gateway.
+ * No-op when no gateway key is present (keeps direct-provider local/CI fallbacks).
+ */
+export function configureLangSmithGateway(): boolean {
+  const gatewayKey =
+    process.env.LANGSMITH_GATEWAY_KEY?.trim() ||
+    process.env.LC_GATEWAY_KEY?.trim();
+
+  if (!gatewayKey) {
+    return false;
+  }
+
+  const baseUrl = (
+    process.env.LANGSMITH_GATEWAY_BASE_URL?.trim() || DEFAULT_GATEWAY_BASE_URL
+  ).replace(/\/+$/, "");
+
+  process.env.ANTHROPIC_BASE_URL = `${baseUrl}/anthropic`;
+  process.env.OPENAI_BASE_URL = `${baseUrl}/openai/v1`;
+  process.env.GOOGLE_GEMINI_BASE_URL = `${baseUrl}/gemini`;
+  process.env.FIREWORKS_BASE_URL = `${baseUrl}/fireworks`;
+  process.env.BASETEN_BASE_URL = `${baseUrl}/baseten/v1`;
+
+  // Gateway auth: LangSmith API key stands in for every provider SDK key.
+  process.env.ANTHROPIC_API_KEY = gatewayKey;
+  process.env.OPENAI_API_KEY = gatewayKey;
+  process.env.GEMINI_API_KEY = gatewayKey;
+  process.env.GOOGLE_API_KEY = gatewayKey;
+  process.env.FIREWORKS_API_KEY = gatewayKey;
+  process.env.BASETEN_API_KEY = gatewayKey;
+
+  // Anthropic SDK also honors this for proxy setups (matches org MDM/Kandji env).
+  process.env.ANTHROPIC_CUSTOM_HEADERS = `X-Api-Key: ${gatewayKey}`;
+
+  return true;
+}
+
+loadRootEnv();
+configureLangSmithGateway();

--- a/scripts/vitest-setup-langsmith-gateway.ts
+++ b/scripts/vitest-setup-langsmith-gateway.ts
@@ -9,62 +9,25 @@
  * @see https://docs.langchain.com/langsmith/llm-gateway-quickstart
  */
 
-import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
 
 const DEFAULT_GATEWAY_BASE_URL = "https://gateway.smith.langchain.com";
 
-/** Load repo-root `.env` without overriding vars already present in the process. */
-function loadRootEnv(): void {
-  const rootEnv = path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "../.env",
-  );
-  if (!fs.existsSync(rootEnv)) {
-    return;
-  }
-
-  for (const rawLine of fs.readFileSync(rootEnv, "utf8").split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#")) {
-      continue;
-    }
-    const eq = line.indexOf("=");
-    if (eq <= 0) {
-      continue;
-    }
-    const key = line.slice(0, eq).trim();
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-      continue;
-    }
-    if (process.env[key] !== undefined) {
-      continue;
-    }
-    let value = line.slice(eq + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    process.env[key] = value;
-  }
-}
+dotenv.config({
+  path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.env"),
+});
 
 /**
  * Configure process.env so Anthropic/OpenAI/Gemini/etc. clients use the gateway.
  * No-op when no gateway key is present (keeps direct-provider local/CI fallbacks).
  */
-export function configureLangSmithGateway(): boolean {
-  const gatewayKey =
-    process.env.LANGSMITH_GATEWAY_KEY?.trim() ||
-    process.env.LC_GATEWAY_KEY?.trim();
+const gatewayKey =
+  process.env.LANGSMITH_GATEWAY_KEY?.trim() ||
+  process.env.LC_GATEWAY_KEY?.trim();
 
-  if (!gatewayKey) {
-    return false;
-  }
-
+if (gatewayKey) {
   const baseUrl = (
     process.env.LANGSMITH_GATEWAY_BASE_URL?.trim() || DEFAULT_GATEWAY_BASE_URL
   ).replace(/\/+$/, "");
@@ -85,9 +48,4 @@ export function configureLangSmithGateway(): boolean {
 
   // Anthropic SDK also honors this for proxy setups (matches org MDM/Kandji env).
   process.env.ANTHROPIC_CUSTOM_HEADERS = `X-Api-Key: ${gatewayKey}`;
-
-  return true;
 }
-
-loadRootEnv();
-configureLangSmithGateway();


### PR DESCRIPTION
## Summary
- Add a shared Vitest setup that remaps Anthropic/OpenAI/etc. clients onto the LangSmith LLM Gateway when `LANGSMITH_GATEWAY_KEY` is present.
- Wire that setup into all package int-test Vitest configs.
- Pass `LANGSMITH_GATEWAY_KEY` into the CI integration-test job (falls back to direct provider keys if unset).
