### PR TITLE
fix(deepagents): coerce grep tool's max_count to a number

### DIFF
--- a/.changeset/fix-grep-max-count-coercion.md
+++ b/.changeset/fix-grep-max-count-coercion.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): coerce grep tool's max_count to a number

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1509,6 +1509,25 @@ describe("createFilesystemMiddleware", () => {
       expect(mockBackend.grep).toHaveBeenCalledWith("needle", "/", null, 5);
     });
 
+    it("grep tool coerces a stringified max_count arg to a number", async () => {
+      const mockBackend = createMockBackend();
+      mockBackend.grep = vi.fn().mockResolvedValue({ matches: [] });
+
+      const state = { messages: [], files: {} };
+      vi.mocked(getCurrentTaskInput).mockReturnValue(state);
+
+      const middleware = createFilesystemMiddleware({
+        backend: () => mockBackend,
+      });
+
+      const grepTool = middleware.tools!.find(
+        (t: any) => t.name === "grep",
+      ) as any;
+      await grepTool.invoke({ pattern: "needle", path: "/", max_count: "5" });
+
+      expect(mockBackend.grep).toHaveBeenCalledWith("needle", "/", null, 5);
+    });
+
     it("grep tool appends the truncation note when the backend flags truncated", async () => {
       const mockBackend = createMockBackend();
       mockBackend.grep = vi.fn().mockResolvedValue({

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -1127,7 +1127,7 @@ function createGrepTool(
           .nullable()
           .default(null)
           .describe("Optional glob pattern to filter files (e.g., '*.py')"),
-        max_count: z
+        max_count: z.coerce
           .number()
           .int()
           .positive()


### PR DESCRIPTION
Fixes #745 

`max_count` was the only numeric grep param without type coercion, causing ToolInputParsingException on stringified input. Switched to z.coerce.number().