### PR TITLE
fix(deepagents): grep/glob match when path points directly at a file

### DIFF
--- a/.changeset/grep-glob-exact-file-path.md
+++ b/.changeset/grep-glob-exact-file-path.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): grep/glob match when `path` points directly at a file

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -17,10 +17,13 @@ import {
   TOOL_RESULT_TOKEN_LIMIT,
   createFileData,
   adaptSandboxProtocol,
+  grepMatchesFromFiles,
+  globSearchFiles,
 } from "./utils.js";
 import type {
   BackendProtocol,
   BackendProtocolV2,
+  FileData,
   GrepMatch,
   SandboxBackendProtocol,
   SandboxBackendProtocolV2,
@@ -382,6 +385,62 @@ describe("migrateToFileDataV2", () => {
   it("should return v2 data unchanged", () => {
     const v2 = createFileData("hello");
     expect(migrateToFileDataV2(v2, "/test.txt")).toBe(v2);
+  });
+});
+
+describe("grepMatchesFromFiles", () => {
+  function makeFiles(): Record<string, FileData> {
+    return {
+      "/catalog/some_file.txt": createFileData(
+        "line one\nSlack integration here\nline three\n",
+      ),
+      "/catalog/other_file.txt": createFileData("nothing interesting here\n"),
+    };
+  }
+
+  it("finds matches when path is an exact existing file with no glob", () => {
+    const files = makeFiles();
+    const matches = grepMatchesFromFiles(
+      files,
+      "Slack",
+      "/catalog/some_file.txt",
+      null,
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].path).toBe("/catalog/some_file.txt");
+  });
+
+  it("still finds matches when path is a directory and glob narrows to the filename", () => {
+    const files = makeFiles();
+    const matches = grepMatchesFromFiles(
+      files,
+      "Slack",
+      "/catalog",
+      "some_file.txt",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].path).toBe("/catalog/some_file.txt");
+  });
+});
+
+describe("globSearchFiles", () => {
+  function makeFiles(): Record<string, FileData> {
+    return {
+      "/catalog/some_file.txt": createFileData("hello"),
+      "/catalog/other_file.md": createFileData("hello"),
+    };
+  }
+
+  it("matches an exact file when path names it directly", () => {
+    const files = makeFiles();
+    const result = globSearchFiles(files, "*.txt", "/catalog/some_file.txt");
+    expect(result).toBe("/catalog/some_file.txt");
+  });
+
+  it("still matches via directory path + filename pattern (regression guard)", () => {
+    const files = makeFiles();
+    const result = globSearchFiles(files, "some_file.txt", "/catalog");
+    expect(result).toBe("/catalog/some_file.txt");
   });
 });
 

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -598,11 +598,41 @@ export function validateFilePath(
 }
 
 /**
+ * Resolve the files under `path` for grep/glob search.
+ *
+ * If `path` exactly names a file that exists in `files`, only that file is
+ * returned (exact match) — this lets grep/glob target a specific file
+ * directly instead of only matching directories. Otherwise `path` is treated
+ * as a directory and files are filtered by the normalized directory prefix.
+ *
+ * @returns Filtered files map, or null if `path` is invalid (e.g. whitespace-only).
+ */
+function filterFilesByPath(
+  files: Record<string, FileData>,
+  path: string | null | undefined,
+): Record<string, FileData> | null {
+  const exactPath = path ? (path.startsWith("/") ? path : "/" + path) : "/";
+  if (Object.prototype.hasOwnProperty.call(files, exactPath)) {
+    return { [exactPath]: files[exactPath] };
+  }
+
+  try {
+    const normalizedPath = validatePath(path);
+    return Object.fromEntries(
+      Object.entries(files).filter(([fp]) => fp.startsWith(normalizedPath)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Search files dict for paths matching glob pattern.
  *
  * @param files - Dictionary of file paths to FileData
  * @param pattern - Glob pattern (e.g., `*.py`, `**\/*.ts`)
- * @param path - Base path to search from
+ * @param path - Base path to search from. If `path` names an exact file, only
+ *               that file is considered.
  * @returns Newline-separated file paths, sorted by modification time (most recent first).
  *          Returns "No files found" if no matches.
  *
@@ -618,16 +648,11 @@ export function globSearchFiles(
   pattern: string,
   path: string = "/",
 ): string {
-  let normalizedPath: string;
-  try {
-    normalizedPath = validatePath(path);
-  } catch {
+  const filtered = filterFilesByPath(files, path);
+  if (filtered === null) {
     return "No files found";
   }
-
-  const filtered = Object.fromEntries(
-    Object.entries(files).filter(([fp]) => fp.startsWith(normalizedPath)),
-  );
+  const normalizedPath = validatePath(path);
 
   // Respect standard glob semantics:
   // - Patterns without path separators (e.g., "*.py") match only in the current
@@ -705,7 +730,8 @@ export function formatGrepResults(
  *
  * @param files - Dictionary of file paths to FileData
  * @param pattern - Literal text to search for
- * @param path - Base path to search from
+ * @param path - Base path to search from. If `path` names an exact file, only
+ *               that file is considered.
  * @param glob - Optional glob pattern to filter files (e.g., "*.py")
  * @param outputMode - Output format - "files_with_matches", "content", or "count"
  * @returns Formatted search results. Returns "No matches found" if no results.
@@ -724,16 +750,10 @@ export function grepSearchFiles(
   glob: string | null = null,
   outputMode: "files_with_matches" | "content" | "count" = "files_with_matches",
 ): string {
-  let normalizedPath: string;
-  try {
-    normalizedPath = validatePath(path);
-  } catch {
+  let filtered = filterFilesByPath(files, path);
+  if (filtered === null) {
     return "No matches found";
   }
-
-  let filtered = Object.fromEntries(
-    Object.entries(files).filter(([fp]) => fp.startsWith(normalizedPath)),
-  );
 
   if (glob) {
     filtered = Object.fromEntries(
@@ -776,6 +796,7 @@ export function grepSearchFiles(
  * Return structured grep matches from an in-memory files mapping.
  *
  * Performs literal text search (not regex). Binary files are skipped.
+ * If `path` names an exact file, only that file is considered.
  * Returns an empty array when no matches are found or on invalid input.
  */
 export function grepMatchesFromFiles(
@@ -784,16 +805,10 @@ export function grepMatchesFromFiles(
   path: string | null = null,
   glob: string | null = null,
 ): GrepMatch[] {
-  let normalizedPath: string;
-  try {
-    normalizedPath = validatePath(path);
-  } catch {
+  let filtered = filterFilesByPath(files, path);
+  if (filtered === null) {
     return [];
   }
-
-  let filtered = Object.fromEntries(
-    Object.entries(files).filter(([fp]) => fp.startsWith(normalizedPath)),
-  );
 
   if (glob) {
     filtered = Object.fromEntries(


### PR DESCRIPTION
## Summary
- `grep`/`glob` on `StateBackend`/`StoreBackend` returned zero matches whenever `path` pointed at an exact file (no glob) — the shared `validatePath` helper forced a trailing `/` before prefix-matching, so a file's own key could never match itself+`/`.
- Added a `filterFilesByPath` helper that checks for an exact key match in the files map first, falling back to the existing directory-prefix behavior otherwise.

## Test plan
- [x] Added regression tests in `utils.test.ts`: exact-file path (no glob) for grep and glob, plus directory + glob/filename non-regression cases for both.
- [x] `pnpm --filter deepagents test` — all tests pass.