### PR TITLE
fix(deepagents): prevent summary callbacks from leaking into streams

### DIFF
--- a/.changeset/silent-summary-callbacks.md
+++ b/.changeset/silent-summary-callbacks.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): prevent summary model callbacks from leaking into agent streams

--- a/libs/deepagents/src/middleware/summarization.test.ts
+++ b/libs/deepagents/src/middleware/summarization.test.ts
@@ -516,6 +516,43 @@ describe("createSummarizationMiddleware", () => {
       const summaryMessage = capturedRequest!.messages[0];
       expect(summaryMessage.additional_kwargs?.lc_source).toBe("summarization");
     });
+
+    it("should not inherit callbacks for internal summary model calls", async () => {
+      const mockBackend = createMockBackend();
+      const leakedCallback = vi.fn();
+      const invoke = vi.fn(
+        async (
+          _messages: BaseMessage[],
+          config?: { callbacks?: Array<() => void> },
+        ) => {
+          for (const callback of config?.callbacks ?? [leakedCallback]) {
+            callback();
+          }
+          return new AIMessage({ content: "Summary of the conversation." });
+        },
+      );
+      const middleware = createSummarizationMiddleware({
+        model: {
+          profile: { maxInputTokens: 128_000 },
+          invoke,
+        } as any,
+        backend: mockBackend,
+        trigger: { type: "messages", value: 5 },
+        keep: { type: "messages", value: 2 },
+      });
+
+      const messages = Array.from(
+        { length: 10 },
+        (_, i) => new HumanMessage({ content: `Message ${i}` }),
+      );
+
+      await callWrapModelCall(middleware, { messages });
+
+      expect(invoke).toHaveBeenCalledWith(expect.any(Array), {
+        callbacks: [],
+      });
+      expect(leakedCallback).not.toHaveBeenCalled();
+    });
   });
 
   describe("summary input trimming", () => {
@@ -1394,7 +1431,9 @@ describe("createSummarizationMiddleware", () => {
       expect(isCommand(result)).toBe(true);
       expect(capturedRequest).not.toBeNull();
       expect(invoke).toHaveBeenCalledTimes(1);
-      expect(invoke).toHaveBeenCalledWith(expect.any(Array));
+      expect(invoke).toHaveBeenCalledWith(expect.any(Array), {
+        callbacks: [],
+      });
     });
   });
 });

--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -964,9 +964,10 @@ export function createSummarizationMiddleware(
     const conversation = getBufferString(messagesToSummarize);
     const prompt = summaryPrompt.replace("{conversation}", conversation);
 
-    const response = await chatModel.invoke([
-      new HumanMessage({ content: prompt }),
-    ]);
+    const response = await chatModel.invoke(
+      [new HumanMessage({ content: prompt })],
+      { callbacks: [] },
+    );
 
     return response.text;
   }


### PR DESCRIPTION
## Summary

- prevent the summarization model call from inheriting parent agent callbacks
- add a regression test proving callbacks are cleared for internal summary calls

Fixes #629

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter ./libs/deepagents typecheck`
- `pnpm build`
- `pnpm --filter ./libs/deepagents test -- src/middleware/summarization.test.ts` (34 passed)
- `pnpm --filter ./libs/deepagents exec vitest run --exclude src/backends/local-shell.test.ts` (1247 passed)

The full unit suite has 1272 passed and 3 unrelated Windows shell-test failures in `src/backends/local-shell.test.ts` because those tests invoke Unix commands (`cat`, `sleep`, and `bash`).