### PR TITLE
Fix quickjs README: correct executionTimeoutMs default

### DIFF
--- a/libs/providers/quickjs/README.md
+++ b/libs/providers/quickjs/README.md
@@ -151,7 +151,7 @@ interface QuickJSMiddlewareOptions {
   ptc?: boolean | string[] | { include: string[] } | { exclude: string[] }; // PTC config
   memoryLimitBytes?: number; // Default: 50MB
   maxStackSizeBytes?: number; // Default: 320KB
-  executionTimeoutMs?: number; // Default: 30s (-1 to disable)
+  executionTimeoutMs?: number; // Default: 5s (-1 to disable)
   systemPrompt?: string | null; // Override the built-in REPL system prompt
 }
 ```


### PR DESCRIPTION
README said the default executionTimeoutMs is 30s; the shipped constant (DEFAULT_EXECUTION_TIMEOUT in src/session.ts) is 5000ms. Updates the doc to match the code.