### PR TITLE
fix(deepagents): persist summarization offloads for StateBackend

### DIFF
--- a/.changeset/curly-bags-summarize.md
+++ b/.changeset/curly-bags-summarize.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): persist conversation history offloads for state-backed backends

--- a/libs/deepagents/src/middleware/summarization.test.ts
+++ b/libs/deepagents/src/middleware/summarization.test.ts
@@ -9,9 +9,11 @@ import {
 } from "./summarization.js";
 import type {
   BackendProtocol,
+  BackendRuntime,
   FileDownloadResponse,
   WriteResult,
 } from "../backends/protocol.js";
+import { StateBackend } from "../backends/state.js";
 import { createMockBackend } from "./test.js";
 
 const mockCountTokensApproximately = vi.hoisted(() => vi.fn());
@@ -705,6 +707,30 @@ describe("createSummarizationMiddleware", () => {
       await callWrapModelCall(middleware, { messages });
 
       expect(writtenPath).toContain("/custom/history/");
+    });
+  });
+
+  describe("state-backed history offload", () => {
+    it("includes legacy StateBackend filesUpdate in the summarization command", async () => {
+      const middleware = createSummarizationMiddleware({
+        model: "gpt-4o-mini",
+        backend: (runtime: BackendRuntime) => new StateBackend(runtime),
+        trigger: { type: "messages", value: 5 },
+        keep: { type: "messages", value: 2 },
+      });
+
+      const messages = Array.from(
+        { length: 10 },
+        (_, i) => new HumanMessage({ content: `Message ${i}` }),
+      );
+
+      const { result } = await callWrapModelCall(middleware, { messages });
+
+      expect(isCommand(result)).toBe(true);
+      const files = (result as any).update.files as Record<string, any>;
+      const [filePath] = Object.keys(files);
+      expect(filePath).toMatch(/^\/conversation_history\//);
+      expect(files[filePath].content).toContain("Message 0");
     });
   });
 

--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -64,6 +64,7 @@ import type {
   AnyBackendProtocol,
   BackendFactory,
   BackendProtocolV2,
+  FileData,
 } from "../backends/protocol.js";
 import { resolveBackend } from "../backends/protocol.js";
 import type { StateBackend } from "../backends/state.js";
@@ -269,6 +270,12 @@ const SummarizationStateSchema = z.object({
   /** Most recent summarization event (private state, not visible to agent) */
   _summarizationEvent: SummarizationEventSchema.optional(),
 });
+
+type FilesUpdate = Record<string, FileData>;
+
+type UploadResultsWithFilesUpdate = Array<{ error?: string }> & {
+  filesUpdate?: FilesUpdate | null;
+};
 
 /**
  * Check if a message is a previous summarization message.
@@ -864,7 +871,7 @@ export function createSummarizationMiddleware(
     resolvedBackend: BackendProtocolV2,
     messages: BaseMessage[],
     state: Record<string, unknown>,
-  ): Promise<string | null> {
+  ): Promise<{ filePath: string; filesUpdate?: FilesUpdate } | null> {
     const filePath = getHistoryPath(state);
     const filteredMessages = filterSummaryMessages(messages);
 
@@ -890,7 +897,11 @@ export function createSummarizationMiddleware(
         }
       }
 
-      let result: { error?: string; path?: string };
+      let result: {
+        error?: string;
+        path?: string;
+        filesUpdate?: FilesUpdate | null;
+      };
       if (existingBytes && resolvedBackend.uploadFiles) {
         // Append: concatenate raw bytes and upload directly
         const combined = new Uint8Array(
@@ -899,12 +910,15 @@ export function createSummarizationMiddleware(
         combined.set(existingBytes, 0);
         combined.set(sectionBytes, existingBytes.byteLength);
 
-        const uploadResults = await resolvedBackend.uploadFiles([
+        const uploadResults = (await resolvedBackend.uploadFiles([
           [filePath, combined],
-        ]);
+        ])) as UploadResultsWithFilesUpdate;
         result = uploadResults[0].error
           ? { error: uploadResults[0].error }
-          : { path: filePath };
+          : {
+              path: filePath,
+              filesUpdate: uploadResults.filesUpdate ?? undefined,
+            };
       } else if (!existingBytes) {
         result = await resolvedBackend.write(filePath, newSection);
       } else {
@@ -925,7 +939,7 @@ export function createSummarizationMiddleware(
         return null;
       }
 
-      return filePath;
+      return { filePath, filesUpdate: result.filesUpdate ?? undefined };
     } catch (e) {
       // oxlint-disable-next-line no-console
       console.warn(
@@ -1015,14 +1029,16 @@ export function createSummarizationMiddleware(
   ): Promise<{
     summaryMessage: HumanMessage;
     filePath: string | null;
+    filesUpdate?: FilesUpdate;
     stateCutoffIndex: number;
   }> {
     const resolvedBackend = await resolveBackend(backend, { state });
-    const filePath = await offloadToBackend(
+    const offloadResult = await offloadToBackend(
       resolvedBackend,
       messagesToSummarize,
       state,
     );
+    const filePath = offloadResult?.filePath ?? null;
 
     if (filePath === null) {
       // oxlint-disable-next-line no-console
@@ -1039,7 +1055,12 @@ export function createSummarizationMiddleware(
         ? previousCutoffIndex + cutoffIndex - 1
         : cutoffIndex;
 
-    return { summaryMessage, filePath, stateCutoffIndex };
+    return {
+      summaryMessage,
+      filePath,
+      filesUpdate: offloadResult?.filesUpdate,
+      stateCutoffIndex,
+    };
   }
 
   /**
@@ -1116,7 +1137,7 @@ export function createSummarizationMiddleware(
         ? (previousEvent as SummarizationEvent).cutoffIndex
         : undefined;
 
-    const { summaryMessage, filePath, stateCutoffIndex } =
+    const { summaryMessage, filePath, filesUpdate, stateCutoffIndex } =
       await summarizeMessages(
         messagesToSummarize,
         resolvedModel,
@@ -1135,6 +1156,7 @@ export function createSummarizationMiddleware(
     let finalStateCutoffIndex = stateCutoffIndex;
     let finalSummaryMessage = summaryMessage;
     let finalFilePath = filePath;
+    let finalFilesUpdate = filesUpdate;
 
     try {
       await handler({ ...request, messages: modifiedMessages });
@@ -1162,6 +1184,7 @@ export function createSummarizationMiddleware(
       finalSummaryMessage = reSumResult.summaryMessage;
       finalFilePath = reSumResult.filePath;
       finalStateCutoffIndex = reSumResult.stateCutoffIndex;
+      finalFilesUpdate = reSumResult.filesUpdate;
 
       modifiedMessages = [reSumResult.summaryMessage];
 
@@ -1170,6 +1193,7 @@ export function createSummarizationMiddleware(
 
     return new Command({
       update: {
+        ...(finalFilesUpdate ? { files: finalFilesUpdate } : {}),
         _summarizationEvent: {
           cutoffIndex: finalStateCutoffIndex,
           summaryMessage: finalSummaryMessage,


### PR DESCRIPTION
## Summary

- Preserve `filesUpdate` returned by `write`, `uploadFiles`, and `edit` while offloading conversation history.
- Include legacy StateBackend updates in the summarization Command so the history file is persisted in graph state.
- Add a regression test using the legacy StateBackend factory path.

Fixes #621

## Validation

- `pnpm --filter deepagents exec vitest run src/middleware/summarization.test.ts` (34 passed)
- `pnpm --filter deepagents typecheck` (passed)
- `pnpm --filter deepagents build` (passed)
- `pnpm lint` (passed)
- `pnpm format:check` (passed)
- `git diff --check` (passed)
- Full `deepagents` unit suite: 1272 passed, 3 pre-existing Windows LocalShellBackend shell compatibility failures in `src/backends/local-shell.test.ts`