### PR TITLE
feat(deepagents): add output_mode parameter to the grep tool

### DIFF
--- a/.changeset/grep-output-mode.md
+++ b/.changeset/grep-output-mode.md
@@ -1,0 +1,5 @@
+---
+"deepagents": minor
+---
+
+feat(deepagents): add `output_mode` parameter to the `grep` tool (`files_with_matches` / `content` / `count`)

--- a/.changeset/grep-output-mode.md
+++ b/.changeset/grep-output-mode.md
@@ -1,5 +1,5 @@
 ---
-"deepagents": minor
+"deepagents": patch
 ---
 
 feat(deepagents): add `output_mode` parameter to the `grep` tool (`files_with_matches` / `content` / `count`)

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1555,6 +1555,42 @@ describe("createFilesystemMiddleware", () => {
       expect(result).toContain("/a.ts");
       expect(result).not.toContain("maximum match count");
     });
+
+    it("grep tool should support output_mode files_with_matches and count", async () => {
+      const matches = [
+        { path: "/src/file1.ts", line: 10, text: "const pattern = 'test'" },
+        { path: "/src/file1.ts", line: 20, text: "another pattern here" },
+        { path: "/src/file2.ts", line: 5, text: "pattern.match(/test/)" },
+      ];
+
+      const mockBackend = createMockBackend();
+      mockBackend.grep = vi.fn().mockResolvedValue({ matches });
+
+      const state = { messages: [], files: {} };
+      vi.mocked(getCurrentTaskInput).mockReturnValue(state);
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+
+      const grepTool = middleware.tools!.find(
+        (t: any) => t.name === "grep",
+      ) as any;
+
+      const filesResult = await grepTool.invoke({
+        pattern: "pattern",
+        path: "/",
+        output_mode: "files_with_matches",
+      });
+      expect(filesResult).toBe("/src/file1.ts\n/src/file2.ts");
+
+      const countResult = await grepTool.invoke({
+        pattern: "pattern",
+        path: "/",
+        output_mode: "count",
+      });
+      expect(countResult).toBe("/src/file1.ts: 2\n/src/file2.ts: 1");
+    });
   });
 
   describe("beforeAgent - large HumanMessage eviction", () => {

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -33,6 +33,7 @@ import { StateBackend } from "../backends/state.js";
 import {
   sanitizeToolCallId,
   formatContentWithLineNumbers,
+  formatGrepMatches,
   truncateIfTooLong,
   getMimeType,
   isTextMimeType,
@@ -1071,7 +1072,8 @@ function createGrepTool(
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
-      const { pattern, path = "/", glob = null } = input;
+      const { pattern, path = "/", glob = null, output_mode = "content" } =
+        input;
       // A per-call max_count overrides the configured middleware default.
       const maxCount = input.max_count ?? grepMaxCount;
       const result = await resolvedBackend.grep(pattern, path, glob, maxCount);
@@ -1092,19 +1094,9 @@ function createGrepTool(
         return `No matches found for pattern '${pattern}'`;
       }
 
-      // Format output: group by file
-      const lines: string[] = [];
-      let currentFile: string | null = null;
-      for (const match of matches) {
-        if (match.path !== currentFile) {
-          currentFile = match.path;
-          lines.push(`\n${currentFile}:`);
-        }
-        lines.push(`  ${match.line}: ${match.text}`);
-      }
-
-      const truncated = truncateIfTooLong(lines);
-      let content = Array.isArray(truncated) ? truncated.join("\n") : truncated;
+      const formatted = formatGrepMatches(matches, output_mode);
+      const truncated = truncateIfTooLong(formatted);
+      let content = typeof truncated === "string" ? truncated : truncated.join("\n");
 
       if (result.truncated) {
         content += `\n\n${GREP_TRUNCATION_NOTE}`;
@@ -1141,6 +1133,13 @@ function createGrepTool(
             "Optional cap on the total number of matches returned across all files. " +
               "Leave unset to use the configured default. When the cap is hit, results " +
               "are truncated and a note says so; narrow the pattern or path to see the rest.",
+          ),
+        output_mode: z
+          .enum(["files_with_matches", "content", "count"])
+          .optional()
+          .default("content")
+          .describe(
+            "Output format: 'files_with_matches' lists matching file paths, 'content' shows matching lines (default), 'count' shows match counts per file",
           ),
       }),
     },

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -1072,8 +1072,12 @@ function createGrepTool(
       }
 
       const resolvedBackend = await resolveBackend(backend, runtime);
-      const { pattern, path = "/", glob = null, output_mode = "content" } =
-        input;
+      const {
+        pattern,
+        path = "/",
+        glob = null,
+        output_mode = "content",
+      } = input;
       // A per-call max_count overrides the configured middleware default.
       const maxCount = input.max_count ?? grepMaxCount;
       const result = await resolvedBackend.grep(pattern, path, glob, maxCount);
@@ -1096,7 +1100,8 @@ function createGrepTool(
 
       const formatted = formatGrepMatches(matches, output_mode);
       const truncated = truncateIfTooLong(formatted);
-      let content = typeof truncated === "string" ? truncated : truncated.join("\n");
+      let content =
+        typeof truncated === "string" ? truncated : truncated.join("\n");
 
       if (result.truncated) {
         content += `\n\n${GREP_TRUNCATION_NOTE}`;


### PR DESCRIPTION
## Summary
- The grep tool's description mentioned output_mode, but it was never an actual parameter the tool always returned one hardcoded format.
- Added output_mode (files_with_matches/content/count) as a real schema parameter, using the existing formatGrepMatches helper.

## Test plan
- Added tests in fs.test.ts for files_with_matches and count modes.
- All tests pass.

Note: default output is now sorted by path with no blank lines between file groups (minor formatting change, same info).