### PR TITLE
fix(deepagents): exclude summarization state from subagent input/output

### DIFF
--- a/.changeset/fix-subagent-summarization-leak.md
+++ b/.changeset/fix-subagent-summarization-leak.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): exclude summarization state from subagent input/output

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -39,7 +39,7 @@ import { createSummarizationMiddleware } from "./summarization.js";
 import { mergeMiddleware } from "./utils.js";
 import { createFileData } from "../backends/utils.js";
 import { createMockBackend } from "./test.js";
-import { createSubAgent } from "./subagents.js";
+import { createSubAgent, filterStateForSubagent } from "./subagents.js";
 import { registerHarnessProfile } from "../profiles/index.js";
 
 const createAgentMock = vi.mocked(createAgent);
@@ -294,6 +294,46 @@ description: A skill for the subagent
     // Verify skillsMetadata is NOT in the parent agent's final state
     // This confirms EXCLUDED_STATE_KEYS is working correctly
     expect(result).not.toHaveProperty("skillsMetadata");
+  });
+});
+
+describe("Subagent summarization state isolation", () => {
+  const summarizationEvent = {
+    cutoffIndex: 40,
+    summaryMessage: new HumanMessage({ content: "STALE_PARENT_SUMMARY" }),
+    filePath: null,
+  };
+
+  it("should exclude _summarizationEvent and _summarizationSessionId from subagent input", () => {
+    const parentState = {
+      messages: [new HumanMessage("irrelevant")],
+      files: { "/foo.txt": "data" },
+      _summarizationEvent: summarizationEvent,
+      _summarizationSessionId: "thread-abc",
+    };
+
+    const filtered = filterStateForSubagent(parentState);
+
+    expect(filtered).not.toHaveProperty("_summarizationEvent");
+    expect(filtered).not.toHaveProperty("_summarizationSessionId");
+    expect(filtered.files).toEqual(parentState.files);
+  });
+
+  it("should exclude a subagent's own _summarizationEvent from its return update", () => {
+    const subagentResult = {
+      messages: [new AIMessage({ content: "Subagent done" })],
+      _summarizationEvent: {
+        cutoffIndex: 99,
+        summaryMessage: new HumanMessage({ content: "SUBAGENT_SUMMARY" }),
+        filePath: null,
+      },
+      _summarizationSessionId: "subagent-thread-xyz",
+    };
+
+    const filtered = filterStateForSubagent(subagentResult);
+
+    expect(filtered).not.toHaveProperty("_summarizationEvent");
+    expect(filtered).not.toHaveProperty("_summarizationSessionId");
   });
 });
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -41,16 +41,9 @@ export const DEFAULT_SUBAGENT_PROMPT =
   "In order to complete the objective that the user asks of you, you have access to a number of standard tools.";
 
 /**
- * State keys that are excluded when passing state to subagents and when returning
- * updates from subagents.
- *
- * When returning updates:
- * 1. The messages key is handled explicitly to ensure only the final message is included
- * 2. The todos and structuredResponse keys are excluded as they do not have a defined reducer
- *    and no clear meaning for returning them from a subagent to the main agent.
- * 3. The skillsMetadata and memoryContents keys are automatically excluded from subagent output
- *    to prevent parent state from leaking to child agents. Each agent loads its own skills/memory
- *    independently based on its middleware configuration.
+ * State keys excluded when passing state to subagents and when returning
+ * updates from subagents. Summarization keys are excluded because their
+ * cutoffIndex is only valid against the message list it was computed from.
  */
 const EXCLUDED_STATE_KEYS = [
   "messages",
@@ -58,6 +51,8 @@ const EXCLUDED_STATE_KEYS = [
   "structuredResponse",
   "skillsMetadata",
   "memoryContents",
+  "_summarizationEvent",
+  "_summarizationSessionId",
 ] as const;
 
 /**
@@ -276,7 +271,7 @@ export const GENERAL_PURPOSE_SUBAGENT: Pick<
 /**
  * Filter state to exclude certain keys when passing to subagents
  */
-function filterStateForSubagent(
+export function filterStateForSubagent(
   state: Record<string, unknown>,
 ): Record<string, unknown> {
   const filtered: Record<string, unknown> = {};

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -555,6 +555,7 @@ function createTaskTool(options: {
       const currentState = getCurrentTaskInput<Record<string, unknown>>();
       const subagentState = filterStateForSubagent(currentState);
       subagentState.messages = [new HumanMessage({ content: description })];
+      subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
 
       const subagentConfig = {
         ...config,


### PR DESCRIPTION
Fixes #748 

Excludes `_summarizationEvent`/`_summarizationSessionId` from subagent state input/output. These weren't in `EXCLUDED_STATE_KEYS`, so a stale parent cutoffIndex could silently drop a subagent's task description, and a subagent's own summarization event could overwrite the parent's on return.