### PR TITLE
fix(deno): extend reconnect readiness retry

### DIFF
--- a/libs/providers/deno/src/sandbox.int.test.ts
+++ b/libs/providers/deno/src/sandbox.int.test.ts
@@ -104,10 +104,13 @@ describe
           // Deno's close() terminates the deployment, even for a
           // duration-based sandbox. Connect a second client while the
           // original remains active to verify reconnect support.
+          // Sandbox.connect() can return 404 until the deployment is visible
+          // to a second WebSocket connection. Allow Deno Deploy's eventual
+          // consistency window before treating the sandbox as unavailable.
           const reconnectedSandbox = await withRetry(
             () => DenoSandbox.fromId(sandboxId),
-            5,
-            1_000,
+            12,
+            2_000,
           );
 
           try {


### PR DESCRIPTION
## Summary

Stabilizes the Deno sandbox reconnection integration test when Deno Deploy has not yet exposed a new deployment to a second WebSocket client. The test now uses a bounded readiness window instead of failing after the shorter retry interval.

## Changes

### `@langchain/deno`

- Extend the reconnect test's retry window to 12 attempts with a 2-second delay.
- Document that temporary `404 DEPLOYMENT_NOT_FOUND` responses are expected during Deno Deploy propagation.
