### PR TITLE
fix(acp): contain filesystem paths within workspace

### DIFF
--- a/.changeset/secure-acp-workspace.md
+++ b/.changeset/secure-acp-workspace.md
@@ -1,0 +1,5 @@
+---
+"deepagents-acp": patch
+---
+
+Keep ACP and local filesystem backends contained within the configured workspace root by default.

--- a/libs/acp/src/acp-filesystem-backend.test.ts
+++ b/libs/acp/src/acp-filesystem-backend.test.ts
@@ -64,6 +64,32 @@ describe("ACPFilesystemBackend", () => {
       expect(callArgs.path).toContain("local.txt");
     });
 
+    it("should keep absolute virtual paths inside the workspace root", async () => {
+      const backend = new ACPFilesystemBackend({
+        conn: mockConn,
+        rootDir: tmpDir,
+      });
+      backend.setSessionId("sess_123");
+
+      await backend.read("/outside.txt");
+
+      const callArgs = mockConn.readTextFile.mock.calls[0][0];
+      expect(callArgs.path).toBe(path.join(tmpDir, "outside.txt"));
+    });
+
+    it("should keep absolute virtual write paths inside the workspace root", async () => {
+      const backend = new ACPFilesystemBackend({
+        conn: mockConn,
+        rootDir: tmpDir,
+      });
+      backend.setSessionId("sess_123");
+
+      await backend.write("/outside.txt", "content");
+
+      const callArgs = mockConn.writeTextFile.mock.calls[0][0];
+      expect(callArgs.path).toBe(path.join(tmpDir, "outside.txt"));
+    });
+
     it("should fall back to local FS when no session is set", async () => {
       const backend = new ACPFilesystemBackend({
         conn: mockConn,

--- a/libs/acp/src/acp-filesystem-backend.ts
+++ b/libs/acp/src/acp-filesystem-backend.ts
@@ -12,7 +12,6 @@ import {
   type WriteResult,
   type ReadResult,
 } from "deepagents";
-import path from "node:path";
 
 /**
  * Backend that proxies read/write through ACP client while using local
@@ -22,8 +21,15 @@ export class ACPFilesystemBackend extends FilesystemBackend {
   private conn: AgentSideConnection;
   private currentSessionId: string | null = null;
 
-  constructor(options: { conn: AgentSideConnection; rootDir: string }) {
-    super({ rootDir: options.rootDir });
+  constructor(options: {
+    conn: AgentSideConnection;
+    rootDir: string;
+    virtualMode?: boolean;
+  }) {
+    super({
+      rootDir: options.rootDir,
+      virtualMode: options.virtualMode ?? true,
+    });
     this.conn = options.conn;
   }
 
@@ -32,8 +38,7 @@ export class ACPFilesystemBackend extends FilesystemBackend {
   }
 
   private resolveAbsPath(filePath: string): string {
-    if (path.isAbsolute(filePath)) return filePath;
-    return path.resolve(this.cwd, filePath);
+    return this.resolvePath(filePath);
   }
 
   /**

--- a/libs/acp/src/cli.ts
+++ b/libs/acp/src/cli.ts
@@ -307,7 +307,10 @@ async function main(): Promise<void> {
         name: options.name,
         description: options.description,
         model: options.model,
-        backend: new FilesystemBackend({ rootDir: workspaceRoot }),
+        backend: new FilesystemBackend({
+          rootDir: workspaceRoot,
+          virtualMode: true,
+        }),
         skills,
         memory,
       },

--- a/libs/acp/src/server.test.ts
+++ b/libs/acp/src/server.test.ts
@@ -16,8 +16,10 @@ vi.mock("deepagents", () => {
   // Define MockFilesystemBackend inside the factory to avoid hoisting issues
   class MockFilesystemBackend {
     rootDir: string;
-    constructor(options: { rootDir: string }) {
+    virtualMode: boolean;
+    constructor(options: { rootDir: string; virtualMode?: boolean }) {
       this.rootDir = options.rootDir;
+      this.virtualMode = options.virtualMode ?? false;
     }
     ls = vi.fn();
     read = vi.fn();
@@ -125,6 +127,37 @@ describe("DeepAgentsServer", () => {
 
       const server = new DeepAgentsServer(options);
       expect(server).toBeInstanceOf(DeepAgentsServer);
+    });
+  });
+
+  describe("backend creation", () => {
+    it("enables virtual mode for ACP and local filesystem backends", () => {
+      const server = new DeepAgentsServer({
+        agents: { name: "test-agent" },
+        workspaceRoot: "/workspace",
+      });
+      const serverAny = server as unknown as {
+        clientCapabilities: {
+          fsReadTextFile?: boolean;
+          fsWriteTextFile?: boolean;
+        };
+        connection: unknown;
+        createBackend: (config: DeepAgentConfig) => {
+          virtualMode: boolean;
+        };
+      };
+      const config: DeepAgentConfig = { name: "test-agent" };
+
+      serverAny.clientCapabilities = {
+        fsReadTextFile: true,
+        fsWriteTextFile: true,
+      };
+      serverAny.connection = {};
+      expect(serverAny.createBackend(config).virtualMode).toBe(true);
+
+      serverAny.clientCapabilities = {};
+      serverAny.connection = null;
+      expect(serverAny.createBackend(config).virtualMode).toBe(true);
     });
   });
 

--- a/libs/acp/src/server.ts
+++ b/libs/acp/src/server.ts
@@ -1360,6 +1360,7 @@ export class DeepAgentsServer {
       const backend = new ACPFilesystemBackend({
         conn: this.connection,
         rootDir: this.workspaceRoot,
+        virtualMode: true,
       });
       this.acpBackends.set(config.name, backend);
       return backend;
@@ -1368,6 +1369,7 @@ export class DeepAgentsServer {
     this.log("Creating FilesystemBackend:", { rootDir: this.workspaceRoot });
     return new FilesystemBackend({
       rootDir: this.workspaceRoot,
+      virtualMode: true,
     });
   }
 

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -77,7 +77,7 @@ export class FilesystemBackend implements BackendProtocolV2 {
    * @returns Resolved absolute path string
    * @throws Error if path traversal detected or path outside root
    */
-  private resolvePath(key: string): string {
+  protected resolvePath(key: string): string {
     if (this.virtualMode) {
       const vpath = key.startsWith("/") ? key : "/" + key;
       if (vpath.includes("..") || vpath.startsWith("~")) {

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -79,6 +79,15 @@ export class FilesystemBackend implements BackendProtocolV2 {
    */
   protected resolvePath(key: string): string {
     if (this.virtualMode) {
+      if (path.isAbsolute(key)) {
+        const relative = path.relative(this.cwd, key);
+        if (
+          relative === "" ||
+          (!relative.startsWith("..") && !path.isAbsolute(relative))
+        ) {
+          return key;
+        }
+      }
       const vpath = key.startsWith("/") ? key : "/" + key;
       if (vpath.includes("..") || vpath.startsWith("~")) {
         throw new Error("Path traversal not allowed");


### PR DESCRIPTION
## Summary

- enable virtual-mode containment for ACP and local filesystem backends created by the server and CLI
- reuse the core filesystem path resolver for ACP client read/write proxies
- add regression coverage for absolute virtual read/write paths and both server backend branches

Fixes #653

## Testing

- `pnpm test` in `libs/acp` (159 passed)
- `pnpm --filter deepagents exec vitest run src/backends/filesystem.test.ts` (31 passed)
- `pnpm --filter deepagents-acp build`
- `pnpm format:check`
- `pnpm lint`
- `git diff --check`

The root `pnpm test` reached 1,271 passing tests but also hit three Windows `local-shell` failures and six missing `@langchain/sandbox-standard-tests/vitest` integration type errors; the focused changed-path suites pass.