### PR TITLE
fix(deepagents): prevent stack overflow in CompositeBackend grep/glob

### DIFF
--- a/.changeset/grep-max-count-truncation.md
+++ b/.changeset/grep-max-count-truncation.md
@@ -1,0 +1,9 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): prevent stack overflow in CompositeBackend grep/glob on huge result sets, and add a grep match-count cap
+
+`CompositeBackend` accumulated merged `ls`/`grep`/`glob` results with `push(...entries)`, which passes every entry as a separate function argument and overflows the call stack (RangeError: Maximum call stack size exceeded) when a broad search over a large tree returns hundreds of thousands of entries. Results are now accumulated with a plain loop, so no result-set size can overflow the stack.
+
+`grep` also gains an optional `maxCount` (backend) / `max_count` (tool) cap, mirroring the Python SDK. When the cap is hit, results are flagged `truncated: true` on `GrepResult`/`GlobResult` and the grep tool appends a note telling the model to narrow the search. The cap defaults to 1000 via the `grepMaxCount` middleware option (set to `null` to disable). `CompositeBackend` splits the budget across routed backends and OR-propagates the `truncated` flag on merged results.

--- a/libs/deepagents/src/backends/composite.test.ts
+++ b/libs/deepagents/src/backends/composite.test.ts
@@ -366,7 +366,7 @@ describe("CompositeBackend", () => {
     expect(paths).toContain("/workspace/index.ts");
     expect(paths).toContain("/workspace/memories/note.md");
     expect(outsideSpy).not.toHaveBeenCalled();
-    expect(insideSpy).toHaveBeenCalledWith("index", "/", "**/*");
+    expect(insideSpy).toHaveBeenCalledWith("index", "/", "**/*", null);
   });
 
   it("glob should only fan out to routed backends mounted under the search path", async () => {
@@ -933,6 +933,155 @@ describe("CompositeBackend", () => {
       expect(result[0].error).toBeNull();
       expect(result[1].error).toBe("file_not_found");
       expect(result[2].error).toBe("file_not_found");
+    });
+  });
+
+  describe("large result sets", () => {
+    /**
+     * Backend stub returning a large fixed result set, used to exercise the
+     * composite merge paths without a real filesystem walk.
+     */
+    function makeLargeBackend(fileCount: number, matchCount: number) {
+      const files = Array.from({ length: fileCount }, (_, i) => ({
+        path: `/f${i}.txt`,
+        is_dir: false,
+      }));
+      const matches = Array.from({ length: matchCount }, (_, i) => ({
+        path: `/f${i}.txt`,
+        line: 1,
+        text: "hit",
+      }));
+      return {
+        ls: vi.fn().mockResolvedValue({ files }),
+        read: vi.fn().mockResolvedValue({ content: "" }),
+        readRaw: vi.fn().mockResolvedValue({ data: {} }),
+        write: vi.fn().mockResolvedValue({ path: "" }),
+        edit: vi.fn().mockResolvedValue({ path: "" }),
+        grep: vi.fn().mockResolvedValue({ matches }),
+        glob: vi.fn().mockResolvedValue({ files }),
+      };
+    }
+
+    it("glob does not overflow the call stack on a huge default-backend result", async () => {
+      // 200k entries comfortably exceeds V8's argument-spread limit
+      // (~65k-125k), which `results.push(...files)` would hit.
+      const composite = new CompositeBackend(makeLargeBackend(200_000, 0), {});
+
+      const result = await composite.glob("**/*", "/");
+
+      expect(result.error).toBeUndefined();
+      expect(result.files).toHaveLength(200_000);
+    });
+
+    it("grep does not overflow the call stack on a huge default-backend result", async () => {
+      const composite = new CompositeBackend(makeLargeBackend(0, 200_000), {});
+
+      const result = await composite.grep("hit", "/");
+
+      expect(result.error).toBeUndefined();
+      expect(result.matches).toHaveLength(200_000);
+    });
+
+    it("glob does not overflow when merging a huge routed-backend result", async () => {
+      const composite = new CompositeBackend(makeLargeBackend(0, 0), {
+        "/big/": makeLargeBackend(200_000, 0),
+      });
+
+      const result = await composite.glob("**/*", "/");
+
+      expect(result.error).toBeUndefined();
+      expect(result.files).toHaveLength(200_000);
+    });
+  });
+
+  describe("grep maxCount", () => {
+    function makeGrepBackend(matches: GrepResult["matches"]) {
+      return {
+        ls: vi.fn().mockResolvedValue({ files: [] }),
+        read: vi.fn().mockResolvedValue({ content: "" }),
+        readRaw: vi.fn().mockResolvedValue({ data: {} }),
+        write: vi.fn().mockResolvedValue({ path: "" }),
+        edit: vi.fn().mockResolvedValue({ path: "" }),
+        grep: vi.fn().mockResolvedValue({ matches }),
+        glob: vi.fn().mockResolvedValue({ files: [] }),
+      };
+    }
+
+    it("caps matches and flags truncated when the default backend exceeds maxCount", async () => {
+      const matches = Array.from({ length: 10 }, (_, i) => ({
+        path: `/f${i}.txt`,
+        line: 1,
+        text: "hit",
+      }));
+      const composite = new CompositeBackend(makeGrepBackend(matches), {});
+
+      const result = await composite.grep("hit", "/", null, 5);
+
+      expect(result.matches).toHaveLength(5);
+      expect(result.truncated).toBe(true);
+    });
+
+    it("splits the maxCount budget across default and routed backends", async () => {
+      const defaultMatches = Array.from({ length: 4 }, (_, i) => ({
+        path: `/d${i}.txt`,
+        line: 1,
+        text: "hit",
+      }));
+      const routedMatches = Array.from({ length: 4 }, (_, i) => ({
+        path: `/r${i}.txt`,
+        line: 1,
+        text: "hit",
+      }));
+      const defaultBackend = makeGrepBackend(defaultMatches);
+      const routedBackend = makeGrepBackend(routedMatches);
+      const composite = new CompositeBackend(defaultBackend, {
+        "/memories/": routedBackend,
+      });
+
+      const result = await composite.grep("hit", "/", null, 5);
+
+      // Default fills 4 of the 5 budget; the route gets the remaining 1.
+      expect(defaultBackend.grep).toHaveBeenCalledWith("hit", "/", null, 5);
+      expect(routedBackend.grep).toHaveBeenCalledWith("hit", "/", null, 1);
+      expect(result.matches).toHaveLength(5);
+      expect(result.truncated).toBe(true);
+      expect(result.matches!.some((m) => m.path === "/memories/r0.txt")).toBe(
+        true,
+      );
+    });
+
+    it("short-circuits remaining routes once the budget is exhausted", async () => {
+      const defaultMatches = Array.from({ length: 5 }, (_, i) => ({
+        path: `/d${i}.txt`,
+        line: 1,
+        text: "hit",
+      }));
+      const defaultBackend = makeGrepBackend(defaultMatches);
+      const routedBackend = makeGrepBackend([
+        { path: "/r0.txt", line: 1, text: "hit" },
+      ]);
+      const composite = new CompositeBackend(defaultBackend, {
+        "/memories/": routedBackend,
+      });
+
+      const result = await composite.grep("hit", "/", null, 5);
+
+      expect(routedBackend.grep).not.toHaveBeenCalled();
+      expect(result.matches).toHaveLength(5);
+      expect(result.truncated).toBe(true);
+    });
+
+    it("returns all matches untruncated when under the cap", async () => {
+      const matches = [
+        { path: "/a.txt", line: 1, text: "hit" },
+        { path: "/b.txt", line: 2, text: "hit" },
+      ];
+      const composite = new CompositeBackend(makeGrepBackend(matches), {});
+
+      const result = await composite.grep("hit", "/", null, 1000);
+
+      expect(result.matches).toHaveLength(2);
+      expect(result.truncated).toBe(false);
     });
   });
 });

--- a/libs/deepagents/src/backends/composite.ts
+++ b/libs/deepagents/src/backends/composite.ts
@@ -19,8 +19,28 @@ import type {
   ReadResult,
   WriteResult,
 } from "./protocol.js";
-import { isSandboxBackend, isSandboxProtocol } from "./protocol.js";
+import {
+  applyGrepMaxCount,
+  isSandboxBackend,
+  isSandboxProtocol,
+} from "./protocol.js";
 import { adaptBackendProtocol, adaptSandboxProtocol } from "./utils.js";
+
+/**
+ * Remaining match budget for the next routed grep, or null when uncapped.
+ *
+ * Returns 0 once the cap is already met so callers can short-circuit
+ * remaining routes.
+ */
+function remainingGrepBudget(
+  maxCount: number | null | undefined,
+  collected: number,
+): number | null {
+  if (maxCount == null) {
+    return null;
+  }
+  return Math.max(maxCount - collected, 0);
+}
 
 /**
  * Backend that routes file operations to different backends based on path prefix.
@@ -179,7 +199,11 @@ export class CompositeBackend implements BackendProtocolV2 {
         return defaultResult;
       }
 
-      results.push(...(defaultResult.files || []));
+      // Loop instead of spread: push(...files) passes each entry as a
+      // separate argument and overflows the call stack on huge listings.
+      for (const fi of defaultResult.files || []) {
+        results.push(fi);
+      }
 
       // Add the route itself as a directory (e.g., /memories/)
       for (const [routePrefix] of this.sortedRoutes) {
@@ -229,11 +253,16 @@ export class CompositeBackend implements BackendProtocolV2 {
 
   /**
    * Structured search results or error string for invalid input.
+   *
+   * @param maxCount - Optional total cap on returned matches across all routed
+   *                   backends. When the cap is reached, remaining routes are
+   *                   short-circuited and the result is flagged `truncated: true`.
    */
   async grep(
     pattern: string,
     path: string | null = "/",
     glob: string | null = null,
+    maxCount: number | null = null,
   ): Promise<GrepResult> {
     const searchPath = path || "/";
 
@@ -241,7 +270,12 @@ export class CompositeBackend implements BackendProtocolV2 {
     for (const [routePrefix, backend] of this.sortedRoutes) {
       if (this.isPathWithinRoute(searchPath, routePrefix)) {
         const routeSearchPath = searchPath.substring(routePrefix.length - 1);
-        const raw = await backend.grep(pattern, routeSearchPath || "/", glob);
+        const raw = await backend.grep(
+          pattern,
+          routeSearchPath || "/",
+          glob,
+          maxCount,
+        );
 
         if (raw.error) {
           return raw;
@@ -252,19 +286,33 @@ export class CompositeBackend implements BackendProtocolV2 {
           ...m,
           path: routePrefix.slice(0, -1) + m.path,
         }));
-        return { matches };
+        return applyGrepMaxCount(
+          { matches, truncated: raw.truncated },
+          maxCount,
+        );
       }
     }
 
     // Otherwise, search default and routed backends mounted inside this path
     const allMatches: GrepMatch[] = [];
-    const rawDefault = await this.default.grep(pattern, searchPath, glob);
+    let truncated = false;
+    const rawDefault = await this.default.grep(
+      pattern,
+      searchPath,
+      glob,
+      maxCount,
+    );
 
     if (rawDefault.error) {
       return rawDefault;
     }
 
-    allMatches.push(...(rawDefault.matches || []));
+    // Loop instead of spread: push(...matches) passes each entry as a
+    // separate argument and overflows the call stack on huge result sets.
+    for (const m of rawDefault.matches || []) {
+      allMatches.push(m);
+    }
+    truncated = truncated || rawDefault.truncated === true;
 
     // Search only routes that are descendants of the requested path
     for (const [routePrefix, backend] of Object.entries(this.routes)) {
@@ -272,21 +320,27 @@ export class CompositeBackend implements BackendProtocolV2 {
         continue;
       }
 
-      const raw = await backend.grep(pattern, "/", glob);
+      const remaining = remainingGrepBudget(maxCount, allMatches.length);
+      if (remaining === 0) {
+        // Cap already met by earlier backends; skip the rest.
+        truncated = true;
+        break;
+      }
+
+      const raw = await backend.grep(pattern, "/", glob, remaining);
 
       if (raw.error) {
         return raw;
       }
 
       // Add route prefix back
-      const matches = (raw.matches || []).map((m) => ({
-        ...m,
-        path: routePrefix.slice(0, -1) + m.path,
-      }));
-      allMatches.push(...matches);
+      for (const m of raw.matches || []) {
+        allMatches.push({ ...m, path: routePrefix.slice(0, -1) + m.path });
+      }
+      truncated = truncated || raw.truncated === true;
     }
 
-    return { matches: allMatches };
+    return applyGrepMaxCount({ matches: allMatches, truncated }, maxCount);
   }
 
   /**
@@ -310,16 +364,22 @@ export class CompositeBackend implements BackendProtocolV2 {
           ...fi,
           path: routePrefix.slice(0, -1) + fi.path,
         }));
-        return { files };
+        return { files, truncated: result.truncated };
       }
     }
 
     // Path doesn't match any specific route - search default and route descendants
+    let truncated = false;
     const defaultResult = await this.default.glob(pattern, path);
     if (defaultResult.error) {
       return defaultResult;
     }
-    results.push(...(defaultResult.files || []));
+    // Loop instead of spread: push(...files) passes each entry as a
+    // separate argument and overflows the call stack on huge result sets.
+    for (const fi of defaultResult.files || []) {
+      results.push(fi);
+    }
+    truncated = truncated || defaultResult.truncated === true;
 
     for (const [routePrefix, backend] of Object.entries(this.routes)) {
       if (!this.isRouteUnderPath(routePrefix, path)) {
@@ -330,16 +390,15 @@ export class CompositeBackend implements BackendProtocolV2 {
       if (result.error) {
         continue; // Skip backends that error
       }
-      const files = (result.files || []).map((fi) => ({
-        ...fi,
-        path: routePrefix.slice(0, -1) + fi.path,
-      }));
-      results.push(...files);
+      for (const fi of result.files || []) {
+        results.push({ ...fi, path: routePrefix.slice(0, -1) + fi.path });
+      }
+      truncated = truncated || result.truncated === true;
     }
 
     // Deterministic ordering
     results.sort((a, b) => a.path.localeCompare(b.path));
-    return { files: results };
+    return { files: results, truncated };
   }
 
   /**

--- a/libs/deepagents/src/backends/composite.ts
+++ b/libs/deepagents/src/backends/composite.ts
@@ -27,22 +27,6 @@ import {
 import { adaptBackendProtocol, adaptSandboxProtocol } from "./utils.js";
 
 /**
- * Remaining match budget for the next routed grep, or null when uncapped.
- *
- * Returns 0 once the cap is already met so callers can short-circuit
- * remaining routes.
- */
-function remainingGrepBudget(
-  maxCount: number | null | undefined,
-  collected: number,
-): number | null {
-  if (maxCount == null) {
-    return null;
-  }
-  return Math.max(maxCount - collected, 0);
-}
-
-/**
  * Backend that routes file operations to different backends based on path prefix.
  *
  * This enables hybrid storage strategies like:
@@ -286,10 +270,10 @@ export class CompositeBackend implements BackendProtocolV2 {
           ...m,
           path: routePrefix.slice(0, -1) + m.path,
         }));
-        return applyGrepMaxCount(
-          { matches, truncated: raw.truncated },
+        return applyGrepMaxCount({
+          result: { matches, truncated: raw.truncated },
           maxCount,
-        );
+        });
       }
     }
 
@@ -307,8 +291,6 @@ export class CompositeBackend implements BackendProtocolV2 {
       return rawDefault;
     }
 
-    // Loop instead of spread: push(...matches) passes each entry as a
-    // separate argument and overflows the call stack on huge result sets.
     for (const m of rawDefault.matches || []) {
       allMatches.push(m);
     }
@@ -320,9 +302,9 @@ export class CompositeBackend implements BackendProtocolV2 {
         continue;
       }
 
-      const remaining = remainingGrepBudget(maxCount, allMatches.length);
+      const remaining =
+        maxCount == null ? null : Math.max(maxCount - allMatches.length, 0);
       if (remaining === 0) {
-        // Cap already met by earlier backends; skip the rest.
         truncated = true;
         break;
       }
@@ -340,7 +322,10 @@ export class CompositeBackend implements BackendProtocolV2 {
       truncated = truncated || raw.truncated === true;
     }
 
-    return applyGrepMaxCount({ matches: allMatches, truncated }, maxCount);
+    return applyGrepMaxCount({
+      result: { matches: allMatches, truncated },
+      maxCount,
+    });
   }
 
   /**
@@ -369,17 +354,15 @@ export class CompositeBackend implements BackendProtocolV2 {
     }
 
     // Path doesn't match any specific route - search default and route descendants
-    let truncated = false;
     const defaultResult = await this.default.glob(pattern, path);
     if (defaultResult.error) {
       return defaultResult;
     }
-    // Loop instead of spread: push(...files) passes each entry as a
-    // separate argument and overflows the call stack on huge result sets.
+
     for (const fi of defaultResult.files || []) {
       results.push(fi);
     }
-    truncated = truncated || defaultResult.truncated === true;
+    let truncated = defaultResult.truncated === true;
 
     for (const [routePrefix, backend] of Object.entries(this.routes)) {
       if (!this.isRouteUnderPath(routePrefix, path)) {

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -21,6 +21,7 @@ import type {
   ReadResult,
   WriteResult,
 } from "./protocol.js";
+import { applyGrepMaxCount } from "./protocol.js";
 import { performStringReplacement } from "./utils.js";
 
 const URL_COMMIT_SUFFIX_RE = /:([0-9a-f]{8,64})$/i;
@@ -350,6 +351,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
     pattern: string,
     path: string | null = null,
     glob: string | null = null,
+    maxCount: number | null = null,
   ): Promise<GrepResult> {
     let cache: Record<string, string>;
     try {
@@ -383,7 +385,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       }
     }
 
-    return { matches };
+    return applyGrepMaxCount({ matches }, maxCount);
   }
 
   async glob(pattern: string, _path: string = "/"): Promise<GlobResult> {

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -385,7 +385,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       }
     }
 
-    return applyGrepMaxCount({ matches }, maxCount);
+    return applyGrepMaxCount({ result: { matches }, maxCount });
   }
 
   async glob(pattern: string, _path: string = "/"): Promise<GlobResult> {

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -30,6 +30,7 @@ import type {
   ReadResult,
   WriteResult,
 } from "./protocol.js";
+import { applyGrepMaxCount } from "./protocol.js";
 import {
   checkEmptyContent,
   getMimeType,
@@ -567,12 +568,15 @@ export class FilesystemBackend implements BackendProtocolV2 {
    * @param pattern - Literal string to search for (NOT regex).
    * @param dirPath - Directory or file path to search in. Defaults to current directory.
    * @param glob - Optional glob pattern to filter which files to search.
+   * @param maxCount - Optional cap on the total number of matches returned.
+   *                   When the cap is hit, results are flagged `truncated: true`.
    * @returns List of GrepMatch dicts containing path, line number, and matched text.
    */
   async grep(
     pattern: string,
     dirPath: string = "/",
     glob: string | null = null,
+    maxCount: number | null = null,
   ): Promise<GrepResult> {
     // Resolve base path
     let baseFull: string;
@@ -600,7 +604,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
         matches.push({ path: fpath, line: lineNum, text: lineText });
       }
     }
-    return { matches };
+    return applyGrepMaxCount({ matches }, maxCount);
   }
 
   /**

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -604,7 +604,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
         matches.push({ path: fpath, line: lineNum, text: lineText });
       }
     }
-    return applyGrepMaxCount({ matches }, maxCount);
+    return applyGrepMaxCount({ result: { matches }, maxCount });
   }
 
   /**

--- a/libs/deepagents/src/backends/index.ts
+++ b/libs/deepagents/src/backends/index.ts
@@ -45,6 +45,7 @@ export type {
 
 // Export type guard and error class
 export {
+  applyGrepMaxCount,
   isSandboxBackend,
   isSandboxProtocol,
   SandboxError,

--- a/libs/deepagents/src/backends/protocol.ts
+++ b/libs/deepagents/src/backends/protocol.ts
@@ -71,8 +71,41 @@ export interface GrepMatch {
 export interface GrepResult {
   /** Error message on failure, undefined on success */
   error?: string;
-  /** Structured grep match entries, undefined on failure */
+  /**
+   * Structured grep match entries. Populated on success and, when the
+   * search was cut short, with whatever was found before stopping.
+   * Undefined only on a hard failure.
+   */
   matches?: GrepMatch[];
+  /**
+   * True when the search stopped early (e.g. hit a match-count cap) and
+   * `matches` is therefore incomplete but still valid.
+   */
+  truncated?: boolean;
+}
+
+/**
+ * Enforce a match cap after a backend grep has completed.
+ *
+ * When `maxCount` is set and the result exceeds it, the matches are sliced
+ * to the cap and the result is flagged `truncated: true`.
+ */
+export function applyGrepMaxCount(
+  result: GrepResult,
+  maxCount: number | null | undefined,
+): GrepResult {
+  if (
+    maxCount == null ||
+    result.matches == null ||
+    result.matches.length <= maxCount
+  ) {
+    return result;
+  }
+  return {
+    error: result.error,
+    matches: result.matches.slice(0, maxCount),
+    truncated: true,
+  };
 }
 
 /**
@@ -161,8 +194,17 @@ export interface LsResult {
 export interface GlobResult {
   /** Error message on failure, undefined on success */
   error?: string;
-  /** List of FileInfo objects matching the pattern, undefined on failure */
+  /**
+   * List of FileInfo objects matching the pattern. Populated on success and,
+   * when the walk was cut short, with whatever was found before stopping.
+   * Undefined only on a hard failure.
+   */
   files?: FileInfo[];
+  /**
+   * True when the walk stopped early (e.g. hit a time or count limit) and
+   * `files` is therefore incomplete but still valid.
+   */
+  truncated?: boolean;
 }
 
 /**

--- a/libs/deepagents/src/backends/protocol.ts
+++ b/libs/deepagents/src/backends/protocol.ts
@@ -90,10 +90,11 @@ export interface GrepResult {
  * When `maxCount` is set and the result exceeds it, the matches are sliced
  * to the cap and the result is flagged `truncated: true`.
  */
-export function applyGrepMaxCount(
-  result: GrepResult,
-  maxCount: number | null | undefined,
-): GrepResult {
+export function applyGrepMaxCount(params: {
+  result: GrepResult;
+  maxCount: number | null | undefined;
+}): GrepResult {
+  const { result, maxCount } = params;
   if (
     maxCount == null ||
     result.matches == null ||

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -459,7 +459,7 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
       }
     }
 
-    return applyGrepMaxCount({ matches }, maxCount);
+    return applyGrepMaxCount({ result: { matches }, maxCount });
   }
 
   /**

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -30,6 +30,7 @@ import type {
   SandboxBackendProtocolV2,
   WriteResult,
 } from "./protocol.js";
+import { applyGrepMaxCount } from "./protocol.js";
 import { getMimeType, isTextMimeType } from "./utils.js";
 
 /**
@@ -424,6 +425,7 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
     pattern: string,
     path: string = "/",
     glob: string | null = null,
+    maxCount: number | null = null,
   ): Promise<GrepResult> {
     const command = buildGrepCommand(pattern, path, glob);
     const result = await this.execute(command);
@@ -457,7 +459,7 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
       }
     }
 
-    return { matches };
+    return applyGrepMaxCount({ matches }, maxCount);
   }
 
   /**

--- a/libs/deepagents/src/backends/state.ts
+++ b/libs/deepagents/src/backends/state.ts
@@ -356,7 +356,7 @@ export class StateBackend implements BackendProtocolV2 {
   ): GrepResult {
     const files = this.files;
     const result = grepMatchesFromFiles(files, pattern, path, glob);
-    return applyGrepMaxCount({ matches: result }, maxCount);
+    return applyGrepMaxCount({ result: { matches: result }, maxCount });
   }
 
   /**

--- a/libs/deepagents/src/backends/state.ts
+++ b/libs/deepagents/src/backends/state.ts
@@ -19,6 +19,7 @@ import type {
   BackendProtocolV2,
   BackendOptions,
 } from "./protocol.js";
+import { applyGrepMaxCount } from "./protocol.js";
 import {
   createFileData,
   createWriteFileData,
@@ -351,10 +352,11 @@ export class StateBackend implements BackendProtocolV2 {
     pattern: string,
     path: string = "/",
     glob: string | null = null,
+    maxCount: number | null = null,
   ): GrepResult {
     const files = this.files;
     const result = grepMatchesFromFiles(files, pattern, path, glob);
-    return { matches: result };
+    return applyGrepMaxCount({ matches: result }, maxCount);
   }
 
   /**

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -26,6 +26,7 @@ import type {
   WriteResult,
   StateAndStore,
 } from "./protocol.js";
+import { applyGrepMaxCount } from "./protocol.js";
 import {
   createFileData,
   createWriteFileData,
@@ -673,6 +674,7 @@ export class StoreBackend implements BackendProtocolV2 {
     pattern: string,
     path: string = "/",
     glob: string | null = null,
+    maxCount: number | null = null,
   ): Promise<GrepResult> {
     const store = this.getStore();
     const namespace = this.getNamespace();
@@ -689,7 +691,7 @@ export class StoreBackend implements BackendProtocolV2 {
     }
 
     const matches = grepMatchesFromFiles(files, pattern, path, glob);
-    return { matches };
+    return applyGrepMaxCount({ matches }, maxCount);
   }
 
   /**

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -691,7 +691,7 @@ export class StoreBackend implements BackendProtocolV2 {
     }
 
     const matches = grepMatchesFromFiles(files, pattern, path, glob);
-    return applyGrepMaxCount({ matches }, maxCount);
+    return applyGrepMaxCount({ result: { matches }, maxCount });
   }
 
   /**

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -7,9 +7,10 @@
  */
 
 import micromatch from "micromatch";
-import type {
+import {
   AnyBackendProtocol,
   AnySandboxProtocol,
+  applyGrepMaxCount,
   BackendProtocolV1,
   BackendProtocolV2,
   FileData,
@@ -1000,7 +1001,9 @@ export function adaptBackendProtocol(
       const result = await ("grep" in backend
         ? (backend as BackendProtocolV2).grep(pattern, path, glob, maxCount)
         : (backend as BackendProtocolV1).grepRaw(pattern, path, glob));
-      if (Array.isArray(result)) return { matches: result };
+      if (Array.isArray(result)) {
+        return applyGrepMaxCount({ result: { matches: result }, maxCount });
+      }
       if (typeof result === "string") return { error: result };
       return result as GrepResult;
     },

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -996,9 +996,9 @@ export function adaptBackendProtocol(
       if (typeof result === "string") return { content: result };
       return result as ReadResult;
     },
-    async grep(pattern, path, glob): Promise<GrepResult> {
+    async grep(pattern, path, glob, maxCount): Promise<GrepResult> {
       const result = await ("grep" in backend
-        ? (backend as BackendProtocolV2).grep(pattern, path, glob)
+        ? (backend as BackendProtocolV2).grep(pattern, path, glob, maxCount)
         : (backend as BackendProtocolV1).grepRaw(pattern, path, glob));
       if (Array.isArray(result)) return { matches: result };
       if (typeof result === "string") return { error: result };

--- a/libs/deepagents/src/backends/v2/protocol.ts
+++ b/libs/deepagents/src/backends/v2/protocol.ts
@@ -88,12 +88,15 @@ export interface BackendProtocolV2 extends Omit<
    * @param pattern - Literal text pattern to search for
    * @param path - Base path to search from (default: null)
    * @param glob - Optional glob pattern to filter files (e.g., "*.py")
+   * @param maxCount - Optional cap on the total number of matches returned.
+   *                   When the cap is hit, results are flagged `truncated: true`.
    * @returns GrepResult with matches on success or error on failure
    */
   grep(
     pattern: string,
     path?: string | null,
     glob?: string | null,
+    maxCount?: number | null,
   ): MaybePromise<GrepResult>;
 
   /**

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -145,6 +145,7 @@ export {
   type BackendProtocolV2,
   type BackendFactory,
   type BackendRuntime,
+  applyGrepMaxCount,
   resolveBackend,
   type FileInfo,
   type GrepMatch,

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1449,6 +1449,112 @@ describe("createFilesystemMiddleware", () => {
       expect(typeof result).toBe("string");
       expect(result).toContain("No matches found");
     });
+
+    it("grep tool passes the configured grepMaxCount to the backend", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.grep = vi.fn().mockResolvedValue({ matches: [] });
+
+      const state = { messages: [], files: {} };
+      vi.mocked(getCurrentTaskInput).mockReturnValue(state);
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+        grepMaxCount: 25,
+      });
+
+      const grepTool = middleware.tools!.find(
+        (t: any) => t.name === "grep",
+      ) as any;
+      await grepTool.invoke({ pattern: "needle", path: "/" });
+
+      expect(mockBackend.grep).toHaveBeenCalledWith("needle", "/", null, 25);
+    });
+
+    it("grep tool defaults grepMaxCount to 1000", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.grep = vi.fn().mockResolvedValue({ matches: [] });
+
+      const state = { messages: [], files: {} };
+      vi.mocked(getCurrentTaskInput).mockReturnValue(state);
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+
+      const grepTool = middleware.tools!.find(
+        (t: any) => t.name === "grep",
+      ) as any;
+      await grepTool.invoke({ pattern: "needle", path: "/" });
+
+      expect(mockBackend.grep).toHaveBeenCalledWith("needle", "/", null, 1000);
+    });
+
+    it("grep tool max_count arg overrides the configured default", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.grep = vi.fn().mockResolvedValue({ matches: [] });
+
+      const state = { messages: [], files: {} };
+      vi.mocked(getCurrentTaskInput).mockReturnValue(state);
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+        grepMaxCount: 25,
+      });
+
+      const grepTool = middleware.tools!.find(
+        (t: any) => t.name === "grep",
+      ) as any;
+      await grepTool.invoke({ pattern: "needle", path: "/", max_count: 5 });
+
+      expect(mockBackend.grep).toHaveBeenCalledWith("needle", "/", null, 5);
+    });
+
+    it("grep tool appends the truncation note when the backend flags truncated", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.grep = vi.fn().mockResolvedValue({
+        matches: [{ path: "/a.ts", line: 1, text: "needle" }],
+        truncated: true,
+      });
+
+      const state = { messages: [], files: {} };
+      vi.mocked(getCurrentTaskInput).mockReturnValue(state);
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+
+      const grepTool = middleware.tools!.find(
+        (t: any) => t.name === "grep",
+      ) as any;
+      const result = await grepTool.invoke({ pattern: "needle", path: "/" });
+
+      expect(result).toContain("/a.ts");
+      expect(result).toContain("maximum match count");
+      expect(result).toContain("valid but incomplete");
+    });
+
+    it("grep tool omits the truncation note when the backend result is complete", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.grep = vi.fn().mockResolvedValue({
+        matches: [{ path: "/a.ts", line: 1, text: "needle" }],
+        truncated: false,
+      });
+
+      const state = { messages: [], files: {} };
+      vi.mocked(getCurrentTaskInput).mockReturnValue(state);
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+
+      const grepTool = middleware.tools!.find(
+        (t: any) => t.name === "grep",
+      ) as any;
+      const result = await grepTool.invoke({ pattern: "needle", path: "/" });
+
+      expect(result).toContain("/a.ts");
+      expect(result).not.toContain("maximum match count");
+    });
   });
 
   describe("beforeAgent - large HumanMessage eviction", () => {

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -142,6 +142,20 @@ const READ_FILE_TRUNCATION_MSG = `
 [Output was truncated due to size limits. The file content is very large. Consider reformatting the file to make it easier to navigate. For example, if this is JSON, use execute(command='jq . {file_path}') to pretty-print it with line breaks. For other formats, you can use appropriate formatting tools to split long lines.]`;
 
 /**
+ * Note appended to grep results that were cut short by the match-count cap.
+ */
+export const GREP_TRUNCATION_NOTE =
+  "Note: the search stopped early because it hit the maximum match count. " +
+  "The matches above are valid but incomplete. Narrow the search (a more " +
+  "specific pattern or a narrower path), or raise max_count, to see the rest.";
+
+/**
+ * Default cap on the number of matches the grep tool returns.
+ * Set to null to disable the cap.
+ */
+export const DEFAULT_GREP_MAX_COUNT = 1000;
+
+/**
  * Message template for evicted tool results.
  */
 const TOO_LARGE_TOOL_MSG = context`
@@ -1040,9 +1054,11 @@ function createGrepTool(
     customDescription: string | undefined;
     permissions: FilesystemPermission[];
     includeExecution: boolean;
+    grepMaxCount: number | null;
   },
 ) {
-  const { customDescription, permissions, includeExecution } = options;
+  const { customDescription, permissions, includeExecution, grepMaxCount } =
+    options;
   return tool(
     async (input, runtime: ToolRuntime) => {
       const permissionError = checkPermission(
@@ -1056,7 +1072,9 @@ function createGrepTool(
 
       const resolvedBackend = await resolveBackend(backend, runtime);
       const { pattern, path = "/", glob = null } = input;
-      const result = await resolvedBackend.grep(pattern, path, glob);
+      // A per-call max_count overrides the configured middleware default.
+      const maxCount = input.max_count ?? grepMaxCount;
+      const result = await resolvedBackend.grep(pattern, path, glob, maxCount);
 
       // If string, it's an error
       if (result.error) {
@@ -1086,11 +1104,12 @@ function createGrepTool(
       }
 
       const truncated = truncateIfTooLong(lines);
+      let content = Array.isArray(truncated) ? truncated.join("\n") : truncated;
 
-      if (Array.isArray(truncated)) {
-        return truncated.join("\n");
+      if (result.truncated) {
+        content += `\n\n${GREP_TRUNCATION_NOTE}`;
       }
-      return truncated;
+      return content;
     },
     {
       name: "grep",
@@ -1111,6 +1130,18 @@ function createGrepTool(
           .nullable()
           .default(null)
           .describe("Optional glob pattern to filter files (e.g., '*.py')"),
+        max_count: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .nullable()
+          .default(null)
+          .describe(
+            "Optional cap on the total number of matches returned across all files. " +
+              "Leave unset to use the configured default. When the cap is hit, results " +
+              "are truncated and a note says so; narrow the pattern or path to see the rest.",
+          ),
       }),
     },
   );
@@ -1244,6 +1275,14 @@ export interface FilesystemMiddlewareOptions {
    * When omitted or empty, all filesystem operations are permitted.
    */
   permissions?: FilesystemPermission[];
+  /**
+   * Default cap on the number of matches the grep tool returns (default: 1000).
+   *
+   * When the cap is hit, the returned matches are flagged as truncated and a
+   * note tells the model to narrow the search. A per-call `max_count` tool
+   * argument overrides this default. Set to `null` to disable the cap.
+   */
+  grepMaxCount?: number | null;
 }
 
 /**
@@ -1325,6 +1364,7 @@ export function createFilesystemMiddleware(
     humanMessageTokenLimitBeforeEvict = 50000,
     permissions = [],
     tools: filesystemTools = null,
+    grepMaxCount = DEFAULT_GREP_MAX_COUNT,
   } = options;
   const enabledFilesystemTools = normalizeFilesystemTools(filesystemTools);
   const executeToolEnabled =
@@ -1387,6 +1427,7 @@ export function createFilesystemMiddleware(
         configuredToolNames.has("execute") &&
         typeof backend !== "function" &&
         isSandboxBackend(backend),
+      grepMaxCount,
     }),
     execute: createExecuteTool(backend, {
       customDescription: customToolDescriptions?.execute,

--- a/libs/providers/node-vfs/src/backend.ts
+++ b/libs/providers/node-vfs/src/backend.ts
@@ -1039,7 +1039,7 @@ export class VfsBackend implements BackendProtocolV2 {
       scanFile(resolvedPath);
     }
 
-    return applyGrepMaxCount({ matches }, maxCount);
+    return applyGrepMaxCount({ result: { matches }, maxCount });
   }
 
   /**

--- a/libs/providers/node-vfs/src/backend.ts
+++ b/libs/providers/node-vfs/src/backend.ts
@@ -29,6 +29,7 @@ import {
   type ReadResult,
   type BackendFactory,
   type WriteResult,
+  applyGrepMaxCount,
 } from "deepagents";
 
 import { VirtualFileSystem } from "node-vfs-polyfill";
@@ -968,6 +969,7 @@ export class VfsBackend implements BackendProtocolV2 {
     pattern: string,
     searchPath: string = "/",
     glob: string | null = null,
+    maxCount: number | null = null,
   ): Promise<GrepResult> {
     this.#ensureInitialized();
 
@@ -1037,7 +1039,7 @@ export class VfsBackend implements BackendProtocolV2 {
       scanFile(resolvedPath);
     }
 
-    return { matches };
+    return applyGrepMaxCount({ matches }, maxCount);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixes `RangeError: Maximum call stack size exceeded` from `CompositeBackend.glob`/`grep` when a broad search (e.g. `**/*.{ts,tsx,...}` at `/`) returns hundreds of thousands of entries. Root cause: results were merged with `push(...entries)`, which passes each entry as a separate function argument and overflows V8's argument-stack limit. Now accumulated with a plain loop.
- Ports the Python SDK's grep match-count cap (`ef591e7`): optional `maxCount` backend param / `max_count` tool arg, `grepMaxCount` middleware option (default 1000, `null` disables), `truncated` flag on `GrepResult`/`GlobResult`, and a truncation note in the grep tool output. `CompositeBackend` splits the budget across routes and OR-propagates `truncated`.

## Backward compatibility

- `truncated` is optional; `maxCount` defaults to unset everywhere. No required changes for existing or new users.

## Test plan

- [x] Regression test: mocked backend returning 200k entries — `glob`/`grep` complete without `RangeError` (verified it fails with the old spread).
- [x] Cap enforcement, `truncated` propagation across composite routes, middleware note rendering.
- [x] `pnpm test` (format + lint + all lib tests) passes.
