### PR TITLE
fix(daytona): isolate integration test cleanup

### DIFF
--- a/libs/providers/daytona/src/sandbox.int.test.ts
+++ b/libs/providers/daytona/src/sandbox.int.test.ts
@@ -16,20 +16,28 @@ import { DaytonaSandbox } from "./index.js";
 
 const TEST_TIMEOUT = 120_000; // 2 minutes
 
-/** Labels that uniquely identify sandboxes created by this CI job. */
+/**
+ * Identify sandboxes created by this test execution. GitHub run ID and attempt
+ * prevent cleanup in one CI run from deleting sandboxes owned by another.
+ */
+const TEST_RUN_ID = process.env.GITHUB_RUN_ID
+  ? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
+  : `local-${process.pid}-${Date.now()}`;
+
 const CI_LABELS: Record<string, string> = {
   purpose: "integration-test",
   package: "@langchain/daytona",
   node: process.version,
   os: os.platform(),
+  run: TEST_RUN_ID,
 };
 
-/**
- * Clean up stale integration-test sandboxes before running tests.
- * Only deletes sandboxes matching this specific Node version + OS combination
- * so parallel CI pipelines don't interfere with each other.
- */
+/** Remove any sandboxes left behind earlier in this test execution. */
 beforeAll(async () => {
+  await DaytonaSandbox.deleteAll(CI_LABELS);
+}, TEST_TIMEOUT);
+
+afterAll(async () => {
   await DaytonaSandbox.deleteAll(CI_LABELS);
 }, TEST_TIMEOUT);
 

--- a/libs/providers/daytona/src/sandbox.int.test.ts
+++ b/libs/providers/daytona/src/sandbox.int.test.ts
@@ -32,11 +32,7 @@ const CI_LABELS: Record<string, string> = {
   run: TEST_RUN_ID,
 };
 
-/** Remove any sandboxes left behind earlier in this test execution. */
-beforeAll(async () => {
-  await DaytonaSandbox.deleteAll(CI_LABELS);
-}, TEST_TIMEOUT);
-
+/** Remove any sandboxes left behind by this test execution. */
 afterAll(async () => {
   await DaytonaSandbox.deleteAll(CI_LABELS);
 }, TEST_TIMEOUT);
@@ -47,7 +43,10 @@ sandboxStandardTests({
   createSandbox: async (options) =>
     DaytonaSandbox.create({
       language: "typescript",
+      // A cancelled test process never reaches afterAll; delete its stopped
+      // sandboxes within 20 minutes (5-minute auto-stop + 15-minute TTL).
       autoStopInterval: 5,
+      autoDeleteInterval: 15,
       labels: CI_LABELS,
       ...options,
     }),
@@ -63,6 +62,7 @@ describe("DaytonaSandbox Provider-Specific Tests", () => {
       DaytonaSandbox.create({
         language: "typescript",
         autoStopInterval: 5,
+        autoDeleteInterval: 15,
         labels: CI_LABELS,
       }),
     );

--- a/libs/providers/daytona/src/sandbox.int.test.ts
+++ b/libs/providers/daytona/src/sandbox.int.test.ts
@@ -156,6 +156,7 @@ console.log(\`User: \${user.name}, Age: \${user.age}\`);
       DaytonaSandbox.create({
         language: "typescript",
         autoStopInterval: 5,
+        autoDeleteInterval: 15,
         labels: { ...CI_LABELS, purpose: "integration-test-typescript" },
         initialFiles: {
           "main.ts": tsCode,

--- a/libs/providers/deno/src/sandbox.int.test.ts
+++ b/libs/providers/deno/src/sandbox.int.test.ts
@@ -101,27 +101,26 @@ describe
             'echo "Reconnect test" > /home/app/reconnect.txt',
           );
 
-          // Close the connection (but sandbox keeps running due to duration lifetime)
-          await originalSandbox.close();
-
-          // Reconnect using DenoSandbox.fromId().
-          // The deployment can take a short moment to become reconnectable
-          // after the original WebSocket closes.
+          // Deno's close() terminates the deployment, even for a
+          // duration-based sandbox. Connect a second client while the
+          // original remains active to verify reconnect support.
           const reconnectedSandbox = await withRetry(
             () => DenoSandbox.fromId(sandboxId),
             5,
             1_000,
           );
 
-          expect(reconnectedSandbox.id).toBe(sandboxId);
-          expect(reconnectedSandbox.isRunning).toBe(true);
+          try {
+            expect(reconnectedSandbox.id).toBe(sandboxId);
+            expect(reconnectedSandbox.isRunning).toBe(true);
 
-          const result = await reconnectedSandbox.execute(
-            "cat /home/app/reconnect.txt",
-          );
-          expect(result.output.trim()).toBe("Reconnect test");
-
-          await reconnectedSandbox.close();
+            const result = await reconnectedSandbox.execute(
+              "cat /home/app/reconnect.txt",
+            );
+            expect(result.output.trim()).toBe("Reconnect test");
+          } finally {
+            await reconnectedSandbox.close();
+          }
         },
         TEST_TIMEOUT * 2,
       );


### PR DESCRIPTION
## Summary

Scopes Daytona integration-test cleanup to a single GitHub Actions run and attempt, preventing concurrent CI runs from deleting each other’s active sandboxes.

## Changes

- Add a per-execution sandbox label derived from GitHub’s run ID and attempt, with a local-process fallback.
- Remove the ineffective pre-test cleanup, which cannot match sandboxes from earlier runs once labels are per-execution.
- Configure a 15-minute Daytona auto-delete TTL after the existing 5-minute auto-stop interval, bounding leaks when a cancelled process cannot run final cleanup.
- Correct the Deno reconnect integration test to keep its duration-based sandbox active while opening a second client, because `close()` terminates the remote deployment.
