### PR TITLE
feat(deepagents): make todo middleware opt-in

### DIFF
--- a/.changeset/todo-middleware-opt-in.md
+++ b/.changeset/todo-middleware-opt-in.md
@@ -1,0 +1,5 @@
+---
+"deepagents": minor
+---
+
+feat(deepagents): make todo middleware opt-in

--- a/libs/deepagents/src/agent.test-d.ts
+++ b/libs/deepagents/src/agent.test-d.ts
@@ -17,6 +17,7 @@ import {
   SystemMessage,
   toolStrategy,
   providerStrategy,
+  todoListMiddleware,
 } from "langchain";
 import { StateSchema } from "@langchain/langgraph";
 import { z } from "zod/v4";
@@ -119,7 +120,7 @@ describe("createDeepAgent types", () => {
   describe("createDeepAgent return type using actual invoke", () => {
     it("should infer state from custom middleware and subagents middleware", async () => {
       const agent = createDeepAgent({
-        middleware: [ResearchMiddleware],
+        middleware: [ResearchMiddleware, todoListMiddleware()],
         subagents: [
           {
             name: "Subagent1",

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { createDeepAgent } from "./agent.js";
 import { isAnthropicModel } from "./utils.js";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
+import { todoListMiddleware } from "langchain";
 import {
   HumanMessage,
   SystemMessage,
@@ -241,6 +242,32 @@ describe("profile tool exclusions", () => {
   });
 });
 
+describe("Todo list middleware", () => {
+  function getToolNames(agent: unknown): string[] {
+    const tools = (agent as any).graph?.nodes?.tools?.bound?.tools ?? [];
+    return tools.map((tool: { name: string }) => tool.name);
+  }
+
+  it("does not include todos by default", () => {
+    const agent = createDeepAgent({
+      model: new FakeListChatModel({ responses: ["Done"] }),
+    });
+
+    expect(getToolNames(agent)).not.toContain("write_todos");
+    expect(Object.keys(agent.graph?.channels ?? {})).not.toContain("todos");
+  });
+
+  it("adds todos when explicitly opted in", () => {
+    const agent = createDeepAgent({
+      model: new FakeListChatModel({ responses: ["Done"] }),
+      middleware: [todoListMiddleware()],
+    });
+
+    expect(getToolNames(agent)).toContain("write_todos");
+    expect(Object.keys(agent.graph?.channels ?? {})).toContain("todos");
+  });
+});
+
 describe("Built-in tool name collision detection", () => {
   const model = new FakeListChatModel({ responses: ["Done"] });
 
@@ -274,13 +301,19 @@ describe("Built-in tool name collision detection", () => {
     ).toThrow(ConfigurationError);
   });
 
-  it("should throw when colliding with subagent or todo tool names", () => {
+  it("should throw when colliding with the subagent tool name", () => {
     expect(() =>
       createDeepAgent({
         model,
-        tools: [makeTool("task"), makeTool("write_todos")],
+        tools: [makeTool("task")],
       }),
     ).toThrow(ConfigurationError);
+  });
+
+  it("allows a custom write_todos tool without todo middleware", () => {
+    expect(() =>
+      createDeepAgent({ model, tools: [makeTool("write_todos")] }),
+    ).not.toThrow();
   });
 
   it("should not throw when tool names do not collide", () => {

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -114,16 +114,17 @@ describe("Legacy system prompt assembly", () => {
     }
   });
 
-  it("does not inject an authored prompt by default", async () => {
+  it("does not inject a system prompt by default", async () => {
     const invokeSpy = vi.spyOn(FakeListChatModel.prototype, "invoke");
     try {
       const agent = createDeepAgent({
         model: new FakeListChatModel({ responses: ["Done"] }),
       });
       await agent.invoke({ messages: [new HumanMessage("Hello")] });
-      const systemPrompt = getLastSystemMessage(invokeSpy).text;
-      expect(systemPrompt).toContain("\u200B");
-      expect(systemPrompt.replaceAll("\u200B", "").trim()).toBe("");
+
+      const lastCall = invokeSpy.mock.calls[invokeSpy.mock.calls.length - 1];
+      const messages = lastCall?.[0] as BaseMessage[] | undefined;
+      expect(messages?.some(SystemMessage.isInstance)).toBe(false);
     } finally {
       invokeSpy.mockRestore();
     }
@@ -175,7 +176,7 @@ describe("System prompt cache control breakpoints", () => {
     return messages.find(SystemMessage.isInstance);
   }
 
-  it("should have separate cache_control breakpoints for system prompt and memory", async () => {
+  it("should cache the system prompt and memory independently", async () => {
     const invokeSpy = vi.spyOn(FakeListChatModel.prototype, "invoke");
     const model = new FakeListChatModel({ responses: ["Done"] });
     // Mock getName so isAnthropicModel detects this as an Anthropic model
@@ -207,20 +208,16 @@ describe("System prompt cache control breakpoints", () => {
     const blocks = systemMessage!.contentBlocks;
     expect(Array.isArray(blocks)).toBe(true);
 
-    // Should have at least 3 blocks: system prompt + static middleware blocks + memory
-    expect(blocks.length).toBeGreaterThanOrEqual(3);
+    // Default agents no longer add the todo middleware's static prompt block.
+    expect(blocks).toHaveLength(2);
 
-    // System prompt block (first) should NOT have cache_control — the breakpoint
-    // is placed on the last static block by createCacheBreakpointMiddleware
+    // The system prompt is now the final static block, so the cache breakpoint
+    // is attached directly to it.
     const systemBlock = blocks[0];
-    expect(systemBlock.cache_control).toBeUndefined();
+    expect(systemBlock.cache_control).toEqual({ type: "ephemeral" });
     expect(systemBlock.text).toContain("You are a helpful assistant.");
 
-    // Second-to-last block is the last static block — has cache_control
-    const lastStaticBlock = blocks[blocks.length - 2];
-    expect(lastStaticBlock.cache_control).toEqual({ type: "ephemeral" });
-
-    // Memory block (last) should have its own cache_control (set by memory middleware)
+    // Memory block (last) has its own cache control (set by memory middleware)
     const memoryBlock = blocks[blocks.length - 1];
     expect(memoryBlock.cache_control).toEqual({ type: "ephemeral" });
     expect(memoryBlock.text).toContain("<agent_memory>");

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -3,7 +3,6 @@ import {
   humanInTheLoopMiddleware,
   anthropicPromptCachingMiddleware,
   bedrockPromptCachingMiddleware,
-  todoListMiddleware,
   SystemMessage,
   type AgentMiddleware,
 } from "langchain";
@@ -107,7 +106,6 @@ const BUILTIN_TOOL_NAMES: ReadonlySet<string> = new Set([
   ...FILESYSTEM_TOOL_NAMES,
   ...ASYNC_TASK_TOOL_NAMES,
   "task",
-  "write_todos",
 ]);
 
 /**
@@ -270,8 +268,6 @@ export function createDeepAgent<
     // Uses createSummarizationMiddleware (deepagents version) with backend support
     // and auto-computed defaults from model profile.
     return [
-      // Provides todo list management capabilities for tracking tasks.
-      todoListMiddleware({ systemPrompt: "\u200B" }),
       // Enables filesystem operations and optional long-term memory storage.
       createFilesystemMiddleware({
         backend,
@@ -296,7 +292,11 @@ export function createDeepAgent<
     let subagentMiddleware = mergeMiddlewareStack(
       subagentDefaultMiddleware,
       input.middleware ?? [],
-      cacheMiddleware,
+      [
+        // Resolve profile middleware per stack so factories create fresh instances.
+        ...resolveMiddleware(harnessProfile.extraMiddleware),
+        ...cacheMiddleware,
+      ],
     );
 
     if (harnessProfile.excludedMiddleware.size > 0) {
@@ -369,8 +369,6 @@ export function createDeepAgent<
   // This tuple is typed without conditional spreads to preserve tuple inference.
   // Optional middleware (skills, memory, HITL, async) are appended at runtime.
   const builtInMiddleware = [
-    // Provides todo list management capabilities for tracking tasks.
-    todoListMiddleware({ systemPrompt: "\u200B" }),
     // Enables filesystem operations and optional long-term memory storage.
     createFilesystemMiddleware({
       backend,
@@ -394,7 +392,6 @@ export function createDeepAgent<
   ] as const;
 
   const [
-    todoMiddleware,
     fsMiddleware,
     subagentMiddleware,
     summarizationMiddleware,
@@ -403,8 +400,6 @@ export function createDeepAgent<
 
   // Runtime middleware array: combine core middleware, custom overrides, and tail middleware.
   const coreMiddleware: AgentMiddleware[] = [
-    // Built-in middleware with deterministic ordering.
-    todoMiddleware,
     // Optional root-level skills.
     ...skillsMiddleware,
     fsMiddleware,

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -10,7 +10,12 @@ vi.mock("langchain", async (importOriginal) => {
 
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
-import { createAgent, tool, type AgentMiddleware } from "langchain";
+import {
+  createAgent,
+  todoListMiddleware,
+  tool,
+  type AgentMiddleware,
+} from "langchain";
 import {
   AIMessage,
   BaseMessage,
@@ -1446,6 +1451,81 @@ describe("middleware override by name", () => {
 
     const middleware = getMiddlewareStack("helper");
     expect(middleware).not.toContain(custom);
+  });
+
+  it("does not add todo middleware to default main or general-purpose stacks", () => {
+    createDeepAgent({ model: fakeModel, name: "main" });
+
+    for (const agentName of ["main", "general-purpose"]) {
+      expect(
+        getMiddlewareStack(agentName).some(
+          (entry) => entry.name === "TodoListMiddleware",
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("keeps a main-agent todo opt-in off the general-purpose subagent", () => {
+    const todo = todoListMiddleware();
+    createDeepAgent({ model: fakeModel, name: "main", middleware: [todo] });
+
+    expect(getMiddlewareStack("main")).toContain(todo);
+    expect(
+      getMiddlewareStack("general-purpose").some(
+        (entry) => entry.name === "TodoListMiddleware",
+      ),
+    ).toBe(false);
+  });
+
+  it("lets declarative subagents opt into todo middleware independently", () => {
+    const todo = todoListMiddleware();
+    createDeepAgent({
+      model: fakeModel,
+      name: "main",
+      middleware: [todoListMiddleware()],
+      subagents: [
+        {
+          name: "helper",
+          description: "Helps with work",
+          systemPrompt: "Help.",
+          middleware: [todo],
+        },
+      ],
+    });
+
+    expect(getMiddlewareStack("helper")).toContain(todo);
+  });
+
+  it("adds fresh profile todo middleware to main and subagent stacks", () => {
+    registerHarnessProfile("todo-profile:model", {
+      extraMiddleware: () => [todoListMiddleware()],
+    });
+    createDeepAgent({
+      model: "todo-profile:model",
+      name: "main",
+      subagents: [
+        {
+          name: "helper",
+          description: "Helps with work",
+          systemPrompt: "Help.",
+        },
+      ],
+    });
+
+    const mainTodo = getMiddlewareStack("main").find(
+      (entry) => entry.name === "TodoListMiddleware",
+    );
+    const generalPurposeTodo = getMiddlewareStack("general-purpose").find(
+      (entry) => entry.name === "TodoListMiddleware",
+    );
+    const helperTodo = getMiddlewareStack("helper").find(
+      (entry) => entry.name === "TodoListMiddleware",
+    );
+    expect(mainTodo).toBeDefined();
+    expect(generalPurposeTodo).toBeDefined();
+    expect(helperTodo).toBeDefined();
+    expect(mainTodo).not.toBe(generalPurposeTodo);
+    expect(mainTodo).not.toBe(helperTodo);
   });
 
   it("replaces declarative subagent defaults with same-name spec middleware", () => {

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -1459,7 +1459,7 @@ describe("middleware override by name", () => {
     for (const agentName of ["main", "general-purpose"]) {
       expect(
         getMiddlewareStack(agentName).some(
-          (entry) => entry.name === "TodoListMiddleware",
+          (entry) => entry.name === "todoListMiddleware",
         ),
       ).toBe(false);
     }
@@ -1472,7 +1472,7 @@ describe("middleware override by name", () => {
     expect(getMiddlewareStack("main")).toContain(todo);
     expect(
       getMiddlewareStack("general-purpose").some(
-        (entry) => entry.name === "TodoListMiddleware",
+        (entry) => entry.name === "todoListMiddleware",
       ),
     ).toBe(false);
   });
@@ -1513,13 +1513,13 @@ describe("middleware override by name", () => {
     });
 
     const mainTodo = getMiddlewareStack("main").find(
-      (entry) => entry.name === "TodoListMiddleware",
+      (entry) => entry.name === "todoListMiddleware",
     );
     const generalPurposeTodo = getMiddlewareStack("general-purpose").find(
-      (entry) => entry.name === "TodoListMiddleware",
+      (entry) => entry.name === "todoListMiddleware",
     );
     const helperTodo = getMiddlewareStack("helper").find(
-      (entry) => entry.name === "TodoListMiddleware",
+      (entry) => entry.name === "todoListMiddleware",
     );
     expect(mainTodo).toBeDefined();
     expect(generalPurposeTodo).toBeDefined();

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -107,8 +107,8 @@ export interface CompiledSubAgent<
  * Specification for a subagent that can be dynamically created.
  *
  * When using `createDeepAgent`, subagents automatically receive a default middleware
- * stack (todoListMiddleware, filesystemMiddleware, summarizationMiddleware, etc.) before
- * any custom `middleware` specified in this spec.
+ * stack (filesystemMiddleware, summarizationMiddleware, etc.) before any custom
+ * `middleware` specified in this spec. Add `todoListMiddleware` explicitly to opt in.
  *
  * Required fields:
  * - `name`: Identifier used to select this subagent in the task tool

--- a/libs/deepagents/src/profiles/harness/builtins/openai-codex.ts
+++ b/libs/deepagents/src/profiles/harness/builtins/openai-codex.ts
@@ -1,3 +1,5 @@
+import { todoListMiddleware, type AgentMiddleware } from "langchain";
+
 import { createHarnessProfile } from "../create.js";
 import { registerHarnessProfileImpl } from "../registry.js";
 
@@ -40,6 +42,10 @@ without seeing a prior result.
 Mark each as done, blocked (with a one-sentence reason), or cancelled. Do not \
 finish with pending items.`;
 
+function createExtraMiddleware(): AgentMiddleware[] {
+  return [todoListMiddleware()];
+}
+
 /**
  * Register the built-in Codex harness profiles.
  *
@@ -52,6 +58,7 @@ finish with pending items.`;
 export function register(): void {
   const profile = createHarnessProfile({
     systemPromptSuffix: SYSTEM_PROMPT_SUFFIX,
+    extraMiddleware: createExtraMiddleware,
   });
   for (const spec of CODEX_MODEL_SPECS) {
     registerHarnessProfileImpl(spec, profile);

--- a/libs/deepagents/src/testing/utils.ts
+++ b/libs/deepagents/src/testing/utils.ts
@@ -17,13 +17,7 @@ import type * as _zodMeta from "@langchain/langgraph/zod";
 import type * as _messages from "@langchain/core/messages";
 import type * as _tools from "@langchain/core/tools";
 
-const expectedTools = [
-  "ls",
-  "read_file",
-  "write_file",
-  "edit_file",
-  "task",
-];
+const expectedTools = ["ls", "read_file", "write_file", "edit_file", "task"];
 
 /**
  * Assert that an agent has all the expected deep agent qualities

--- a/libs/deepagents/src/testing/utils.ts
+++ b/libs/deepagents/src/testing/utils.ts
@@ -18,7 +18,6 @@ import type * as _messages from "@langchain/core/messages";
 import type * as _tools from "@langchain/core/tools";
 
 const expectedTools = [
-  "write_todos",
   "ls",
   "read_file",
   "write_file",
@@ -35,11 +34,6 @@ export function assertAllDeepAgentQualities(agent: {
 }) {
   // Check state channels
   const channels = Object.keys(agent.graph?.channels || {});
-  if (!channels.includes("todos")) {
-    throw new Error(
-      `Expected agent to have 'todos' channel, got: ${channels.join(", ")}`,
-    );
-  }
   if (!channels.includes("files")) {
     throw new Error(
       `Expected agent to have 'files' channel, got: ${channels.join(", ")}`,

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -45,14 +45,13 @@ import type { FilesystemPermission } from "./permissions/index.js";
 type AnyAnnotationRoot = AnnotationRoot<any>;
 
 /**
- * Literal union of all built-in deep agent tool names.
- * These are always present on the agent regardless of user-provided tools.
+ * Literal union of deep agent tool names that are always present regardless of
+ * user-provided tools.
  */
 type DeepAgentBuiltinToolName =
   | (typeof FILESYSTEM_TOOL_NAMES)[number]
   | (typeof ASYNC_TASK_TOOL_NAMES)[number]
-  | "task"
-  | "write_todos";
+  | "task";
 
 /**
  * A placeholder StructuredTool type with a literal `name` for each
@@ -527,8 +526,8 @@ export interface CreateDeepAgentParams<
   systemPrompt?: string | SystemMessage | SystemPromptConfig;
   /**
    * Optional schema for custom agent state. Allows you to define custom state properties
-   * beyond built-in `messages`, `todos`, and `files`. These properties can be accessed
-   * in hooks, middleware, and throughout the agent's execution.
+   * beyond built-in `messages` and `files`. The optional todo middleware adds `todos`.
+   * These properties can be accessed in hooks, middleware, and throughout the agent's execution.
    *
    * Unlike `contextSchema` the state is persisted between agent invocations when using a
    * checkpointer, making it suitable for maintaining conversation history, user preferences,


### PR DESCRIPTION
## Summary

Makes `todoListMiddleware` opt-in. Default agents and default subagents no longer expose `write_todos` or the `todos` state channel, reducing the default tool surface while preserving explicit opt-in.

## Changes

- Remove default todo middleware from the main, general-purpose, and declarative subagent stacks.
- Preserve opt-in support through `middleware: [todoListMiddleware()]`; declarative subagents opt in through their own middleware.
- Remove `write_todos` from always-present tool typing and built-in name-collision handling.
- Update state and subagent documentation plus shared runtime assertions for the optional todo state/tool.

### Harness profiles and coverage

- Re-add todo middleware in the Codex harness profile because its model-specific prompt requires `write_todos`
- Apply profile `extraMiddleware` to subagent stacks, with profile factories creating fresh instances per stack.
- Add coverage for default exclusion, explicit opt-in, main/GP/declarative isolation, profile middleware propagation, and type inference.
