### PR TITLE
fix(deepagents): disable summary input trimming by default

### DIFF
--- a/.changeset/summary-input-trim-default.md
+++ b/.changeset/summary-input-trim-default.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): disable summary-input trimming by default
+
+Match Python DeepAgents by providing the full selected conversation to the summarizer unless `trimTokensToSummarize` is explicitly configured. This prevents oversized tool results from producing context-empty summaries under the default configuration.

--- a/libs/deepagents/src/middleware/summarization.test.ts
+++ b/libs/deepagents/src/middleware/summarization.test.ts
@@ -475,6 +475,36 @@ describe("createSummarizationMiddleware", () => {
     });
   });
 
+  describe("summary input trimming", () => {
+    it("does not trim an oversized summary input by default", async () => {
+      const invoke = vi.fn(async (_messages: BaseMessage[]) => ({
+        content: "Summary of the conversation.",
+      }));
+      const middleware = createSummarizationMiddleware({
+        model: {
+          profile: { maxInputTokens: 128_000 },
+          invoke,
+        } as any,
+        backend: createMockBackend(),
+        trigger: { type: "messages", value: 2 },
+        keep: { type: "messages", value: 1 },
+      });
+      const oversizedContent = `important tool result: ${"x".repeat(20_000)}`;
+
+      const { result } = await callWrapModelCall(middleware, {
+        messages: [
+          new HumanMessage({ content: oversizedContent }),
+          new HumanMessage({ content: "Continue with the task." }),
+        ],
+      });
+
+      expect(isCommand(result)).toBe(true);
+      expect(invoke).toHaveBeenCalledOnce();
+      const summaryRequest = invoke.mock.calls[0][0] as BaseMessage[];
+      expect(summaryRequest[0].content).toContain(oversizedContent);
+    });
+  });
+
   describe("argument truncation", () => {
     it("should count tokens once when nothing is truncated or summarized", async () => {
       const middleware = createSummarizationMiddleware({

--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -153,8 +153,8 @@ export interface SummarizationMiddlewareOptions {
   summaryPrompt?: string;
 
   /**
-   * Max tokens to include when generating summary.
-   * Defaults to 4000.
+   * Max tokens to include when generating a summary.
+   * If omitted, the complete selected conversation is provided to the summarizer.
    */
   trimTokensToSummarize?: number;
 
@@ -173,7 +173,6 @@ export interface SummarizationMiddlewareOptions {
 
 // Default values
 const DEFAULT_MESSAGES_TO_KEEP = 20;
-const DEFAULT_TRIM_TOKEN_LIMIT = 4000;
 
 // Fallback defaults when model has no profile (matches Python's fallback)
 const FALLBACK_TRIGGER: ContextSize = { type: "tokens", value: 170_000 };
@@ -301,7 +300,7 @@ export function createSummarizationMiddleware(
     model,
     backend,
     summaryPrompt = DEFAULT_SUMMARY_PROMPT,
-    trimTokensToSummarize = DEFAULT_TRIM_TOKEN_LIMIT,
+    trimTokensToSummarize,
     historyPathPrefix = "/conversation_history",
   } = options;
 
@@ -923,7 +922,7 @@ export function createSummarizationMiddleware(
     // Trim messages if too long
     let messagesToSummarize = messages;
     const tokens = countTokensApproximately(messages);
-    if (tokens > trimTokensToSummarize) {
+    if (trimTokensToSummarize !== undefined && tokens > trimTokensToSummarize) {
       // Keep only recent messages that fit
       let kept = 0;
       const trimmedMessages: BaseMessage[] = [];


### PR DESCRIPTION
## Summary

Prevent default DeepAgents JS summarization from discarding an oversized message before it reaches the summary model

## Changes

### `deepagents`

- Make `trimTokensToSummarize` opt-in rather than defaulting to 4,000 tokens.
- Preserve existing capped behavior when callers explicitly configure the option.
- Add coverage confirming oversized summary input reaches the summary model under default configuration.
- Add a patch changeset for the bug fix.
