### PR TITLE
fix: forward runnable config to browser tools

### DIFF
--- a/.changeset/calm-cats-flow.md
+++ b/.changeset/calm-cats-flow.md
@@ -1,0 +1,6 @@
+---
+"deepagents": patch
+"@langchain/quickjs": patch
+---
+
+Forward LangGraph runnable config explicitly through subagent and QuickJS PTC tool calls so browser runtimes do not depend on AsyncLocalStorage.

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -39,7 +39,7 @@ import { createSummarizationMiddleware } from "./summarization.js";
 import { mergeMiddleware } from "./utils.js";
 import { createFileData } from "../backends/utils.js";
 import { createMockBackend } from "./test.js";
-import { createSubAgent } from "./subagents.js";
+import { createSubAgent, createSubAgentMiddleware } from "./subagents.js";
 import { registerHarnessProfile } from "../profiles/index.js";
 
 const createAgentMock = vi.mocked(createAgent);
@@ -71,6 +71,58 @@ description: A test skill for subagent isolation tests
 
 Instructions for the test skill.
 `;
+
+describe("Browser-compatible subagent state propagation", () => {
+  it("reads parent state from the task tool config without AsyncLocalStorage", async () => {
+    let receivedState: Record<string, unknown> | undefined;
+    const worker = RunnableLambda.from(
+      async (state: Record<string, unknown>) => {
+        receivedState = state;
+        return { messages: [new AIMessage("browser child complete")] };
+      },
+    );
+    const middleware = createSubAgentMiddleware({
+      defaultModel: new FakeListChatModel({ responses: ["unused"] }),
+      defaultTools: [],
+      subagents: [
+        {
+          name: "browser-worker",
+          description: "A worker invoked directly from a browser tool config.",
+          runnable: worker,
+        },
+      ],
+      generalPurposeAgent: false,
+    });
+    const taskTool = middleware.tools?.find(
+      (candidate) => candidate.name === "task",
+    );
+    expect(taskTool).toBeDefined();
+
+    const result = await taskTool!.invoke(
+      {
+        description: "Do the isolated browser task.",
+        subagent_type: "browser-worker",
+      },
+      {
+        configurable: {
+          thread_id: "browser-task-config",
+          __pregel_scratchpad: {
+            currentTaskInput: {
+              messages: [new HumanMessage("parent message")],
+              browserContext: "preserved",
+            },
+          },
+        },
+      },
+    );
+
+    expect(result).toBe("browser child complete");
+    expect(receivedState).toMatchObject({ browserContext: "preserved" });
+    expect((receivedState!.messages as BaseMessage[])[0].text).toBe(
+      "Do the isolated browser task.",
+    );
+  });
+});
 
 /**
  * Subagent skills isolation tests.

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -557,7 +557,7 @@ function createTaskTool(options: {
 
       const subagent = selectSubagent(subagent_type, config);
 
-      const currentState = getCurrentTaskInput<Record<string, unknown>>();
+      const currentState = getCurrentTaskInput<Record<string, unknown>>(config);
       const subagentState = filterStateForSubagent(currentState);
       subagentState.messages = [new HumanMessage({ content: description })];
 

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -229,6 +229,49 @@ describe("createCodeInterpreterMiddleware", () => {
       );
       expect(req.systemMessage.text).not.toContain("pure computation");
     });
+
+    it("should forward the eval config to PTC tools", async () => {
+      const capturedConfigs: unknown[] = [];
+      const configAwareTool = tool(
+        async (_input, config) => {
+          capturedConfigs.push(config);
+          return "config received";
+        },
+        {
+          name: "config_aware",
+          description: "Captures the runnable config.",
+          schema: z.object({}),
+        },
+      );
+      const middleware = createCodeInterpreterMiddleware({
+        ptc: [configAwareTool],
+      });
+      const mockHandler = vi.fn().mockReturnValue({ response: "ok" });
+      await middleware.wrapModelCall!(
+        {
+          systemMessage: new SystemMessage("Base"),
+          state: {},
+          runtime: { configurable: { thread_id: "ptc-config" } },
+          tools: [],
+        } as any,
+        mockHandler,
+      );
+      const evalConfig = {
+        configurable: {
+          thread_id: "ptc-config",
+          task_id: "browser-task",
+        },
+      };
+      const evalTool = middleware.tools!.find(
+        (candidate) => candidate.name === "eval",
+      );
+
+      await expect(
+        evalTool!.invoke({ code: "await tools.configAware({})" }, evalConfig),
+      ).resolves.toContain("config received");
+      expect(capturedConfigs).toHaveLength(1);
+      expect(capturedConfigs[0]).toMatchObject(evalConfig);
+    });
   });
 
   describe("generatePtcPrompt", () => {

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -500,6 +500,7 @@ export function createCodeInterpreterMiddleware(
         session.updateBridgeDispatch(createBridgeDispatch(taskTool, config));
       }
 
+      session.setToolConfig(config);
       const result = await session.eval(input.code, executionTimeoutMs);
       return formatReplResult(result);
     },

--- a/libs/providers/quickjs/src/session.ts
+++ b/libs/providers/quickjs/src/session.ts
@@ -26,6 +26,7 @@ import type {
   QuickJSAsyncWASMModule,
 } from "quickjs-emscripten-core";
 import type { StructuredToolInterface } from "@langchain/core/tools";
+import type { RunnableConfig } from "@langchain/core/runnables";
 
 import { PTCCallBudgetExceededError } from "./errors.js";
 import type {
@@ -230,6 +231,7 @@ export class ReplSession {
   private options: ReplSessionOptions;
   private readonly maxPtcCalls: number | null;
   private ptcCallsRemaining: number | null = null;
+  private toolConfig: RunnableConfig | undefined;
   private subagentQueue: PQueue | null = null;
   private bridgeDispatchRef: {
     current: SubagentBridgeOptions["dispatch"];
@@ -480,6 +482,7 @@ export class ReplSession {
       };
     } finally {
       this.ptcCallsRemaining = null;
+      this.toolConfig = undefined;
     }
   }
 
@@ -516,6 +519,15 @@ export class ReplSession {
       session.dispose();
     }
     ReplSession.sessions.clear();
+  }
+
+  /**
+   * Store the active LangGraph config for programmatic tool calls made by the
+   * current eval. Browser runtimes cannot recover this context through
+   * AsyncLocalStorage, so the middleware must pass it explicitly.
+   */
+  setToolConfig(config?: RunnableConfig): void {
+    this.toolConfig = config;
   }
 
   private setupConsole(): void {
@@ -563,7 +575,7 @@ export class ReplSession {
               this.consumePtcBudget(camelName);
               const rawInput =
                 typeof input === "object" && input !== null ? input : {};
-              const result = await t.invoke(rawInput);
+              const result = await t.invoke(rawInput, this.toolConfig);
               let text = extractToolText(result);
               if (t.name === "read_file") {
                 text = stripLineNumbers(text);


### PR DESCRIPTION
## Summary

- pass the task tool's runnable config to `getCurrentTaskInput(config)` so declarative subagents work in browsers without `AsyncLocalStorage`
- retain the active eval config in the QuickJS session and forward it to `tools.*` PTC calls
- add regression coverage for direct browser-style task invocation and config-aware PTC tools

## Context

This reapplies the fixes from #554 cleanly on current `main`, where that approved PR is now conflict-blocked. Credit to @luizzappa for the original diagnosis and patch. The tests here are adapted to the current native `task()` bridge and current LangChain config normalization.

Fixes #553.

## Verification

- `pnpm --filter @langchain/quickjs test:unit` — 174 passed
- focused DeepAgents subagent suite — 39 passed, no type errors
- focused QuickJS middleware suite — 26 passed
- `deepagents` and `@langchain/quickjs` builds
- `oxlint` and `oxfmt --check` on changed files

The full DeepAgents unit run reached 1,256 passing tests; three unrelated config tests require writing to `~/.deepagents`, and the fresh workspace also reports pre-existing unresolved `@langchain/sandbox-standard-tests/vitest` type imports until that workspace package is built.
