### PR TITLE
fix(deepagents): batch concurrent Context Hub mutations

### DIFF
--- a/.changeset/calm-herons-commit.md
+++ b/.changeset/calm-herons-commit.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): batch concurrent Context Hub mutations

--- a/libs/deepagents/src/backends/context-hub.int.test.ts
+++ b/libs/deepagents/src/backends/context-hub.int.test.ts
@@ -170,7 +170,7 @@ describeWithLangSmith(
       }
     });
 
-    it("recovers parent-commit conflicts on stale writers", async () => {
+    it("replays stale edits without losing non-overlapping changes", async () => {
       const identifier = makeIdentifier();
       const backend = new ContextHubBackend(identifier, {
         client: new Client(),
@@ -178,19 +178,33 @@ describeWithLangSmith(
       const staleClient = new Client();
       const pushSpy = vi.spyOn(staleClient, "pushAgent");
       try {
-        expect((await backend.write("/prime.md", "v0")).error).toBeUndefined();
+        expect(
+          (await backend.write("/shared.md", "before\ntarget\nafter")).error,
+        ).toBeUndefined();
 
         const stale = new ContextHubBackend(identifier, {
           client: staleClient,
         });
-        expect(await stale.read("/prime.md")).toMatchObject({ content: "v0" });
+        expect(await stale.read("/shared.md")).toMatchObject({
+          content: "before\ntarget\nafter",
+        });
 
         expect(
-          (await backend.write("/unrelated.md", "v1")).error,
+          (
+            await backend.edit(
+              "/shared.md",
+              "before",
+              "remote insertion\nbefore",
+            )
+          ).error,
         ).toBeUndefined();
 
-        const staleWrite = await stale.write("/local.md", "recovered");
-        expect(staleWrite.error).toBeUndefined();
+        const staleEdit = await stale.edit(
+          "/shared.md",
+          "target",
+          "replacement",
+        );
+        expect(staleEdit.error).toBeUndefined();
         expect(pushSpy).toHaveBeenCalledTimes(2);
         const firstParent = pushSpy.mock.calls[0][1].parentCommit;
         const secondParent = pushSpy.mock.calls[1][1].parentCommit;
@@ -201,11 +215,8 @@ describeWithLangSmith(
         const fresh = new ContextHubBackend(identifier, {
           client: new Client(),
         });
-        expect(await fresh.read("/unrelated.md")).toMatchObject({
-          content: "v1",
-        });
-        expect(await fresh.read("/local.md")).toMatchObject({
-          content: "recovered",
+        expect(await fresh.read("/shared.md")).toMatchObject({
+          content: "remote insertion\nbefore\nreplacement\nafter",
         });
       } finally {
         pushSpy.mockRestore();

--- a/libs/deepagents/src/backends/context-hub.int.test.ts
+++ b/libs/deepagents/src/backends/context-hub.int.test.ts
@@ -170,24 +170,45 @@ describeWithLangSmith(
       }
     });
 
-    it("surfaces parent-commit conflicts on stale writers", async () => {
+    it("recovers parent-commit conflicts on stale writers", async () => {
       const identifier = makeIdentifier();
       const backend = new ContextHubBackend(identifier, {
         client: new Client(),
       });
+      const staleClient = new Client();
+      const pushSpy = vi.spyOn(staleClient, "pushAgent");
       try {
-        expect((await backend.write("/shared.md", "v0")).error).toBeUndefined();
+        expect((await backend.write("/prime.md", "v0")).error).toBeUndefined();
 
         const stale = new ContextHubBackend(identifier, {
+          client: staleClient,
+        });
+        expect(await stale.read("/prime.md")).toMatchObject({ content: "v0" });
+
+        expect(
+          (await backend.write("/unrelated.md", "v1")).error,
+        ).toBeUndefined();
+
+        const staleWrite = await stale.write("/local.md", "recovered");
+        expect(staleWrite.error).toBeUndefined();
+        expect(pushSpy).toHaveBeenCalledTimes(2);
+        const firstParent = pushSpy.mock.calls[0][1].parentCommit;
+        const secondParent = pushSpy.mock.calls[1][1].parentCommit;
+        expect(firstParent).toBeDefined();
+        expect(secondParent).toBeDefined();
+        expect(secondParent).not.toBe(firstParent);
+
+        const fresh = new ContextHubBackend(identifier, {
           client: new Client(),
         });
-        await stale.read("/shared.md");
-
-        expect((await backend.write("/shared.md", "v1")).error).toBeUndefined();
-
-        const staleWrite = await stale.write("/other.md", "should-fail");
-        expect(staleWrite.error).toContain("Hub unavailable");
+        expect(await fresh.read("/unrelated.md")).toMatchObject({
+          content: "v1",
+        });
+        expect(await fresh.read("/local.md")).toMatchObject({
+          content: "recovered",
+        });
       } finally {
+        pushSpy.mockRestore();
         await safeDeleteAgent(identifier);
       }
     });

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -617,14 +617,16 @@ describe("ContextHubBackend", () => {
       });
     });
 
-    it("replays an edit after a 409 conflict without losing a remote same-file insertion", async () => {
+    it("continues a valid 409 retry when a queued edit no longer applies", async () => {
       vi.useFakeTimers();
+      const firstPush = deferred<string>();
       const { backend, client } = makeBackend();
       client.pullAgent
         .mockReset()
         .mockResolvedValueOnce(
           makeContext("base0000", {
             "shared.md": { type: "file", content: "before\ntarget\nafter" },
+            "queued.md": { type: "file", content: "before\ntarget\nafter" },
           }),
         )
         .mockResolvedValueOnce(
@@ -633,25 +635,44 @@ describe("ContextHubBackend", () => {
               type: "file",
               content: "remote insertion\nbefore\ntarget\nafter",
             },
+            "queued.md": {
+              type: "file",
+              content: "before\nremote replacement\nafter",
+            },
             "remote.md": { type: "file", content: "unrelated" },
           }),
         );
       client.pushAgent
         .mockReset()
-        .mockRejectedValueOnce(
-          makeLangSmithError("conflict", {
-            name: "LangSmithConflictError",
-            status: 409,
-          }),
-        )
+        .mockImplementationOnce(() => firstPush.promise)
         .mockResolvedValueOnce(commitUrl("22222222"));
 
       const edit = backend.edit("/shared.md", "target", "replacement");
       await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      const queuedEdit = backend.edit(
+        "/queued.md",
+        "target",
+        "local replacement",
+      );
+      const queuedExpectation = expect(queuedEdit).resolves.toMatchObject({
+        error: expect.stringContaining("Hub unavailable"),
+      });
+      await flushMicrotasks();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      firstPush.reject(
+        makeLangSmithError("conflict", {
+          name: "LangSmithConflictError",
+          status: 409,
+        }),
+      );
       await expect(edit).resolves.toMatchObject({
         path: "/shared.md",
         occurrences: 1,
       });
+      await queuedExpectation;
 
       expect(client.pushAgent).toHaveBeenCalledTimes(2);
       expect(client.pushAgent.mock.calls[0][1].parentCommit).toBe("base0000");
@@ -667,9 +688,13 @@ describe("ContextHubBackend", () => {
       await expect(backend.read("/shared.md")).resolves.toMatchObject({
         content: "remote insertion\nbefore\nreplacement\nafter",
       });
+      await expect(backend.read("/queued.md")).resolves.toMatchObject({
+        content: "before\nremote replacement\nafter",
+      });
       await expect(backend.read("/remote.md")).resolves.toMatchObject({
         content: "unrelated",
       });
+      expect(vi.getTimerCount()).toBe(0);
     });
 
     it("stops after four conflicting pushes and allows the next burst to recover", async () => {

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -266,92 +266,37 @@ describe("ContextHubBackend", () => {
     expect(options.parentCommit).toBe(COMMIT_HASH);
   });
 
-  it("write updates commit hash from the current push URL shape", async () => {
-    const { backend, client } = makeBackend();
-    await backend.write("/a.md", "a");
-    await backend.write("/b.md", "b");
-
-    const [, options] = client.pushAgent.mock.calls[1];
-    expect(options.parentCommit).toBe("ef567890");
-  });
-
-  it("write normalizes a bare target name for the current URL shape", async () => {
-    const { backend, client } = makeBackend({}, "test-agent");
-    client.pushAgent.mockResolvedValueOnce(commitUrl("deadbeef"));
-
-    await backend.write("/a.md", "a");
-    await backend.write("/b.md", "b");
-
-    const [, options] = client.pushAgent.mock.calls[1];
-    expect(options.parentCommit).toBe("deadbeef");
-  });
-
-  it("write updates commit hash from the legacy push URL shape", async () => {
-    const { backend, client } = makeBackend();
-    client.pushAgent.mockResolvedValueOnce(
-      "https://host/hub/-/test-agent:deadbeef",
-    );
-
-    await backend.write("/a.md", "a");
-    await backend.write("/b.md", "b");
-
-    const [, options] = client.pushAgent.mock.calls[1];
-    expect(options.parentCommit).toBe("deadbeef");
-  });
-
-  it("write matches the owner in a legacy push URL", async () => {
-    const { backend, client } = makeBackend({}, "owner/test-agent");
-    client.pushAgent.mockResolvedValueOnce(
-      "https://host/hub/owner/test-agent:deadbeef",
-    );
-
-    await backend.write("/a.md", "a");
-    await backend.write("/b.md", "b");
-
-    const [, options] = client.pushAgent.mock.calls[1];
-    expect(options.parentCommit).toBe("deadbeef");
-  });
-
-  it("write ignores an identifier version when matching a legacy URL", async () => {
-    const { backend, client } = makeBackend({}, "owner/test-agent:version");
-    client.pushAgent.mockResolvedValueOnce(
-      "https://host/hub/owner/test-agent:deadbeef",
-    );
-
-    await backend.write("/a.md", "a");
-    await backend.write("/b.md", "b");
-
-    const [, options] = client.pushAgent.mock.calls[1];
-    expect(options.parentCommit).toBe("deadbeef");
-  });
-
   it.each([
+    ["the current URL shape", "-/test-agent", commitUrl("deadbeef")],
     [
-      "a prefixed context path",
-      "https://host/prefix/context/test-agent/deadbeef",
+      "a bare target with the current URL shape",
+      "test-agent",
+      commitUrl("deadbeef"),
     ],
-    ["a non-hub colon suffix", "https://host/not-hub/test-agent:deadbeef"],
-    ["an arbitrary colon suffix", "https://host/arbitrary:deadbeef"],
-    ["a different current target", "https://host/context/other-agent/deadbeef"],
     [
-      "a different legacy owner",
-      "https://host/hub/other-owner/test-agent:deadbeef",
+      "the legacy URL shape",
+      "-/test-agent",
+      "https://host/hub/-/test-agent:deadbeef",
     ],
-    ["a different legacy target", "https://host/hub/-/other-agent:deadbeef"],
     [
-      "a multi-segment current target",
-      "https://host/context/owner/test-agent/deadbeef",
+      "an owned, versioned target with the legacy URL shape",
+      "owner/test-agent:version",
+      "https://host/hub/owner/test-agent:deadbeef",
     ],
-    ["an uppercase hash", "https://host/context/test-agent/DEADBEEF"],
-    ["a 9-character hash", "https://host/context/test-agent/deadbeef0"],
-    [
-      "a 64-character legacy hash",
-      `https://host/hub/-/test-agent:${"deadbeef".repeat(8)}`,
-    ],
-    ["a trailing slash", "https://host/context/test-agent/deadbeef/"],
-    ["a trailing legacy slash", "https://host/hub/-/test-agent:deadbeef/"],
-    ["a malformed URL", "not a valid URL"],
-  ])("reloads after %s", async (_description, invalidUrl) => {
+  ])(
+    "updates the commit hash from %s",
+    async (_description, identifier, url) => {
+      const { backend, client } = makeBackend({}, identifier);
+      client.pushAgent.mockResolvedValueOnce(url);
+
+      await backend.write("/a.md", "a");
+      await backend.write("/b.md", "b");
+
+      expect(client.pushAgent.mock.calls[1][1].parentCommit).toBe("deadbeef");
+    },
+  );
+
+  it("reloads when a push URL targets a different repo", async () => {
     vi.useFakeTimers();
     const { backend, client } = makeBackend();
     client.pullAgent
@@ -362,7 +307,9 @@ describe("ContextHubBackend", () => {
           "remote.md": { type: "file", content: "remote value" },
         }),
       );
-    client.pushAgent.mockResolvedValueOnce(invalidUrl);
+    client.pushAgent.mockResolvedValueOnce(
+      "https://host/context/other-agent/deadbeef",
+    );
 
     const firstWrite = backend.write("/local.md", "local value");
     await advanceMutationWindow();
@@ -434,45 +381,6 @@ describe("ContextHubBackend", () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
-    it("fans out one failed cold pull to concurrent mutations and lets a new burst recover", async () => {
-      vi.useFakeTimers();
-      const failedPull = deferred<ReturnType<typeof makeContext>>();
-      const { backend, client } = makeBackend();
-      client.pullAgent.mockReset().mockReturnValue(failedPull.promise);
-
-      const writes = Array.from({ length: 4 }, (_, index) =>
-        backend.write(`/file-${index}.md`, `value-${index}`),
-      );
-      await flushMicrotasks();
-      expect(client.pullAgent).toHaveBeenCalledTimes(1);
-
-      failedPull.reject(
-        makeLangSmithError("pull failed", {
-          name: "LangSmithAPIError",
-          status: 500,
-        }),
-      );
-      const results = await Promise.all(writes);
-
-      expect(
-        results.every((result) => result.error?.includes("Hub unavailable")),
-      ).toBe(true);
-      expect(client.pullAgent).toHaveBeenCalledTimes(1);
-      expect(client.pushAgent).not.toHaveBeenCalled();
-      expect(vi.getTimerCount()).toBe(0);
-
-      client.pullAgent.mockResolvedValueOnce(makeContext("recovery0"));
-      client.pushAgent.mockResolvedValueOnce(commitUrl("11111111"));
-      const recovered = backend.write("/recovered.md", "yes");
-      await advanceMutationWindow();
-
-      await expect(recovered).resolves.toMatchObject({
-        path: "/recovered.md",
-      });
-      expect(client.pullAgent).toHaveBeenCalledTimes(2);
-      expect(client.pushAgent).toHaveBeenCalledTimes(1);
-    });
-
     it("coalesces mixed write, edit, delete, and upload operations", async () => {
       vi.useFakeTimers();
       const { backend, client } = makeBackend({
@@ -508,36 +416,46 @@ describe("ContextHubBackend", () => {
       });
     });
 
-    it("serializes a queued follow-on batch behind an in-flight push", async () => {
+    it("serializes an edit computed from an in-flight write into the follow-on batch", async () => {
       vi.useFakeTimers();
       const firstPush = deferred<string>();
       const secondPush = deferred<string>();
-      const { backend, client } = makeBackend();
+      const { backend, client } = makeBackend({
+        "same.md": { type: "file", content: "base" },
+      });
       client.pushAgent
         .mockImplementationOnce(() => firstPush.promise)
         .mockImplementationOnce(() => secondPush.promise);
+      await backend.read("/same.md");
 
-      const firstWrite = backend.write("/first.md", "first");
+      const write = backend.write("/same.md", "first version");
       await advanceMutationWindow();
       expect(client.pushAgent).toHaveBeenCalledTimes(1);
 
-      const secondWrite = backend.write("/second.md", "second");
+      const edit = backend.edit("/same.md", "first", "second");
       await advanceMutationWindow();
       expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      await expect(backend.read("/same.md")).resolves.toMatchObject({
+        content: "second version",
+      });
 
       firstPush.resolve(commitUrl("11111111"));
       await flushMicrotasks();
 
       expect(client.pushAgent).toHaveBeenCalledTimes(2);
-      const [, secondOptions] = client.pushAgent.mock.calls[1];
-      expect(secondOptions.parentCommit).toBe("11111111");
-      expect(secondOptions.files).toEqual({
-        "second.md": { type: "file", content: "second" },
+      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+        parentCommit: "11111111",
+        files: {
+          "same.md": { type: "file", content: "second version" },
+        },
       });
-
       secondPush.resolve(commitUrl("22222222"));
-      await expect(firstWrite).resolves.toMatchObject({ path: "/first.md" });
-      await expect(secondWrite).resolves.toMatchObject({ path: "/second.md" });
+
+      await expect(write).resolves.toMatchObject({ path: "/same.md" });
+      await expect(edit).resolves.toMatchObject({
+        path: "/same.md",
+        occurrences: 1,
+      });
       expect(vi.getTimerCount()).toBe(0);
     });
 
@@ -699,19 +617,22 @@ describe("ContextHubBackend", () => {
       });
     });
 
-    it("reloads and reapplies the local full-file delta after a 409 conflict", async () => {
+    it("replays an edit after a 409 conflict without losing a remote same-file insertion", async () => {
       vi.useFakeTimers();
       const { backend, client } = makeBackend();
       client.pullAgent
         .mockReset()
         .mockResolvedValueOnce(
           makeContext("base0000", {
-            "shared.md": { type: "file", content: "base" },
+            "shared.md": { type: "file", content: "before\ntarget\nafter" },
           }),
         )
         .mockResolvedValueOnce(
           makeContext("remote01", {
-            "shared.md": { type: "file", content: "remote version" },
+            "shared.md": {
+              type: "file",
+              content: "remote insertion\nbefore\ntarget\nafter",
+            },
             "remote.md": { type: "file", content: "unrelated" },
           }),
         );
@@ -725,20 +646,26 @@ describe("ContextHubBackend", () => {
         )
         .mockResolvedValueOnce(commitUrl("22222222"));
 
-      const write = backend.write("/shared.md", "local wins");
+      const edit = backend.edit("/shared.md", "target", "replacement");
       await advanceMutationWindow();
-      await expect(write).resolves.toMatchObject({ path: "/shared.md" });
+      await expect(edit).resolves.toMatchObject({
+        path: "/shared.md",
+        occurrences: 1,
+      });
 
       expect(client.pushAgent).toHaveBeenCalledTimes(2);
       expect(client.pushAgent.mock.calls[0][1].parentCommit).toBe("base0000");
       expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
         parentCommit: "remote01",
         files: {
-          "shared.md": { type: "file", content: "local wins" },
+          "shared.md": {
+            type: "file",
+            content: "remote insertion\nbefore\nreplacement\nafter",
+          },
         },
       });
       await expect(backend.read("/shared.md")).resolves.toMatchObject({
-        content: "local wins",
+        content: "remote insertion\nbefore\nreplacement\nafter",
       });
       await expect(backend.read("/remote.md")).resolves.toMatchObject({
         content: "unrelated",
@@ -804,49 +731,7 @@ describe("ContextHubBackend", () => {
       });
     });
 
-    it("computes an edit from an in-flight write and commits it in the next batch", async () => {
-      vi.useFakeTimers();
-      const firstPush = deferred<string>();
-      const secondPush = deferred<string>();
-      const { backend, client } = makeBackend({
-        "same.md": { type: "file", content: "base" },
-      });
-      client.pushAgent
-        .mockImplementationOnce(() => firstPush.promise)
-        .mockImplementationOnce(() => secondPush.promise);
-      await backend.read("/same.md");
-
-      const write = backend.write("/same.md", "first version");
-      await advanceMutationWindow();
-      expect(client.pushAgent).toHaveBeenCalledTimes(1);
-
-      const edit = backend.edit("/same.md", "first", "second");
-      await advanceMutationWindow();
-      expect(client.pushAgent).toHaveBeenCalledTimes(1);
-      await expect(backend.read("/same.md")).resolves.toMatchObject({
-        content: "second version",
-      });
-
-      firstPush.resolve(commitUrl("11111111"));
-      await flushMicrotasks();
-
-      expect(client.pushAgent).toHaveBeenCalledTimes(2);
-      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
-        parentCommit: "11111111",
-        files: {
-          "same.md": { type: "file", content: "second version" },
-        },
-      });
-      secondPush.resolve(commitUrl("22222222"));
-
-      await expect(write).resolves.toMatchObject({ path: "/same.md" });
-      await expect(edit).resolves.toMatchObject({
-        path: "/same.md",
-        occurrences: 1,
-      });
-    });
-
-    it("reloads authoritative state after a hashless success without replaying the older batch", async () => {
+    it("rematerializes a pending edit after an authoritative hashless reload", async () => {
       vi.useFakeTimers();
       const firstPush = deferred<string>();
       const secondPush = deferred<string>();
@@ -856,7 +741,7 @@ describe("ContextHubBackend", () => {
         .mockReset()
         .mockResolvedValueOnce(
           makeContext("base0000", {
-            "shared.md": { type: "file", content: "v0" },
+            "shared.md": { type: "file", content: "before\ntarget\nafter" },
           }),
         )
         .mockImplementationOnce(() => authoritativePull.promise);
@@ -866,70 +751,137 @@ describe("ContextHubBackend", () => {
         .mockImplementationOnce(() => secondPush.promise);
       await backend.read("/shared.md");
 
-      const firstWrite = backend.write("/shared.md", "older local value");
+      const durableWrite = backend.write("/durable.md", "durable");
       await advanceMutationWindow();
       expect(client.pushAgent).toHaveBeenCalledTimes(1);
 
-      const pendingWrite = backend.write("/pending.md", "pending value");
+      const pendingEdit = backend.edit("/shared.md", "target", "replacement");
       await advanceMutationWindow();
       expect(client.pushAgent).toHaveBeenCalledTimes(1);
-      await expect(backend.read("/pending.md")).resolves.toMatchObject({
-        content: "pending value",
+      await expect(backend.read("/shared.md")).resolves.toMatchObject({
+        content: "before\nreplacement\nafter",
       });
 
       firstPush.resolve(
         "https://host/context/test-agent?organizationId=org-id",
       );
-      let firstSettled = false;
-      void firstWrite.then(() => {
-        firstSettled = true;
+      let durableSettled = false;
+      void durableWrite.then(() => {
+        durableSettled = true;
       });
       await flushMicrotasks();
 
       expect(client.pullAgent).toHaveBeenCalledTimes(2);
-      expect(firstSettled).toBe(false);
+      expect(durableSettled).toBe(false);
       expect(client.pushAgent).toHaveBeenCalledTimes(1);
 
-      const readAfterAuthoritativePull = authoritativePull.promise.then(() =>
-        backend.read("/shared.md"),
-      );
       authoritativePull.resolve(
         makeContext("authoritative1", {
-          "shared.md": { type: "file", content: "newer remote value" },
-          "remote.md": { type: "file", content: "remote addition" },
+          "durable.md": { type: "file", content: "durable" },
+          "shared.md": {
+            type: "file",
+            content: "remote insertion\nbefore\ntarget\nafter",
+          },
         }),
       );
-      await expect(readAfterAuthoritativePull).resolves.toMatchObject({
-        content: "newer remote value",
+      await expect(durableWrite).resolves.toMatchObject({
+        path: "/durable.md",
       });
-      await expect(firstWrite).resolves.toMatchObject({ path: "/shared.md" });
       await flushMicrotasks();
 
-      expect(firstSettled).toBe(true);
-      await expect(backend.read("/shared.md")).resolves.toMatchObject({
-        content: "newer remote value",
-      });
-      await expect(backend.read("/remote.md")).resolves.toMatchObject({
-        content: "remote addition",
-      });
-      await expect(backend.read("/pending.md")).resolves.toMatchObject({
-        content: "pending value",
-      });
+      expect(durableSettled).toBe(true);
       expect(client.pushAgent).toHaveBeenCalledTimes(2);
       expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
         parentCommit: "authoritative1",
         files: {
-          "pending.md": { type: "file", content: "pending value" },
+          "shared.md": {
+            type: "file",
+            content: "remote insertion\nbefore\nreplacement\nafter",
+          },
         },
       });
 
       secondPush.resolve(commitUrl("33333333"));
-      await expect(pendingWrite).resolves.toMatchObject({
-        path: "/pending.md",
+      await expect(pendingEdit).resolves.toMatchObject({
+        path: "/shared.md",
+        occurrences: 1,
       });
       await expect(backend.read("/shared.md")).resolves.toMatchObject({
-        content: "newer remote value",
+        content: "remote insertion\nbefore\nreplacement\nafter",
       });
+    });
+
+    it("keeps a durable hashless commit when a pending edit no longer applies", async () => {
+      vi.useFakeTimers();
+      const firstPush = deferred<string>();
+      const authoritativePull = deferred<ReturnType<typeof makeContext>>();
+      const { backend, client } = makeBackend();
+      client.pullAgent
+        .mockReset()
+        .mockResolvedValueOnce(
+          makeContext("base0000", {
+            "shared.md": { type: "file", content: "before\ntarget\nafter" },
+          }),
+        )
+        .mockImplementationOnce(() => authoritativePull.promise);
+      client.pushAgent
+        .mockReset()
+        .mockImplementationOnce(() => firstPush.promise)
+        .mockResolvedValueOnce(commitUrl("44444444"));
+      await backend.read("/shared.md");
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown): void => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+
+      try {
+        const durableWrite = backend.write("/durable.md", "durable");
+        await advanceMutationWindow();
+        const pendingEdit = backend.edit("/shared.md", "target", "replacement");
+        const pendingExpectation = expect(pendingEdit).resolves.toMatchObject({
+          error: expect.stringContaining("Hub unavailable"),
+        });
+        await flushMicrotasks();
+
+        firstPush.resolve(
+          "https://host/context/test-agent?organizationId=org-id",
+        );
+        await flushMicrotasks();
+        authoritativePull.resolve(
+          makeContext("authoritative1", {
+            "durable.md": { type: "file", content: "durable" },
+            "shared.md": {
+              type: "file",
+              content: "remote insertion\nbefore\nremote replacement\nafter",
+            },
+          }),
+        );
+
+        await expect(durableWrite).resolves.toMatchObject({
+          path: "/durable.md",
+        });
+        await pendingExpectation;
+        expect(client.pushAgent).toHaveBeenCalledTimes(1);
+        expect(client.pullAgent).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
+        await expect(backend.read("/shared.md")).resolves.toMatchObject({
+          content: "remote insertion\nbefore\nremote replacement\nafter",
+        });
+
+        const recovered = backend.write("/next.md", "next");
+        await advanceMutationWindow();
+        await expect(recovered).resolves.toMatchObject({ path: "/next.md" });
+        expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+          parentCommit: "authoritative1",
+          files: { "next.md": { type: "file", content: "next" } },
+        });
+        await flushMicrotasks();
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
     });
 
     it("rejects a hashless success when its authoritative reload has no commit", async () => {
@@ -977,74 +929,6 @@ describe("ContextHubBackend", () => {
           "next.md": { type: "file", content: "next" },
         },
       });
-    });
-
-    it("does not replay a durable hashless push when its authoritative reload conflicts", async () => {
-      vi.useFakeTimers();
-      const { backend, client } = makeBackend();
-      client.pullAgent
-        .mockReset()
-        .mockResolvedValueOnce(makeContext("base0000"))
-        .mockRejectedValueOnce(
-          makeLangSmithError("reload conflict", {
-            name: "LangSmithConflictError",
-            status: 409,
-          }),
-        )
-        .mockResolvedValueOnce(
-          makeContext("recovery0", {
-            "durable.md": { type: "file", content: "durable" },
-          }),
-        );
-      client.pushAgent
-        .mockReset()
-        .mockResolvedValueOnce(
-          "https://host/context/test-agent?organizationId=org-id",
-        )
-        .mockResolvedValueOnce(commitUrl("44444444"));
-
-      const durableWrite = backend.write("/durable.md", "durable");
-      await advanceMutationWindow();
-      const durableResult = await durableWrite;
-
-      expect(durableResult.error).toContain("Hub unavailable");
-      expect(client.pushAgent).toHaveBeenCalledTimes(1);
-      expect(client.pullAgent).toHaveBeenCalledTimes(2);
-      expect(vi.getTimerCount()).toBe(0);
-
-      const recovered = backend.write("/next.md", "next");
-      await advanceMutationWindow();
-      await expect(recovered).resolves.toMatchObject({ path: "/next.md" });
-
-      expect(client.pullAgent).toHaveBeenCalledTimes(3);
-      expect(client.pushAgent).toHaveBeenCalledTimes(2);
-      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
-        parentCommit: "recovery0",
-        files: {
-          "next.md": { type: "file", content: "next" },
-        },
-      });
-    });
-
-    it("leaves no timer after draining and starts a new burst cleanly", async () => {
-      vi.useFakeTimers();
-      const { backend, client } = makeBackend();
-
-      const first = backend.write("/first.md", "first");
-      await advanceMutationWindow();
-      await first;
-
-      expect(client.pushAgent).toHaveBeenCalledTimes(1);
-      expect(vi.getTimerCount()).toBe(0);
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(client.pushAgent).toHaveBeenCalledTimes(1);
-
-      const second = backend.write("/second.md", "second");
-      await advanceMutationWindow();
-      await second;
-
-      expect(client.pushAgent).toHaveBeenCalledTimes(2);
-      expect(vi.getTimerCount()).toBe(0);
     });
   });
 

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import type { Client } from "langsmith";
 import type { Entry } from "langsmith/schemas";
 
@@ -11,7 +11,52 @@ import { CompositeBackend } from "./composite.js";
 import { FilesystemBackend } from "./filesystem.js";
 
 const COMMIT_HASH = "abcd1234".repeat(8);
-const COMMIT_URL = "https://host/hub/-/test-agent:ef567890";
+const COMMIT_URL = commitUrl("ef567890");
+
+function commitUrl(hash: string, targetName = "test-agent"): string {
+  return `https://host/context/${targetName}/${hash.slice(0, 8)}?organizationId=org-id`;
+}
+
+function makeContext(
+  commitHash: string,
+  files: Record<string, Entry> = {},
+): {
+  commit_id: string;
+  commit_hash: string;
+  files: Record<string, Entry>;
+} {
+  return {
+    commit_id: "00000000-0000-0000-0000-000000000000",
+    commit_hash: commitHash,
+    files,
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+async function advanceMutationWindow(): Promise<void> {
+  await flushMicrotasks();
+  await vi.advanceTimersByTimeAsync(50);
+  await flushMicrotasks();
+}
 
 function makeLangSmithError(
   message: string,
@@ -27,7 +72,10 @@ function makeLangSmithError(
   return error;
 }
 
-function makeBackend(files: Record<string, Entry> = {}): {
+function makeBackend(
+  files: Record<string, Entry> = {},
+  identifier = "-/test-agent",
+): {
   backend: ContextHubBackend;
   client: {
     pullAgent: ReturnType<typeof vi.fn>;
@@ -35,21 +83,21 @@ function makeBackend(files: Record<string, Entry> = {}): {
   };
 } {
   const client = {
-    pullAgent: vi.fn().mockResolvedValue({
-      commit_id: "00000000-0000-0000-0000-000000000000",
-      commit_hash: COMMIT_HASH,
-      files,
-    }),
+    pullAgent: vi.fn().mockResolvedValue(makeContext(COMMIT_HASH, files)),
     pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
   };
 
-  const backend = new ContextHubBackend("-/test-agent", {
+  const backend = new ContextHubBackend(identifier, {
     client: client as unknown as Client,
   });
   return { backend, client };
 }
 
 describe("ContextHubBackend", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("read returns file content", async () => {
     const { backend } = makeBackend({
       "AGENTS.md": { type: "file", content: "# hi\nworld" },
@@ -180,7 +228,7 @@ describe("ContextHubBackend", () => {
           status: 404,
         }),
       ),
-      pushAgent: vi.fn().mockResolvedValue(COMMIT_URL),
+      pushAgent: vi.fn().mockResolvedValue(commitUrl("ef567890", "fresh")),
     };
     const backend = new ContextHubBackend("-/fresh", {
       client: client as unknown as Client,
@@ -218,13 +266,119 @@ describe("ContextHubBackend", () => {
     expect(options.parentCommit).toBe(COMMIT_HASH);
   });
 
-  it("write updates commit hash from push URL", async () => {
+  it("write updates commit hash from the current push URL shape", async () => {
     const { backend, client } = makeBackend();
     await backend.write("/a.md", "a");
     await backend.write("/b.md", "b");
 
     const [, options] = client.pushAgent.mock.calls[1];
     expect(options.parentCommit).toBe("ef567890");
+  });
+
+  it("write normalizes a bare target name for the current URL shape", async () => {
+    const { backend, client } = makeBackend({}, "test-agent");
+    client.pushAgent.mockResolvedValueOnce(commitUrl("deadbeef"));
+
+    await backend.write("/a.md", "a");
+    await backend.write("/b.md", "b");
+
+    const [, options] = client.pushAgent.mock.calls[1];
+    expect(options.parentCommit).toBe("deadbeef");
+  });
+
+  it("write updates commit hash from the legacy push URL shape", async () => {
+    const { backend, client } = makeBackend();
+    client.pushAgent.mockResolvedValueOnce(
+      "https://host/hub/-/test-agent:deadbeef",
+    );
+
+    await backend.write("/a.md", "a");
+    await backend.write("/b.md", "b");
+
+    const [, options] = client.pushAgent.mock.calls[1];
+    expect(options.parentCommit).toBe("deadbeef");
+  });
+
+  it("write matches the owner in a legacy push URL", async () => {
+    const { backend, client } = makeBackend({}, "owner/test-agent");
+    client.pushAgent.mockResolvedValueOnce(
+      "https://host/hub/owner/test-agent:deadbeef",
+    );
+
+    await backend.write("/a.md", "a");
+    await backend.write("/b.md", "b");
+
+    const [, options] = client.pushAgent.mock.calls[1];
+    expect(options.parentCommit).toBe("deadbeef");
+  });
+
+  it("write ignores an identifier version when matching a legacy URL", async () => {
+    const { backend, client } = makeBackend({}, "owner/test-agent:version");
+    client.pushAgent.mockResolvedValueOnce(
+      "https://host/hub/owner/test-agent:deadbeef",
+    );
+
+    await backend.write("/a.md", "a");
+    await backend.write("/b.md", "b");
+
+    const [, options] = client.pushAgent.mock.calls[1];
+    expect(options.parentCommit).toBe("deadbeef");
+  });
+
+  it.each([
+    [
+      "a prefixed context path",
+      "https://host/prefix/context/test-agent/deadbeef",
+    ],
+    ["a non-hub colon suffix", "https://host/not-hub/test-agent:deadbeef"],
+    ["an arbitrary colon suffix", "https://host/arbitrary:deadbeef"],
+    ["a different current target", "https://host/context/other-agent/deadbeef"],
+    [
+      "a different legacy owner",
+      "https://host/hub/other-owner/test-agent:deadbeef",
+    ],
+    ["a different legacy target", "https://host/hub/-/other-agent:deadbeef"],
+    [
+      "a multi-segment current target",
+      "https://host/context/owner/test-agent/deadbeef",
+    ],
+    ["an uppercase hash", "https://host/context/test-agent/DEADBEEF"],
+    ["a 9-character hash", "https://host/context/test-agent/deadbeef0"],
+    [
+      "a 64-character legacy hash",
+      `https://host/hub/-/test-agent:${"deadbeef".repeat(8)}`,
+    ],
+    ["a trailing slash", "https://host/context/test-agent/deadbeef/"],
+    ["a trailing legacy slash", "https://host/hub/-/test-agent:deadbeef/"],
+    ["a malformed URL", "not a valid URL"],
+  ])("reloads after %s", async (_description, invalidUrl) => {
+    vi.useFakeTimers();
+    const { backend, client } = makeBackend();
+    client.pullAgent
+      .mockReset()
+      .mockResolvedValueOnce(makeContext("base0000"))
+      .mockResolvedValueOnce(
+        makeContext("authoritative1", {
+          "remote.md": { type: "file", content: "remote value" },
+        }),
+      );
+    client.pushAgent.mockResolvedValueOnce(invalidUrl);
+
+    const firstWrite = backend.write("/local.md", "local value");
+    await advanceMutationWindow();
+    await expect(firstWrite).resolves.toMatchObject({ path: "/local.md" });
+
+    expect(client.pullAgent).toHaveBeenCalledTimes(2);
+    await expect(backend.read("/remote.md")).resolves.toMatchObject({
+      content: "remote value",
+    });
+
+    const secondWrite = backend.write("/next.md", "next value");
+    await advanceMutationWindow();
+    await expect(secondWrite).resolves.toMatchObject({ path: "/next.md" });
+    expect(client.pushAgent.mock.calls[1][1].parentCommit).toBe(
+      "authoritative1",
+    );
   });
 
   it("write updates cache after commit", async () => {
@@ -244,6 +398,654 @@ describe("ContextHubBackend", () => {
     const result = await backend.write("/skills/code-reviewer.md", "sibling");
     expect(result.error).toBeUndefined();
     expect(client.pushAgent).toHaveBeenCalledTimes(1);
+  });
+
+  describe("mutation concurrency", () => {
+    it("coalesces eight concurrent writes after one cold pull and settles after durability", async () => {
+      vi.useFakeTimers();
+      const pushed = deferred<string>();
+      const { backend, client } = makeBackend();
+      client.pushAgent.mockReturnValue(pushed.promise);
+
+      const settled = Array.from({ length: 8 }, () => false);
+      const writes = Array.from({ length: 8 }, (_, index) => {
+        const write = backend.write(`/file-${index}.md`, `value-${index}`);
+        void write.then(() => {
+          settled[index] = true;
+        });
+        return write;
+      });
+
+      await advanceMutationWindow();
+
+      expect(client.pullAgent).toHaveBeenCalledTimes(1);
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      const [, options] = client.pushAgent.mock.calls[0];
+      expect(Object.keys(options.files).sort()).toEqual(
+        Array.from({ length: 8 }, (_, index) => `file-${index}.md`),
+      );
+      expect(settled).toEqual(Array.from({ length: 8 }, () => false));
+
+      pushed.resolve(commitUrl("11111111"));
+      const results = await Promise.all(writes);
+
+      expect(results.every((result) => result.error === undefined)).toBe(true);
+      expect(settled).toEqual(Array.from({ length: 8 }, () => true));
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("fans out one failed cold pull to concurrent mutations and lets a new burst recover", async () => {
+      vi.useFakeTimers();
+      const failedPull = deferred<ReturnType<typeof makeContext>>();
+      const { backend, client } = makeBackend();
+      client.pullAgent.mockReset().mockReturnValue(failedPull.promise);
+
+      const writes = Array.from({ length: 4 }, (_, index) =>
+        backend.write(`/file-${index}.md`, `value-${index}`),
+      );
+      await flushMicrotasks();
+      expect(client.pullAgent).toHaveBeenCalledTimes(1);
+
+      failedPull.reject(
+        makeLangSmithError("pull failed", {
+          name: "LangSmithAPIError",
+          status: 500,
+        }),
+      );
+      const results = await Promise.all(writes);
+
+      expect(
+        results.every((result) => result.error?.includes("Hub unavailable")),
+      ).toBe(true);
+      expect(client.pullAgent).toHaveBeenCalledTimes(1);
+      expect(client.pushAgent).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+
+      client.pullAgent.mockResolvedValueOnce(makeContext("recovery0"));
+      client.pushAgent.mockResolvedValueOnce(commitUrl("11111111"));
+      const recovered = backend.write("/recovered.md", "yes");
+      await advanceMutationWindow();
+
+      await expect(recovered).resolves.toMatchObject({
+        path: "/recovered.md",
+      });
+      expect(client.pullAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it("coalesces mixed write, edit, delete, and upload operations", async () => {
+      vi.useFakeTimers();
+      const { backend, client } = makeBackend({
+        "edit.md": { type: "file", content: "hello world" },
+        "delete.md": { type: "file", content: "remove me" },
+      });
+      await backend.read("/edit.md");
+
+      const write = backend.write("/write.md", "written");
+      const edit = backend.edit("/edit.md", "world", "earth");
+      const deletion = backend.delete("/delete.md");
+      const upload = backend.uploadFiles([
+        ["/upload-a.md", new TextEncoder().encode("alpha")],
+        ["/upload-b.md", new TextEncoder().encode("beta")],
+      ]);
+
+      await advanceMutationWindow();
+      const [writeResult, editResult, deleteResult, uploadResult] =
+        await Promise.all([write, edit, deletion, upload]);
+
+      expect(writeResult.error).toBeUndefined();
+      expect(editResult.error).toBeUndefined();
+      expect(deleteResult.error).toBeUndefined();
+      expect(uploadResult.every((result) => result.error === null)).toBe(true);
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      const [, options] = client.pushAgent.mock.calls[0];
+      expect(options.files).toEqual({
+        "write.md": { type: "file", content: "written" },
+        "edit.md": { type: "file", content: "hello earth" },
+        "delete.md": null,
+        "upload-a.md": { type: "file", content: "alpha" },
+        "upload-b.md": { type: "file", content: "beta" },
+      });
+    });
+
+    it("serializes a queued follow-on batch behind an in-flight push", async () => {
+      vi.useFakeTimers();
+      const firstPush = deferred<string>();
+      const secondPush = deferred<string>();
+      const { backend, client } = makeBackend();
+      client.pushAgent
+        .mockImplementationOnce(() => firstPush.promise)
+        .mockImplementationOnce(() => secondPush.promise);
+
+      const firstWrite = backend.write("/first.md", "first");
+      await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      const secondWrite = backend.write("/second.md", "second");
+      await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      firstPush.resolve(commitUrl("11111111"));
+      await flushMicrotasks();
+
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      const [, secondOptions] = client.pushAgent.mock.calls[1];
+      expect(secondOptions.parentCommit).toBe("11111111");
+      expect(secondOptions.files).toEqual({
+        "second.md": { type: "file", content: "second" },
+      });
+
+      secondPush.resolve(commitUrl("22222222"));
+      await expect(firstWrite).resolves.toMatchObject({ path: "/first.md" });
+      await expect(secondWrite).resolves.toMatchObject({ path: "/second.md" });
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("exposes pending writes and deletes to read, list, search, and download", async () => {
+      vi.useFakeTimers();
+      const pushed = deferred<string>();
+      const { backend, client } = makeBackend({
+        "delete.md": { type: "file", content: "old content" },
+      });
+      client.pushAgent.mockReturnValue(pushed.promise);
+      await backend.read("/delete.md");
+
+      const write = backend.write("/nested/new.md", "pending needle");
+      const deletion = backend.delete("/delete.md");
+      await flushMicrotasks();
+
+      expect(client.pushAgent).not.toHaveBeenCalled();
+      await expect(backend.read("/nested/new.md")).resolves.toMatchObject({
+        content: "pending needle",
+      });
+      await expect(backend.read("/delete.md")).resolves.toMatchObject({
+        error: "File '/delete.md' not found",
+      });
+
+      const listed = await backend.ls("/");
+      expect(listed.files).toContainEqual({ path: "/nested", is_dir: true });
+      const grepped = await backend.grep("needle");
+      expect(grepped.matches).toContainEqual({
+        path: "/nested/new.md",
+        line: 1,
+        text: "pending needle",
+      });
+      const globbed = await backend.glob("*.md");
+      expect(globbed.files).toContainEqual({
+        path: "/nested/new.md",
+        is_dir: false,
+      });
+      const downloaded = await backend.downloadFiles(["/nested/new.md"]);
+      expect(new TextDecoder().decode(downloaded[0].content!)).toBe(
+        "pending needle",
+      );
+
+      await advanceMutationWindow();
+      pushed.resolve(commitUrl("11111111"));
+      await Promise.all([write, deletion]);
+    });
+
+    it("fails in-flight and queued waiters together without an unhandled worker rejection, then recovers", async () => {
+      vi.useFakeTimers();
+      const failedPush = deferred<string>();
+      const { backend, client } = makeBackend();
+      client.pushAgent.mockImplementationOnce(() => failedPush.promise);
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown): void => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+
+      try {
+        const firstWrite = backend.write("/first.md", "first");
+        await advanceMutationWindow();
+        expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+        const queuedWrite = backend.write("/queued.md", "queued");
+        let queuedObserved = false;
+        const queuedObservation = queuedWrite.then((result) => {
+          queuedObserved = true;
+          return result;
+        });
+        await flushMicrotasks();
+        failedPush.reject(
+          makeLangSmithError("server failed", {
+            name: "LangSmithAPIError",
+            status: 500,
+          }),
+        );
+
+        const firstResult = await firstWrite;
+        expect(firstResult.error).toContain("Hub unavailable");
+        expect(client.pushAgent).toHaveBeenCalledTimes(1);
+        expect(queuedObserved).toBe(false);
+
+        client.pullAgent.mockResolvedValueOnce(
+          makeContext("recovery0", {
+            "remote.md": { type: "file", content: "remote" },
+          }),
+        );
+        client.pushAgent.mockResolvedValueOnce(commitUrl("33333333"));
+        const recovered = backend.write("/recovered.md", "yes");
+
+        const queuedResult = await queuedObservation;
+        expect(queuedResult.error).toContain("Hub unavailable");
+
+        await vi.runAllTimersAsync();
+        await flushMicrotasks();
+        expect(unhandled).toEqual([]);
+
+        await expect(recovered).resolves.toMatchObject({
+          path: "/recovered.md",
+        });
+        expect(client.pullAgent).toHaveBeenCalledTimes(2);
+        expect(client.pushAgent).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
+    });
+
+    it("re-pulls before accepting a mutation whose preload was invalidated while it waited for its turn", async () => {
+      vi.useFakeTimers();
+      const failedPush = deferred<string>();
+      const { backend, client } = makeBackend({
+        "base.md": { type: "file", content: "base" },
+      });
+      client.pushAgent
+        .mockImplementationOnce(() => failedPush.promise)
+        .mockResolvedValueOnce(commitUrl("33333333"));
+      await backend.read("/base.md");
+
+      const firstWrite = backend.write("/first.md", "first");
+      await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      client.pullAgent.mockResolvedValueOnce(
+        makeContext("recovery0", {
+          "base.md": { type: "file", content: "base" },
+        }),
+      );
+      const failedFollower = backend.write("/failed-follower.md", "failed");
+      const survivor = backend.write("/survivor.md", "survivor");
+
+      for (let index = 0; index < 3; index += 1) {
+        await Promise.resolve();
+      }
+      failedPush.reject(
+        makeLangSmithError("server failed", {
+          name: "LangSmithAPIError",
+          status: 500,
+        }),
+      );
+      await flushMicrotasks();
+
+      const [firstResult, followerResult] = await Promise.all([
+        firstWrite,
+        failedFollower,
+      ]);
+      expect(firstResult.error).toContain("Hub unavailable");
+      expect(followerResult.error).toContain("Hub unavailable");
+
+      await advanceMutationWindow();
+      await expect(survivor).resolves.toMatchObject({ path: "/survivor.md" });
+      expect(client.pullAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+        parentCommit: "recovery0",
+        files: {
+          "survivor.md": { type: "file", content: "survivor" },
+        },
+      });
+    });
+
+    it("reloads and reapplies the local full-file delta after a 409 conflict", async () => {
+      vi.useFakeTimers();
+      const { backend, client } = makeBackend();
+      client.pullAgent
+        .mockReset()
+        .mockResolvedValueOnce(
+          makeContext("base0000", {
+            "shared.md": { type: "file", content: "base" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeContext("remote01", {
+            "shared.md": { type: "file", content: "remote version" },
+            "remote.md": { type: "file", content: "unrelated" },
+          }),
+        );
+      client.pushAgent
+        .mockReset()
+        .mockRejectedValueOnce(
+          makeLangSmithError("conflict", {
+            name: "LangSmithConflictError",
+            status: 409,
+          }),
+        )
+        .mockResolvedValueOnce(commitUrl("22222222"));
+
+      const write = backend.write("/shared.md", "local wins");
+      await advanceMutationWindow();
+      await expect(write).resolves.toMatchObject({ path: "/shared.md" });
+
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent.mock.calls[0][1].parentCommit).toBe("base0000");
+      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+        parentCommit: "remote01",
+        files: {
+          "shared.md": { type: "file", content: "local wins" },
+        },
+      });
+      await expect(backend.read("/shared.md")).resolves.toMatchObject({
+        content: "local wins",
+      });
+      await expect(backend.read("/remote.md")).resolves.toMatchObject({
+        content: "unrelated",
+      });
+    });
+
+    it("stops after four conflicting pushes and allows the next burst to recover", async () => {
+      vi.useFakeTimers();
+      const { backend, client } = makeBackend();
+      const conflict = makeLangSmithError("conflict", {
+        name: "LangSmithConflictError",
+        status: 409,
+      });
+      client.pullAgent
+        .mockReset()
+        .mockResolvedValueOnce(makeContext("base0000"))
+        .mockResolvedValueOnce(makeContext("remote01"))
+        .mockResolvedValueOnce(makeContext("remote02"))
+        .mockResolvedValueOnce(makeContext("remote03"));
+      client.pushAgent.mockReset().mockRejectedValue(conflict);
+
+      const failed = backend.write("/local.md", "local");
+      await advanceMutationWindow();
+      const failedResult = await failed;
+
+      expect(failedResult.error).toContain("Hub unavailable");
+      expect(client.pushAgent).toHaveBeenCalledTimes(4);
+      expect(
+        client.pushAgent.mock.calls.map(([, options]) => options.parentCommit),
+      ).toEqual(["base0000", "remote01", "remote02", "remote03"]);
+      expect(client.pullAgent).toHaveBeenCalledTimes(4);
+      expect(vi.getTimerCount()).toBe(0);
+
+      client.pullAgent.mockResolvedValueOnce(
+        makeContext("recover0", {
+          "remote.md": { type: "file", content: "still here" },
+        }),
+      );
+      client.pushAgent.mockResolvedValueOnce(commitUrl("44444444"));
+      const recovered = backend.write("/next.md", "next");
+      await advanceMutationWindow();
+
+      await expect(recovered).resolves.toMatchObject({ path: "/next.md" });
+      expect(client.pullAgent).toHaveBeenCalledTimes(5);
+      expect(client.pushAgent).toHaveBeenCalledTimes(5);
+    });
+
+    it("uses the last enqueued value for the same path", async () => {
+      vi.useFakeTimers();
+      const { backend, client } = makeBackend();
+
+      const first = backend.write("/same.md", "first");
+      const second = backend.write("/same.md", "second");
+      await advanceMutationWindow();
+      await Promise.all([first, second]);
+
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      expect(client.pushAgent.mock.calls[0][1].files).toEqual({
+        "same.md": { type: "file", content: "second" },
+      });
+      await expect(backend.read("/same.md")).resolves.toMatchObject({
+        content: "second",
+      });
+    });
+
+    it("computes an edit from an in-flight write and commits it in the next batch", async () => {
+      vi.useFakeTimers();
+      const firstPush = deferred<string>();
+      const secondPush = deferred<string>();
+      const { backend, client } = makeBackend({
+        "same.md": { type: "file", content: "base" },
+      });
+      client.pushAgent
+        .mockImplementationOnce(() => firstPush.promise)
+        .mockImplementationOnce(() => secondPush.promise);
+      await backend.read("/same.md");
+
+      const write = backend.write("/same.md", "first version");
+      await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      const edit = backend.edit("/same.md", "first", "second");
+      await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      await expect(backend.read("/same.md")).resolves.toMatchObject({
+        content: "second version",
+      });
+
+      firstPush.resolve(commitUrl("11111111"));
+      await flushMicrotasks();
+
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+        parentCommit: "11111111",
+        files: {
+          "same.md": { type: "file", content: "second version" },
+        },
+      });
+      secondPush.resolve(commitUrl("22222222"));
+
+      await expect(write).resolves.toMatchObject({ path: "/same.md" });
+      await expect(edit).resolves.toMatchObject({
+        path: "/same.md",
+        occurrences: 1,
+      });
+    });
+
+    it("reloads authoritative state after a hashless success without replaying the older batch", async () => {
+      vi.useFakeTimers();
+      const firstPush = deferred<string>();
+      const secondPush = deferred<string>();
+      const authoritativePull = deferred<ReturnType<typeof makeContext>>();
+      const { backend, client } = makeBackend();
+      client.pullAgent
+        .mockReset()
+        .mockResolvedValueOnce(
+          makeContext("base0000", {
+            "shared.md": { type: "file", content: "v0" },
+          }),
+        )
+        .mockImplementationOnce(() => authoritativePull.promise);
+      client.pushAgent
+        .mockReset()
+        .mockImplementationOnce(() => firstPush.promise)
+        .mockImplementationOnce(() => secondPush.promise);
+      await backend.read("/shared.md");
+
+      const firstWrite = backend.write("/shared.md", "older local value");
+      await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      const pendingWrite = backend.write("/pending.md", "pending value");
+      await advanceMutationWindow();
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      await expect(backend.read("/pending.md")).resolves.toMatchObject({
+        content: "pending value",
+      });
+
+      firstPush.resolve(
+        "https://host/context/test-agent?organizationId=org-id",
+      );
+      let firstSettled = false;
+      void firstWrite.then(() => {
+        firstSettled = true;
+      });
+      await flushMicrotasks();
+
+      expect(client.pullAgent).toHaveBeenCalledTimes(2);
+      expect(firstSettled).toBe(false);
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      const readAfterAuthoritativePull = authoritativePull.promise.then(() =>
+        backend.read("/shared.md"),
+      );
+      authoritativePull.resolve(
+        makeContext("authoritative1", {
+          "shared.md": { type: "file", content: "newer remote value" },
+          "remote.md": { type: "file", content: "remote addition" },
+        }),
+      );
+      await expect(readAfterAuthoritativePull).resolves.toMatchObject({
+        content: "newer remote value",
+      });
+      await expect(firstWrite).resolves.toMatchObject({ path: "/shared.md" });
+      await flushMicrotasks();
+
+      expect(firstSettled).toBe(true);
+      await expect(backend.read("/shared.md")).resolves.toMatchObject({
+        content: "newer remote value",
+      });
+      await expect(backend.read("/remote.md")).resolves.toMatchObject({
+        content: "remote addition",
+      });
+      await expect(backend.read("/pending.md")).resolves.toMatchObject({
+        content: "pending value",
+      });
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+        parentCommit: "authoritative1",
+        files: {
+          "pending.md": { type: "file", content: "pending value" },
+        },
+      });
+
+      secondPush.resolve(commitUrl("33333333"));
+      await expect(pendingWrite).resolves.toMatchObject({
+        path: "/pending.md",
+      });
+      await expect(backend.read("/shared.md")).resolves.toMatchObject({
+        content: "newer remote value",
+      });
+    });
+
+    it("rejects a hashless success when its authoritative reload has no commit", async () => {
+      vi.useFakeTimers();
+      const { backend, client } = makeBackend();
+      client.pullAgent
+        .mockReset()
+        .mockResolvedValueOnce(makeContext("base0000"))
+        .mockRejectedValueOnce(
+          makeLangSmithError("missing after push", {
+            name: "LangSmithNotFoundError",
+            status: 404,
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeContext("recovery0", {
+            "durable.md": { type: "file", content: "durable" },
+          }),
+        );
+      client.pushAgent
+        .mockReset()
+        .mockResolvedValueOnce("not a valid URL")
+        .mockResolvedValueOnce(commitUrl("44444444"));
+
+      const unresolved = backend.write("/durable.md", "durable");
+      const unresolvedExpectation = expect(unresolved).rejects.toThrow(
+        "Context Hub commit succeeded but its hash could not be resolved",
+      );
+      await advanceMutationWindow();
+
+      await unresolvedExpectation;
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      expect(client.pullAgent).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+
+      const recovered = backend.write("/next.md", "next");
+      await advanceMutationWindow();
+      await expect(recovered).resolves.toMatchObject({ path: "/next.md" });
+
+      expect(client.pullAgent).toHaveBeenCalledTimes(3);
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+        parentCommit: "recovery0",
+        files: {
+          "next.md": { type: "file", content: "next" },
+        },
+      });
+    });
+
+    it("does not replay a durable hashless push when its authoritative reload conflicts", async () => {
+      vi.useFakeTimers();
+      const { backend, client } = makeBackend();
+      client.pullAgent
+        .mockReset()
+        .mockResolvedValueOnce(makeContext("base0000"))
+        .mockRejectedValueOnce(
+          makeLangSmithError("reload conflict", {
+            name: "LangSmithConflictError",
+            status: 409,
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeContext("recovery0", {
+            "durable.md": { type: "file", content: "durable" },
+          }),
+        );
+      client.pushAgent
+        .mockReset()
+        .mockResolvedValueOnce(
+          "https://host/context/test-agent?organizationId=org-id",
+        )
+        .mockResolvedValueOnce(commitUrl("44444444"));
+
+      const durableWrite = backend.write("/durable.md", "durable");
+      await advanceMutationWindow();
+      const durableResult = await durableWrite;
+
+      expect(durableResult.error).toContain("Hub unavailable");
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      expect(client.pullAgent).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+
+      const recovered = backend.write("/next.md", "next");
+      await advanceMutationWindow();
+      await expect(recovered).resolves.toMatchObject({ path: "/next.md" });
+
+      expect(client.pullAgent).toHaveBeenCalledTimes(3);
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      expect(client.pushAgent.mock.calls[1][1]).toMatchObject({
+        parentCommit: "recovery0",
+        files: {
+          "next.md": { type: "file", content: "next" },
+        },
+      });
+    });
+
+    it("leaves no timer after draining and starts a new burst cleanly", async () => {
+      vi.useFakeTimers();
+      const { backend, client } = makeBackend();
+
+      const first = backend.write("/first.md", "first");
+      await advanceMutationWindow();
+      await first;
+
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(client.pushAgent).toHaveBeenCalledTimes(1);
+
+      const second = backend.write("/second.md", "second");
+      await advanceMutationWindow();
+      await second;
+
+      expect(client.pushAgent).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 
   it("commit failures invalidate cache and re-pull on next read", async () => {

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -5,6 +5,7 @@
 import micromatch from "micromatch";
 import { Client } from "langsmith";
 import type { AgentContext, Entry } from "langsmith/schemas";
+import { Deferred } from "../utils.js";
 import type {
   BackendProtocolV2,
   DeleteResult,
@@ -46,15 +47,13 @@ type MutationIntent =
 
 interface MutationWaiter {
   intent: MutationIntent;
-  resolve: () => void;
-  reject: (error: unknown) => void;
+  completion: Deferred<void>;
 }
 
 interface MutationBatch {
   changes: FileChanges;
   waiters: MutationWaiter[];
-  ready: Promise<void>;
-  markReady: () => void;
+  ready: Deferred<void>;
   timer: ReturnType<typeof setTimeout> | null;
 }
 
@@ -72,11 +71,6 @@ interface TreeSnapshot {
 type PushBatchResult =
   | { kind: "commit"; commitHash: string }
   | { kind: "snapshot"; snapshot: TreeSnapshot };
-
-interface SnapshotPublication {
-  promise: Promise<void>;
-  complete: () => void;
-}
 
 function parseHubTargetIdentifier(
   identifier: string,
@@ -256,7 +250,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
   private pendingBatch: MutationBatch | null = null;
   private inFlightBatch: MutationBatch | null = null;
   private workerPromise: Promise<void> | null = null;
-  private snapshotPublication: SnapshotPublication | null = null;
+  private snapshotPublication: Deferred<void> | null = null;
 
   constructor(
     identifier: string,
@@ -319,26 +313,19 @@ export class ContextHubBackend implements BackendProtocolV2 {
       throw new Error("Context Hub snapshot publication is already pending");
     }
 
-    let complete!: () => void;
-    const promise = new Promise<void>((resolve) => {
-      complete = resolve;
-    });
-    this.snapshotPublication = { promise, complete };
+    this.snapshotPublication = new Deferred<void>();
   }
 
   private finishSnapshotPublication(): void {
     const publication = this.snapshotPublication;
-    if (publication === null) {
-      return;
-    }
     this.snapshotPublication = null;
-    publication.complete();
+    publication?.resolve();
   }
 
   private async ensureCacheLoaded(): Promise<void> {
     // Publish a hashless-push snapshot only after its old in-flight overlay can be removed.
     while (this.snapshotPublication !== null) {
-      await this.snapshotPublication.promise;
+      await this.snapshotPublication;
     }
 
     if (this.cache === null) {
@@ -439,20 +426,15 @@ export class ContextHubBackend implements BackendProtocolV2 {
   }
 
   private createMutationBatch(): MutationBatch {
-    let markReady!: () => void;
-    const ready = new Promise<void>((resolve) => {
-      markReady = resolve;
-    });
     const batch: MutationBatch = {
       changes: {},
       waiters: [],
-      ready,
-      markReady,
+      ready: new Deferred<void>(),
       timer: null,
     };
     batch.timer = setTimeout(() => {
       batch.timer = null;
-      batch.markReady();
+      batch.ready.resolve();
     }, MUTATION_COALESCE_MS);
     return batch;
   }
@@ -462,7 +444,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       clearTimeout(batch.timer);
       batch.timer = null;
     }
-    batch.markReady();
+    batch.ready.resolve();
   }
 
   private enqueueCommit(
@@ -480,11 +462,10 @@ export class ContextHubBackend implements BackendProtocolV2 {
     }
     Object.assign(batch.changes, changes);
 
-    const completion = new Promise<void>((resolve, reject) => {
-      batch.waiters.push({ intent, resolve, reject });
-    });
+    const completion = new Deferred<void>();
+    batch.waiters.push({ intent, completion });
     this.startWorker();
-    return completion;
+    return completion.promise;
   }
 
   private rematerializeBatch(
@@ -618,7 +599,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
         this.invalidateCache();
         this.finishSnapshotPublication();
         for (const waiter of batch.waiters) {
-          waiter.reject(error);
+          waiter.completion.reject(error);
         }
         this.failPendingBatch(error);
         return;
@@ -627,7 +608,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
       this.inFlightBatch = null;
       this.finishSnapshotPublication();
       for (const waiter of batch.waiters) {
-        waiter.resolve();
+        waiter.completion.resolve();
       }
       if (pendingReplayError !== null) {
         this.failPendingBatch(pendingReplayError);
@@ -644,7 +625,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
     this.pendingBatch = null;
     this.cancelBatchTimer(pending);
     for (const waiter of pending.waiters) {
-      waiter.reject(error);
+      waiter.completion.reject(error);
     }
   }
 
@@ -656,7 +637,7 @@ export class ContextHubBackend implements BackendProtocolV2 {
     if (inFlight !== null) {
       this.cancelBatchTimer(inFlight);
       for (const waiter of inFlight.waiters) {
-        waiter.reject(error);
+        waiter.completion.reject(error);
       }
     }
     this.failPendingBatch(error);

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -34,6 +34,11 @@ const FNMATCH_OPTIONS = { bash: true };
 
 type FileChanges = Record<string, string | null>;
 
+/**
+ * The logical operation a caller requested. `changes` operations are absolute
+ * file updates, while `edit` retains the replacement instruction so it can be
+ * replayed against a freshly pulled tree after a parent-commit conflict.
+ */
 type MutationIntent =
   | { kind: "changes"; changes: FileChanges }
   | {
@@ -45,11 +50,21 @@ type MutationIntent =
       updateOccurrences: (occurrences: number) => void;
     };
 
+/**
+ * A caller waiting for one logical mutation to become durable. Completion is
+ * settled only after the batch push succeeds, or rejected if the worker can no
+ * longer commit the caller's batch.
+ */
 interface MutationWaiter {
   intent: MutationIntent;
   completion: Deferred<void>;
 }
 
+/**
+ * A coalesced group of mutations. `changes` is the current materialization of
+ * the ordered waiter intents and is used both for the Hub payload and the
+ * optimistic read overlay. A later conflict refresh may rebuild it.
+ */
 interface MutationBatch {
   changes: FileChanges;
   waiters: MutationWaiter[];
@@ -62,6 +77,7 @@ interface MutationAcceptance<T> {
   completion?: Promise<void>;
 }
 
+/** The last authoritative Context Hub tree and its parent commit hash. */
 interface TreeSnapshot {
   cache: Record<string, string>;
   linkedEntries: Record<string, string>;
@@ -239,17 +255,48 @@ function mapHubFileOperationError(error: unknown): FileOperationError {
 /**
  * Backend that stores files in a LangSmith Hub agent repo (persistent).
  */
+/**
+ * Backend that stores files in a LangSmith Hub agent repository.
+ *
+ * ## Mutation model
+ *
+ * Mutations are accepted in call order, coalesced for a short window, and
+ * pushed by one worker. Only one batch is in flight at a time; mutations that
+ * arrive during a push form the next batch. This serializes one backend
+ * instance's writes while still reducing the number of Hub commits.
+ *
+ * Reads use an optimistic view: the last durable cache overlaid with the
+ * in-flight batch and then the pending batch. A read can therefore observe an
+ * accepted mutation before it is durable; a failed push invalidates that view
+ * and the next operation reloads from Hub.
+ *
+ * A `409` parent conflict triggers an authoritative pull and rematerializes
+ * the in-flight batch over the fetched tree before retrying. Edits replay their
+ * original replacement intent; absolute writes, deletes, and uploads replay as
+ * absolute changes. Retries are bounded by `MAX_CONFLICT_RETRIES`.
+ */
 export class ContextHubBackend implements BackendProtocolV2 {
   private identifier: string;
   private client: Client;
+  /** Last durable Hub file state; `null` means the next access must load it. */
   private cache: Record<string, string> | null = null;
   private linkedEntries: Record<string, string> = {};
+  /** Parent hash for the durable cache, used for optimistic-concurrency pushes. */
   private commitHash: string | null = null;
+  /** Shared cold-load promise so concurrent first operations perform one pull. */
   private loadPromise: Promise<void> | null = null;
+  /** Promise chain serializing mutation acceptance and optimistic projections. */
   private mutationOrder = Promise.resolve();
+  /** Mutations accepted for the next coalesced push. */
   private pendingBatch: MutationBatch | null = null;
+  /** The batch currently submitted to Hub and visible to optimistic reads. */
   private inFlightBatch: MutationBatch | null = null;
+  /** The single queue-draining worker, when active. */
   private workerPromise: Promise<void> | null = null;
+  /**
+   * Blocks cache consumers while a successful push without a parseable commit
+   * hash is being confirmed by an authoritative pull.
+   */
   private snapshotPublication: Deferred<void> | null = null;
 
   constructor(
@@ -368,6 +415,10 @@ export class ContextHubBackend implements BackendProtocolV2 {
     return next;
   }
 
+  /**
+   * Build the read-your-writes view without publishing speculative data as the
+   * durable cache. Later batches overlay earlier ones, matching worker order.
+   */
   private visibleCache(): Record<string, string> {
     let visible = { ...(this.cache ?? {}) };
     if (this.inFlightBatch !== null) {
@@ -402,6 +453,11 @@ export class ContextHubBackend implements BackendProtocolV2 {
     return release;
   }
 
+  /**
+   * Serialize validation and enqueueing so each operation is evaluated against
+   * a stable optimistic projection. Cache loading begins before acquiring the
+   * turn, allowing concurrent cold-start callers to share the same pull.
+   */
   private async acceptMutation<T>(
     operation: (cache: Record<string, string>) => MutationAcceptance<T>,
   ): Promise<MutationAcceptance<T>> {
@@ -425,6 +481,11 @@ export class ContextHubBackend implements BackendProtocolV2 {
     }
   }
 
+  /**
+   * Start a batch's coalescing window. The worker waits for this signal before
+   * detaching the batch; cancellation resolves it immediately so failures do
+   * not leave the worker waiting on a timer.
+   */
   private createMutationBatch(): MutationBatch {
     const batch: MutationBatch = {
       changes: {},
@@ -468,6 +529,11 @@ export class ContextHubBackend implements BackendProtocolV2 {
     return completion.promise;
   }
 
+  /**
+   * Replay ordered intents over an authoritative base after a conflict. This
+   * rebuilds the push payload and optimistic overlay. An edit that no longer
+   * applies throws the supplied conflict error; absolute changes are reapplied.
+   */
   private rematerializeBatch(
     batch: MutationBatch,
     base: Record<string, string>,
@@ -571,6 +637,11 @@ export class ContextHubBackend implements BackendProtocolV2 {
     this.workerPromise = worker;
   }
 
+  /**
+   * Drain coalesced batches sequentially. A completed batch publishes durable
+   * state before settling its callers; a failed batch invalidates local state
+   * and rejects both in-flight and queued callers so the next mutation reloads.
+   */
   private async drainMutationQueue(): Promise<void> {
     while (this.pendingBatch !== null) {
       const batch = this.pendingBatch;
@@ -643,6 +714,12 @@ export class ContextHubBackend implements BackendProtocolV2 {
     this.failPendingBatch(error);
   }
 
+  /**
+   * Push a materialized batch with the durable commit as its parent. On a 409,
+   * refresh Hub state, replay the batch, and retry with the new parent. A push
+   * response without a trustworthy hash is confirmed by a pull before callers
+   * are allowed to observe it as durable.
+   */
   private async pushBatch(batch: MutationBatch): Promise<PushBatchResult> {
     for (let attempt = 0; ; attempt += 1) {
       const payload: Record<string, Entry | null> = {};

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -33,7 +33,19 @@ const FNMATCH_OPTIONS = { bash: true };
 
 type FileChanges = Record<string, string | null>;
 
+type MutationIntent =
+  | { kind: "changes"; changes: FileChanges }
+  | {
+      kind: "edit";
+      path: string;
+      oldString: string;
+      newString: string;
+      replaceAll: boolean;
+      updateOccurrences: (occurrences: number) => void;
+    };
+
 interface MutationWaiter {
+  intent: MutationIntent;
   resolve: () => void;
   reject: (error: unknown) => void;
 }
@@ -208,6 +220,15 @@ function getLangSmithStatus(error: unknown): number | undefined {
   }
 
   return undefined;
+}
+
+function createLangSmithConflictError(message: string): Error & {
+  status: number;
+} {
+  const error = new Error(message) as Error & { status: number };
+  error.name = "LangSmithConflictError";
+  error.status = 409;
+  return error;
 }
 
 function mapHubFileOperationError(error: unknown): FileOperationError {
@@ -444,7 +465,10 @@ export class ContextHubBackend implements BackendProtocolV2 {
     batch.markReady();
   }
 
-  private enqueueCommit(changes: FileChanges): Promise<void> {
+  private enqueueCommit(
+    changes: FileChanges,
+    intent: MutationIntent = { kind: "changes", changes: { ...changes } },
+  ): Promise<void> {
     if (Object.keys(changes).length === 0) {
       return Promise.resolve();
     }
@@ -457,10 +481,81 @@ export class ContextHubBackend implements BackendProtocolV2 {
     Object.assign(batch.changes, changes);
 
     const completion = new Promise<void>((resolve, reject) => {
-      batch.waiters.push({ resolve, reject });
+      batch.waiters.push({ intent, resolve, reject });
     });
     this.startWorker();
     return completion;
+  }
+
+  private rematerializeBatch(
+    batch: MutationBatch,
+    base: Record<string, string>,
+    conflictError: unknown,
+  ): Record<string, string> {
+    let cache = { ...base };
+    const changes: FileChanges = {};
+
+    for (const waiter of batch.waiters) {
+      const { intent } = waiter;
+      if (intent.kind === "changes") {
+        Object.assign(changes, intent.changes);
+        cache = ContextHubBackend.applyChanges(cache, intent.changes);
+        continue;
+      }
+
+      const current = cache[intent.path];
+      if (current === undefined) {
+        throw conflictError;
+      }
+      const replacementResult = performStringReplacement(
+        current,
+        intent.oldString,
+        intent.newString,
+        intent.replaceAll,
+      );
+      if (typeof replacementResult === "string") {
+        throw conflictError;
+      }
+
+      const [newContent, occurrences] = replacementResult;
+      const editChanges = { [intent.path]: newContent };
+      Object.assign(changes, editChanges);
+      cache = ContextHubBackend.applyChanges(cache, editChanges);
+      intent.updateOccurrences(occurrences);
+    }
+
+    batch.changes = changes;
+    return cache;
+  }
+
+  private rematerializeAfterConflict(
+    batch: MutationBatch,
+    snapshot: TreeSnapshot,
+    conflictError: unknown,
+  ): void {
+    const cache = this.rematerializeBatch(batch, snapshot.cache, conflictError);
+    if (this.pendingBatch !== null) {
+      this.rematerializeBatch(this.pendingBatch, cache, conflictError);
+    }
+    this.publishSnapshot(snapshot);
+  }
+
+  private rematerializePendingBatch(snapshot: TreeSnapshot): Error | null {
+    if (this.pendingBatch === null) {
+      return null;
+    }
+    const conflictError = createLangSmithConflictError(
+      "Pending Context Hub mutation conflicts with authoritative state",
+    );
+    try {
+      this.rematerializeBatch(this.pendingBatch, snapshot.cache, conflictError);
+      return null;
+    } catch (error) {
+      if (error !== conflictError) {
+        throw error;
+      }
+      return conflictError;
+    }
   }
 
   private startWorker(): void {
@@ -493,9 +588,11 @@ export class ContextHubBackend implements BackendProtocolV2 {
 
       this.pendingBatch = null;
       this.inFlightBatch = batch;
+      let pendingReplayError: Error | null = null;
       try {
-        const result = await this.pushBatch(batch.changes);
+        const result = await this.pushBatch(batch);
         if (result.kind === "snapshot") {
+          pendingReplayError = this.rematerializePendingBatch(result.snapshot);
           this.publishSnapshot(result.snapshot);
         } else {
           this.cache = ContextHubBackend.applyChanges(
@@ -519,6 +616,10 @@ export class ContextHubBackend implements BackendProtocolV2 {
       this.finishSnapshotPublication();
       for (const waiter of batch.waiters) {
         waiter.resolve();
+      }
+      if (pendingReplayError !== null) {
+        this.failPendingBatch(pendingReplayError);
+        return;
       }
     }
   }
@@ -549,13 +650,13 @@ export class ContextHubBackend implements BackendProtocolV2 {
     this.failPendingBatch(error);
   }
 
-  private async pushBatch(changes: FileChanges): Promise<PushBatchResult> {
-    const payload: Record<string, Entry | null> = {};
-    for (const [path, content] of Object.entries(changes)) {
-      payload[path] = content === null ? null : { type: "file", content };
-    }
-
+  private async pushBatch(batch: MutationBatch): Promise<PushBatchResult> {
     for (let attempt = 0; ; attempt += 1) {
+      const payload: Record<string, Entry | null> = {};
+      for (const [path, content] of Object.entries(batch.changes)) {
+        payload[path] = content === null ? null : { type: "file", content };
+      }
+
       let url: string;
       try {
         url = await this.client.pushAgent(this.identifier, {
@@ -569,7 +670,8 @@ export class ContextHubBackend implements BackendProtocolV2 {
         ) {
           throw error;
         }
-        await this.loadTree();
+        const snapshot = await this.fetchTree();
+        this.rematerializeAfterConflict(batch, snapshot, error);
         continue;
       }
 
@@ -812,13 +914,26 @@ export class ContextHubBackend implements BackendProtocolV2 {
         }
 
         const [newContent, occurrences] = replacementResult;
+        const result: EditResult = {
+          path: filePath,
+          filesUpdate: null,
+          occurrences,
+        };
         return {
-          result: {
-            path: filePath,
-            filesUpdate: null,
-            occurrences,
-          },
-          completion: this.enqueueCommit({ [hubPath]: newContent }),
+          result,
+          completion: this.enqueueCommit(
+            { [hubPath]: newContent },
+            {
+              kind: "edit",
+              path: hubPath,
+              oldString,
+              newString,
+              replaceAll,
+              updateOccurrences: (replayedOccurrences) => {
+                result.occurrences = replayedOccurrences;
+              },
+            },
+          ),
         };
       });
       await accepted.completion;

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -24,9 +24,99 @@ import type {
 import { applyGrepMaxCount } from "./protocol.js";
 import { performStringReplacement } from "./utils.js";
 
-const URL_COMMIT_SUFFIX_RE = /:([0-9a-f]{8,64})$/i;
+const CONTEXT_URL_COMMIT_PATH_RE = /^\/context\/([^/]+)\/([0-9a-f]{8})$/;
+const LEGACY_URL_COMMIT_PATH_RE = /^\/hub\/([^/]+)\/([^/:]+):([0-9a-f]{8})$/;
+const MUTATION_COALESCE_MS = 50;
+const MAX_CONFLICT_RETRIES = 3;
 const TEXT_MIME_TYPE = "text/plain";
 const FNMATCH_OPTIONS = { bash: true };
+
+type FileChanges = Record<string, string | null>;
+
+interface MutationWaiter {
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+interface MutationBatch {
+  changes: FileChanges;
+  waiters: MutationWaiter[];
+  ready: Promise<void>;
+  markReady: () => void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+interface MutationAcceptance<T> {
+  result: T;
+  completion?: Promise<void>;
+}
+
+interface TreeSnapshot {
+  cache: Record<string, string>;
+  linkedEntries: Record<string, string>;
+  commitHash: string | null;
+}
+
+type PushBatchResult =
+  | { kind: "commit"; commitHash: string }
+  | { kind: "snapshot"; snapshot: TreeSnapshot };
+
+interface SnapshotPublication {
+  promise: Promise<void>;
+  complete: () => void;
+}
+
+function parseHubTargetIdentifier(
+  identifier: string,
+): [owner: string, name: string] | null {
+  if (
+    !identifier ||
+    identifier.split("/").length > 2 ||
+    identifier.startsWith("/") ||
+    identifier.endsWith("/") ||
+    identifier.split(":").length > 2
+  ) {
+    return null;
+  }
+
+  const [ownerNamePart] = identifier.split(":");
+  if (ownerNamePart.includes("/")) {
+    const [owner, name] = ownerNamePart.split("/", 2);
+    return owner && name ? [owner, name] : null;
+  }
+  return ownerNamePart ? ["-", ownerNamePart] : null;
+}
+
+function parseCommitHashFromUrl(
+  url: string,
+  identifier: string,
+): string | null {
+  try {
+    const pathname = decodeURIComponent(new URL(url).pathname);
+    const target = parseHubTargetIdentifier(identifier);
+    if (target === null) {
+      return null;
+    }
+    const [targetOwner, targetName] = target;
+
+    const contextMatch = CONTEXT_URL_COMMIT_PATH_RE.exec(pathname);
+    if (contextMatch !== null && contextMatch[1] === targetName) {
+      return contextMatch[2];
+    }
+
+    const legacyMatch = LEGACY_URL_COMMIT_PATH_RE.exec(pathname);
+    if (
+      legacyMatch !== null &&
+      legacyMatch[1] === targetOwner &&
+      legacyMatch[2] === targetName
+    ) {
+      return legacyMatch[3];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 function getErrorMessage(error: unknown): string {
   if (typeof error === "string") {
@@ -140,6 +230,12 @@ export class ContextHubBackend implements BackendProtocolV2 {
   private cache: Record<string, string> | null = null;
   private linkedEntries: Record<string, string> = {};
   private commitHash: string | null = null;
+  private loadPromise: Promise<void> | null = null;
+  private mutationOrder = Promise.resolve();
+  private pendingBatch: MutationBatch | null = null;
+  private inFlightBatch: MutationBatch | null = null;
+  private workerPromise: Promise<void> | null = null;
+  private snapshotPublication: SnapshotPublication | null = null;
 
   constructor(
     identifier: string,
@@ -159,83 +255,339 @@ export class ContextHubBackend implements BackendProtocolV2 {
     return `Hub unavailable: ${getErrorMessage(error)}`;
   }
 
-  private async loadTree(): Promise<void> {
+  private async fetchTree(): Promise<TreeSnapshot> {
     let context: AgentContext;
     try {
       context = await this.client.pullAgent(this.identifier);
     } catch (error) {
       if (isLangSmithNotFoundError(error)) {
-        this.cache = {};
-        this.linkedEntries = {};
-        this.commitHash = null;
-        return;
+        return { cache: {}, linkedEntries: {}, commitHash: null };
       }
       throw error;
     }
 
-    this.commitHash = context.commit_hash;
-    this.cache = {};
-    this.linkedEntries = {};
+    const cache: Record<string, string> = {};
+    const linkedEntries: Record<string, string> = {};
 
     for (const [path, entry] of Object.entries(context.files)) {
       if (entry.type === "file") {
-        this.cache[path] = entry.content;
+        cache[path] = entry.content;
       } else if (
         (entry.type === "agent" || entry.type === "skill") &&
         typeof entry.repo_handle === "string"
       ) {
-        this.linkedEntries[path] = entry.repo_handle;
+        linkedEntries[path] = entry.repo_handle;
       }
     }
+
+    return { cache, linkedEntries, commitHash: context.commit_hash };
   }
 
-  private async ensureCache(): Promise<Record<string, string>> {
+  private publishSnapshot(snapshot: TreeSnapshot): void {
+    this.cache = snapshot.cache;
+    this.linkedEntries = snapshot.linkedEntries;
+    this.commitHash = snapshot.commitHash;
+  }
+
+  private async loadTree(): Promise<void> {
+    this.publishSnapshot(await this.fetchTree());
+  }
+
+  private beginSnapshotPublication(): void {
+    if (this.snapshotPublication !== null) {
+      throw new Error("Context Hub snapshot publication is already pending");
+    }
+
+    let complete!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      complete = resolve;
+    });
+    this.snapshotPublication = { promise, complete };
+  }
+
+  private finishSnapshotPublication(): void {
+    const publication = this.snapshotPublication;
+    if (publication === null) {
+      return;
+    }
+    this.snapshotPublication = null;
+    publication.complete();
+  }
+
+  private async ensureCacheLoaded(): Promise<void> {
+    // Publish a hashless-push snapshot only after its old in-flight overlay can be removed.
+    while (this.snapshotPublication !== null) {
+      await this.snapshotPublication.promise;
+    }
+
     if (this.cache === null) {
-      await this.loadTree();
+      let loadPromise = this.loadPromise;
+      if (loadPromise === null) {
+        loadPromise = this.loadTree();
+        this.loadPromise = loadPromise;
+      }
+
+      try {
+        await loadPromise;
+      } finally {
+        if (this.loadPromise === loadPromise) {
+          this.loadPromise = null;
+        }
+      }
     }
     if (this.cache === null) {
       throw new Error("Context Hub cache failed to initialize");
     }
-    return this.cache;
   }
 
-  private async commit(changes: Record<string, string | null>): Promise<void> {
+  private async ensureCache(): Promise<Record<string, string>> {
+    await this.ensureCacheLoaded();
+    return this.visibleCache();
+  }
+
+  private static applyChanges(
+    cache: Record<string, string>,
+    changes: FileChanges,
+  ): Record<string, string> {
+    const next = { ...cache };
+    for (const [path, content] of Object.entries(changes)) {
+      if (content === null) {
+        delete next[path];
+      } else {
+        next[path] = content;
+      }
+    }
+    return next;
+  }
+
+  private visibleCache(): Record<string, string> {
+    let visible = { ...(this.cache ?? {}) };
+    if (this.inFlightBatch !== null) {
+      visible = ContextHubBackend.applyChanges(
+        visible,
+        this.inFlightBatch.changes,
+      );
+    }
+    if (this.pendingBatch !== null) {
+      visible = ContextHubBackend.applyChanges(
+        visible,
+        this.pendingBatch.changes,
+      );
+    }
+    return visible;
+  }
+
+  private invalidateCache(): void {
+    this.cache = null;
+    this.linkedEntries = {};
+    this.commitHash = null;
+    this.loadPromise = null;
+  }
+
+  private async acquireMutationTurn(): Promise<() => void> {
+    let release!: () => void;
+    const previous = this.mutationOrder;
+    this.mutationOrder = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    return release;
+  }
+
+  private async acceptMutation<T>(
+    operation: (cache: Record<string, string>) => MutationAcceptance<T>,
+  ): Promise<MutationAcceptance<T>> {
+    const turn = this.acquireMutationTurn();
+    const cacheOutcome = this.ensureCacheLoaded().then(
+      () => ({ loaded: true }) as const,
+      (error: unknown) => ({ loaded: false, error }) as const,
+    );
+    const release = await turn;
+    try {
+      const outcome = await cacheOutcome;
+      if (!outcome.loaded) {
+        throw outcome.error;
+      }
+      while (this.cache === null) {
+        await this.ensureCacheLoaded();
+      }
+      return operation(this.visibleCache());
+    } finally {
+      release();
+    }
+  }
+
+  private createMutationBatch(): MutationBatch {
+    let markReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      markReady = resolve;
+    });
+    const batch: MutationBatch = {
+      changes: {},
+      waiters: [],
+      ready,
+      markReady,
+      timer: null,
+    };
+    batch.timer = setTimeout(() => {
+      batch.timer = null;
+      batch.markReady();
+    }, MUTATION_COALESCE_MS);
+    return batch;
+  }
+
+  private cancelBatchTimer(batch: MutationBatch): void {
+    if (batch.timer !== null) {
+      clearTimeout(batch.timer);
+      batch.timer = null;
+    }
+    batch.markReady();
+  }
+
+  private enqueueCommit(changes: FileChanges): Promise<void> {
     if (Object.keys(changes).length === 0) {
+      return Promise.resolve();
+    }
+
+    let batch = this.pendingBatch;
+    if (batch === null) {
+      batch = this.createMutationBatch();
+      this.pendingBatch = batch;
+    }
+    Object.assign(batch.changes, changes);
+
+    const completion = new Promise<void>((resolve, reject) => {
+      batch.waiters.push({ resolve, reject });
+    });
+    this.startWorker();
+    return completion;
+  }
+
+  private startWorker(): void {
+    if (this.workerPromise !== null) {
       return;
     }
 
+    const worker = this.drainMutationQueue()
+      .catch((error: unknown) => {
+        this.failAllBatches(error);
+      })
+      .finally(() => {
+        if (this.workerPromise === worker) {
+          this.workerPromise = null;
+          if (this.pendingBatch !== null) {
+            this.startWorker();
+          }
+        }
+      });
+    this.workerPromise = worker;
+  }
+
+  private async drainMutationQueue(): Promise<void> {
+    while (this.pendingBatch !== null) {
+      const batch = this.pendingBatch;
+      await batch.ready;
+      if (this.pendingBatch !== batch) {
+        continue;
+      }
+
+      this.pendingBatch = null;
+      this.inFlightBatch = batch;
+      try {
+        const result = await this.pushBatch(batch.changes);
+        if (result.kind === "snapshot") {
+          this.publishSnapshot(result.snapshot);
+        } else {
+          this.cache = ContextHubBackend.applyChanges(
+            this.cache ?? {},
+            batch.changes,
+          );
+          this.commitHash = result.commitHash;
+        }
+      } catch (error) {
+        this.inFlightBatch = null;
+        this.invalidateCache();
+        this.finishSnapshotPublication();
+        for (const waiter of batch.waiters) {
+          waiter.reject(error);
+        }
+        this.failPendingBatch(error);
+        return;
+      }
+
+      this.inFlightBatch = null;
+      this.finishSnapshotPublication();
+      for (const waiter of batch.waiters) {
+        waiter.resolve();
+      }
+    }
+  }
+
+  private failPendingBatch(error: unknown): void {
+    const pending = this.pendingBatch;
+    if (pending === null) {
+      return;
+    }
+    this.pendingBatch = null;
+    this.cancelBatchTimer(pending);
+    for (const waiter of pending.waiters) {
+      waiter.reject(error);
+    }
+  }
+
+  private failAllBatches(error: unknown): void {
+    const inFlight = this.inFlightBatch;
+    this.inFlightBatch = null;
+    this.invalidateCache();
+    this.finishSnapshotPublication();
+    if (inFlight !== null) {
+      this.cancelBatchTimer(inFlight);
+      for (const waiter of inFlight.waiters) {
+        waiter.reject(error);
+      }
+    }
+    this.failPendingBatch(error);
+  }
+
+  private async pushBatch(changes: FileChanges): Promise<PushBatchResult> {
     const payload: Record<string, Entry | null> = {};
     for (const [path, content] of Object.entries(changes)) {
       payload[path] = content === null ? null : { type: "file", content };
     }
 
-    const url = await this.client.pushAgent(this.identifier, {
-      files: payload,
-      ...(this.commitHash ? { parentCommit: this.commitHash } : {}),
-    });
+    for (let attempt = 0; ; attempt += 1) {
+      let url: string;
+      try {
+        url = await this.client.pushAgent(this.identifier, {
+          files: payload,
+          ...(this.commitHash ? { parentCommit: this.commitHash } : {}),
+        });
+      } catch (error) {
+        if (
+          getLangSmithStatus(error) !== 409 ||
+          attempt >= MAX_CONFLICT_RETRIES
+        ) {
+          throw error;
+        }
+        await this.loadTree();
+        continue;
+      }
 
-    const match = URL_COMMIT_SUFFIX_RE.exec(url);
-    if (match) {
-      this.commitHash = match[1];
-    }
-
-    if (this.cache !== null) {
-      const deletions = new Set(
-        Object.entries(changes)
-          .filter(([, content]) => content === null)
-          .map(([path]) => path),
-      );
-      const updates = Object.fromEntries(
-        Object.entries(changes).filter(
-          (entry): entry is [string, string] => entry[1] !== null,
-        ),
-      );
-      this.cache = {
-        ...Object.fromEntries(
-          Object.entries(this.cache).filter(([path]) => !deletions.has(path)),
-        ),
-        ...updates,
-      };
+      const pushedCommitHash = parseCommitHashFromUrl(url, this.identifier);
+      if (pushedCommitHash === null) {
+        this.beginSnapshotPublication();
+        const snapshot = await this.fetchTree();
+        if (snapshot.commitHash === null) {
+          throw new Error(
+            "Context Hub commit succeeded but its hash could not be resolved",
+          );
+        }
+        return {
+          kind: "snapshot",
+          snapshot,
+        };
+      }
+      return { kind: "commit", commitHash: pushedCommitHash };
     }
   }
 
@@ -416,17 +768,20 @@ export class ContextHubBackend implements BackendProtocolV2 {
     const hubPath = ContextHubBackend.stripPrefix(filePath);
 
     try {
-      await this.ensureCache();
-      await this.commit({ [hubPath]: content });
+      const accepted = await this.acceptMutation<WriteResult>(() => {
+        return {
+          result: { path: filePath, filesUpdate: null },
+          completion: this.enqueueCommit({ [hubPath]: content }),
+        };
+      });
+      await accepted.completion;
+      return accepted.result;
     } catch (error) {
       if (isLangSmithError(error)) {
-        this.cache = null;
         return { error: ContextHubBackend.toHubUnavailableError(error) };
       }
       throw error;
     }
-
-    return { path: filePath, filesUpdate: null };
   }
 
   async edit(
@@ -438,32 +793,38 @@ export class ContextHubBackend implements BackendProtocolV2 {
     const hubPath = ContextHubBackend.stripPrefix(filePath);
 
     try {
-      const cache = await this.ensureCache();
-      const current = cache[hubPath];
-      if (current === undefined) {
-        return { error: `Error: File '${filePath}' not found` };
-      }
+      const accepted = await this.acceptMutation<EditResult>((cache) => {
+        const current = cache[hubPath];
+        if (current === undefined) {
+          return {
+            result: { error: `Error: File '${filePath}' not found` },
+          };
+        }
 
-      const replacementResult = performStringReplacement(
-        current,
-        oldString,
-        newString,
-        replaceAll,
-      );
-      if (typeof replacementResult === "string") {
-        return { error: replacementResult };
-      }
+        const replacementResult = performStringReplacement(
+          current,
+          oldString,
+          newString,
+          replaceAll,
+        );
+        if (typeof replacementResult === "string") {
+          return { result: { error: replacementResult } };
+        }
 
-      const [newContent, occurrences] = replacementResult;
-      await this.commit({ [hubPath]: newContent });
-      return {
-        path: filePath,
-        filesUpdate: null,
-        occurrences,
-      };
+        const [newContent, occurrences] = replacementResult;
+        return {
+          result: {
+            path: filePath,
+            filesUpdate: null,
+            occurrences,
+          },
+          completion: this.enqueueCommit({ [hubPath]: newContent }),
+        };
+      });
+      await accepted.completion;
+      return accepted.result;
     } catch (error) {
       if (isLangSmithError(error)) {
-        this.cache = null;
         return { error: ContextHubBackend.toHubUnavailableError(error) };
       }
       throw error;
@@ -474,16 +835,22 @@ export class ContextHubBackend implements BackendProtocolV2 {
     const hubPath = ContextHubBackend.stripPrefix(filePath);
 
     try {
-      const cache = await this.ensureCache();
-      if (!(hubPath in cache)) {
-        return { error: `Error: File '${filePath}' not found` };
-      }
+      const accepted = await this.acceptMutation<DeleteResult>((cache) => {
+        if (!(hubPath in cache)) {
+          return {
+            result: { error: `Error: File '${filePath}' not found` },
+          };
+        }
 
-      await this.commit({ [hubPath]: null });
-      return { path: filePath };
+        return {
+          result: { path: filePath },
+          completion: this.enqueueCommit({ [hubPath]: null }),
+        };
+      });
+      await accepted.completion;
+      return accepted.result;
     } catch (error) {
       if (isLangSmithError(error)) {
-        this.cache = null;
         return { error: ContextHubBackend.toHubUnavailableError(error) };
       }
       throw error;
@@ -510,11 +877,15 @@ export class ContextHubBackend implements BackendProtocolV2 {
     let commitError: FileOperationError | null = null;
     if (Object.keys(validFiles).length > 0) {
       try {
-        await this.ensureCache();
-        await this.commit(validFiles);
+        const accepted = await this.acceptMutation<null>(() => {
+          return {
+            result: null,
+            completion: this.enqueueCommit(validFiles),
+          };
+        });
+        await accepted.completion;
       } catch (error) {
         if (isLangSmithError(error)) {
-          this.cache = null;
           commitError = mapHubFileOperationError(error);
         } else {
           throw error;

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -534,10 +534,22 @@ export class ContextHubBackend implements BackendProtocolV2 {
     conflictError: unknown,
   ): void {
     const cache = this.rematerializeBatch(batch, snapshot.cache, conflictError);
+    let pendingReplayError: unknown = null;
     if (this.pendingBatch !== null) {
-      this.rematerializeBatch(this.pendingBatch, cache, conflictError);
+      try {
+        this.rematerializeBatch(this.pendingBatch, cache, conflictError);
+      } catch (error) {
+        if (error !== conflictError) {
+          throw error;
+        }
+        pendingReplayError = error;
+      }
     }
     this.publishSnapshot(snapshot);
+    if (pendingReplayError !== null) {
+      // A queued replay failure must not abort the valid in-flight retry.
+      this.failPendingBatch(pendingReplayError);
+    }
   }
 
   private rematerializePendingBatch(snapshot: TreeSnapshot): Error | null {

--- a/libs/deepagents/src/utils.test.ts
+++ b/libs/deepagents/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
-import { isBedrockConverseModel } from "./utils.js";
+import { Deferred, isBedrockConverseModel } from "./utils.js";
 
 describe("isBedrockConverseModel", () => {
   describe("string inputs", () => {
@@ -82,5 +82,32 @@ describe("isBedrockConverseModel", () => {
       vi.spyOn(model, "getName").mockReturnValue("ConfigurableModel");
       expect(isBedrockConverseModel(model)).toBe(false);
     });
+  });
+});
+
+describe("Deferred", () => {
+  it("resolves through both its promise and PromiseLike interface", async () => {
+    const deferred = new Deferred<number>();
+    deferred.resolve(42);
+
+    await expect(deferred.promise).resolves.toBe(42);
+    await expect(deferred).resolves.toBe(42);
+  });
+
+  it("rejects with the supplied reason", async () => {
+    const deferred = new Deferred<void>();
+    const error = new Error("failed");
+    deferred.reject(error);
+
+    await expect(deferred.promise).rejects.toBe(error);
+  });
+
+  it("settles only once", async () => {
+    const deferred = new Deferred<string>();
+    deferred.resolve("first");
+    deferred.resolve("second");
+    deferred.reject(new Error("ignored"));
+
+    await expect(deferred).resolves.toBe("first");
   });
 });

--- a/libs/deepagents/src/utils.ts
+++ b/libs/deepagents/src/utils.ts
@@ -26,6 +26,45 @@ export function isAnthropicModel(
   return model.getName() === "ChatAnthropic";
 }
 
+/** A one-shot promise whose settlement is controlled externally. */
+export class Deferred<T = void> implements PromiseLike<T> {
+  readonly promise: Promise<T>;
+
+  private settled = false;
+  private resolvePromise!: (value: T | PromiseLike<T>) => void;
+  private rejectPromise!: (reason?: unknown) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolvePromise = resolve;
+      this.rejectPromise = reject;
+    });
+  }
+
+  resolve(value: T | PromiseLike<T>): void {
+    if (this.settled) {
+      return;
+    }
+    this.settled = true;
+    this.resolvePromise(value);
+  }
+
+  reject(reason?: unknown): void {
+    if (this.settled) {
+      return;
+    }
+    this.settled = true;
+    this.rejectPromise(reason);
+  }
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.promise.then(onfulfilled, onrejected);
+  }
+}
+
 /**
  * Detect whether a model is an AWS Bedrock Converse model.
  *

--- a/libs/deepagents/src/utils.ts
+++ b/libs/deepagents/src/utils.ts
@@ -26,7 +26,18 @@ export function isAnthropicModel(
   return model.getName() === "ChatAnthropic";
 }
 
-/** A one-shot promise whose settlement is controlled externally. */
+/**
+ * A one-shot promise whose settlement is controlled externally.
+ *
+ * Use this when one part of a workflow must wait for an event that is owned
+ * elsewhere—for example, a queued mutation waiting for the worker that will
+ * push it. `Deferred` is awaitable because it implements `PromiseLike`, and
+ * `.promise` is available when a concrete `Promise` is required.
+ *
+ * The first call to `resolve` or `reject` wins; later calls are ignored. This
+ * class deliberately does not provide cancellation, reset, or notification
+ * semantics. It models exactly one eventual outcome.
+ */
 export class Deferred<T = void> implements PromiseLike<T> {
   readonly promise: Promise<T>;
 


### PR DESCRIPTION
ContextHubBackend now preserves concurrent file mutations in one durable commit and retains compatible remote changes during conflict recovery.

---

Concurrent callers previously reused the same parent commit, causing 409s. Retries could also replay stale edit payloads.

Mutations now coalesce for 50 ms into serialized multi-file commits. Conflict recovery replays ordered edit intent against refreshed state; explicit writes, uploads, and deletes remain last-writer-wins.