### PR TITLE
fix(deepagents): return tool exceptions as error messages

### DIFF
--- a/.changeset/tool-errors-as-messages.md
+++ b/.changeset/tool-errors-as-messages.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): return tool exceptions as error messages

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -599,6 +599,38 @@ describe("createFilesystemMiddleware", () => {
       expect(result).toBe(mockMessage);
     });
 
+    it.each([null, 100])(
+      "should convert thrown tool errors into error ToolMessages (limit: %s)",
+      async (toolTokenLimitBeforeEvict) => {
+        const middleware = createFilesystemMiddleware({
+          backend: createMockBackend(),
+          toolTokenLimitBeforeEvict,
+        });
+        const mockHandler = vi
+          .fn()
+          .mockRejectedValue(new Error("permission denied"));
+        const request = {
+          toolCall: { id: "test-id", name: "test_tool" },
+          runtime: { toolCall: { id: "test-id", name: "test_tool" } },
+          state: {},
+          config: {},
+        };
+
+        const result = await middleware.wrapToolCall!(
+          request as any,
+          mockHandler,
+        );
+
+        expect(ToolMessage.isInstance(result)).toBe(true);
+        if (ToolMessage.isInstance(result)) {
+          expect(result.status).toBe("error");
+          expect(result.name).toBe("test_tool");
+          expect(result.tool_call_id).toBe("test-id");
+          expect(result.content).toContain("Error: permission denied");
+        }
+      },
+    );
+
     it("should not evict tools in TOOLS_EXCLUDED_FROM_EVICTION even with large results", async () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -444,6 +444,19 @@ function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
+/** Extract a useful stack trace from an unknown thrown value when available. */
+function getToolErrorMessage(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "stack" in error &&
+    typeof (error as { stack?: unknown }).stack === "string"
+  ) {
+    return (error as { stack: string }).stack;
+  }
+  return getErrorMessage(error);
+}
+
 /**
  * Check whether `path` is permitted under `rules` for `operation`, returning an
  * error string to surface to the model (or `undefined` when allowed).
@@ -486,14 +499,15 @@ function checkPermission(
  * successful result.
  */
 function toolError(
-  runtime: ToolRuntime,
+  runtime: ToolRuntime | undefined,
   toolName: string,
   message: string,
+  toolCallId?: string,
 ): ToolMessage {
   return new ToolMessage({
     content: message,
     name: toolName,
-    tool_call_id: runtime.toolCall?.id as string,
+    tool_call_id: toolCallId ?? (runtime?.toolCall?.id as string),
     status: "error",
   });
 }
@@ -1615,23 +1629,36 @@ export function createFilesystemMiddleware(
       });
     },
     wrapToolCall: async (request, handler) => {
+      const toolName = request.toolCall?.name;
+      const handleToolCall = async () => {
+        try {
+          return await handler(request);
+        } catch (error) {
+          return toolError(
+            undefined,
+            toolName ?? "unknown",
+            getToolErrorMessage(error),
+            request.toolCall?.id,
+          );
+        }
+      };
+
       // Return early if eviction is disabled
       if (!toolTokenLimitBeforeEvict) {
-        return handler(request);
+        return handleToolCall();
       }
 
       // Check if this tool is excluded from eviction
-      const toolName = request.toolCall?.name;
       if (
         toolName &&
         TOOLS_EXCLUDED_FROM_EVICTION.includes(
           toolName as (typeof TOOLS_EXCLUDED_FROM_EVICTION)[number],
         )
       ) {
-        return handler(request);
+        return handleToolCall();
       }
 
-      const result = await handler(request);
+      const result = await handleToolCall();
 
       if (ToolMessage.isInstance(result)) {
         const processed = await processToolMessage(


### PR DESCRIPTION
Fixes #655

## Summary
- Convert exceptions raised by wrapped tools into `ToolMessage` instances with `status: error`.
- Preserve the tool name, call ID, and stack information so the model can react to the failure.
- Cover tool-call execution with filesystem result eviction enabled and disabled.
- Add a patch changeset.

## Validation
- `pnpm --filter deepagents exec vitest run src/middleware/fs.test.ts`
- `pnpm --filter deepagents build`
- `pnpm format:check`
- `pnpm lint`
- Full unit suite: 1271/1274 tests passed; 3 existing Windows local-shell tests fail because they assume Unix commands, and existing integration-test type errors are caused by the missing sandbox test module.