### PR TITLE
fix: correct changelogs and versions

### DIFF
--- a/libs/providers/daytona/CHANGELOG.md
+++ b/libs/providers/daytona/CHANGELOG.md
@@ -1,6 +1,8 @@
 # @langchain/daytona
 
-## 1.0.0
+## 0.2.2
+
+- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.2.2 instead.
 
 ## 1.0.0-rc.0
 

--- a/libs/providers/daytona/CHANGELOG.md
+++ b/libs/providers/daytona/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.2.2
 
-- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.2.2 instead.
-
 ## 1.0.0-rc.0
 
 ### Patch Changes

--- a/libs/providers/daytona/package.json
+++ b/libs/providers/daytona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/daytona",
-  "version": "1.0.0",
+  "version": "0.2.2",
   "description": "Daytona Sandbox backend for deepagents",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/libs/providers/deno/CHANGELOG.md
+++ b/libs/providers/deno/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.2.3
 
-- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.2.3 instead.
-
 ## 1.0.0-rc.0
 
 ### Patch Changes

--- a/libs/providers/deno/CHANGELOG.md
+++ b/libs/providers/deno/CHANGELOG.md
@@ -1,6 +1,8 @@
 # @langchain/deno
 
-## 1.0.0
+## 0.2.3
+
+- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.2.3 instead.
 
 ## 1.0.0-rc.0
 

--- a/libs/providers/deno/package.json
+++ b/libs/providers/deno/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/deno",
-  "version": "1.0.0",
+  "version": "0.2.3",
   "description": "Deno Sandbox backend for deepagents",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/libs/providers/modal/CHANGELOG.md
+++ b/libs/providers/modal/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.1.6
 
-- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.1.6 instead.
-
 ## 1.0.0-rc.0
 
 ### Patch Changes

--- a/libs/providers/modal/CHANGELOG.md
+++ b/libs/providers/modal/CHANGELOG.md
@@ -1,6 +1,8 @@
 # @langchain/modal
 
-## 1.0.0
+## 0.1.6
+
+- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.1.6 instead.
 
 ## 1.0.0-rc.0
 

--- a/libs/providers/modal/package.json
+++ b/libs/providers/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/modal",
-  "version": "1.0.0",
+  "version": "0.1.6",
   "description": "Modal Sandbox backend for deepagents",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/libs/providers/node-vfs/CHANGELOG.md
+++ b/libs/providers/node-vfs/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.2.2
 
-- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.2.2 instead.
-
 ### Patch Changes
 
 - [#674](https://github.com/langchain-ai/deepagentsjs/pull/674) [`dd142fe`](https://github.com/langchain-ai/deepagentsjs/commit/dd142fe4fc54c986d5bcf51211d9a839a427e931) Thanks [@hntrl](https://github.com/hntrl)! - fix: allow `VfsBackend.write` to overwrite existing files while continuing to reject symlinks

--- a/libs/providers/node-vfs/CHANGELOG.md
+++ b/libs/providers/node-vfs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # @langchain/node-vfs
 
-## 1.0.0
+## 0.2.2
+
+- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.2.2 instead.
 
 ### Patch Changes
 

--- a/libs/providers/node-vfs/package.json
+++ b/libs/providers/node-vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/node-vfs",
-  "version": "1.0.0",
+  "version": "0.2.2",
   "description": "Virtual File System sandbox backend for deepagents",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/libs/providers/quickjs/CHANGELOG.md
+++ b/libs/providers/quickjs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # @langchain/quickjs
 
-## 1.0.0
+## 0.6.1
+
+- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.6.1 instead.
 
 ## 1.0.0-rc.0
 

--- a/libs/providers/quickjs/CHANGELOG.md
+++ b/libs/providers/quickjs/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.6.1
 
-- The 1.0.0 release was published by mistake and has been deprecated. Please use 0.6.1 instead.
-
 ## 1.0.0-rc.0
 
 ### Patch Changes

--- a/libs/providers/quickjs/package.json
+++ b/libs/providers/quickjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/quickjs",
-  "version": "1.0.0",
+  "version": "0.6.1",
   "description": "Sandboxed JavaScript REPL for deepagents using QuickJS (WASM)",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Correct the release metadata for provider packages whose `1.0.0` versions were published prematurely and deprecated. This preserves the intended pre-1.0 version lines by advancing each affected package by a patch release.

## Changes

### Provider packages

- Change `@langchain/node-vfs` and `@langchain/daytona` to `0.2.2`; `@langchain/deno` to `0.2.3`; `@langchain/modal` to `0.1.6`; and `@langchain/quickjs` to `0.6.1`.
- Replace each accidental `1.0.0` changelog heading with the corrected patch version and a notice directing consumers away from the deprecated release.

