### PR TITLE
feat(deepagents): introduce ForkedSubAgent type for subagent conversation forking

### DIFF
--- a/.changeset/subagent-mode-fork.md
+++ b/.changeset/subagent-mode-fork.md
@@ -2,6 +2,6 @@
 "deepagents": minor
 ---
 
-feat(deepagents): add `mode: "fork"` for subagent conversation forking
+feat(deepagents): add `ForkedSubAgent` for subagent conversation forking
 
-Lets a subagent inherit the parent's conversation history and (when the model matches) system prompt, instead of only seeing the task description.
+Lets a subagent inherit the parent's conversation history and (when the model matches) system prompt, instead of only seeing the task description. Unlike a regular `SubAgent`, a `ForkedSubAgent` has no `systemPrompt` of its own — it always inherits the parent's.

--- a/.changeset/subagent-mode-fork.md
+++ b/.changeset/subagent-mode-fork.md
@@ -1,0 +1,7 @@
+---
+"deepagents": minor
+---
+
+feat(deepagents): add `mode: "fork" | "dynamic"` for subagent conversation forking
+
+Lets a subagent inherit the parent's conversation history and (when the model matches) system prompt, instead of only seeing the task description.

--- a/.changeset/subagent-mode-fork.md
+++ b/.changeset/subagent-mode-fork.md
@@ -4,4 +4,4 @@
 
 feat(deepagents): add `ForkedSubAgent` for subagent conversation forking
 
-Lets a subagent inherit the parent's conversation history and (when the model matches) system prompt, instead of only seeing the task description. Unlike a regular `SubAgent`, a `ForkedSubAgent` has no `systemPrompt` of its own — it always inherits the parent's.
+Lets a subagent inherit the parent's conversation history instead of only seeing the task description.

--- a/.changeset/subagent-mode-fork.md
+++ b/.changeset/subagent-mode-fork.md
@@ -2,6 +2,6 @@
 "deepagents": minor
 ---
 
-feat(deepagents): add `mode: "fork" | "dynamic"` for subagent conversation forking
+feat(deepagents): add `mode: "fork"` for subagent conversation forking
 
 Lets a subagent inherit the parent's conversation history and (when the model matches) system prompt, instead of only seeing the task description.

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -313,19 +313,15 @@ export function createDeepAgent<
         ]
       : [];
 
-  // Mirror middleware for a "dynamic" spec's per-call recompile.
-  const buildMirrorMiddleware = (): AgentMiddleware[] => [
-    ...customMiddleware,
-    ...buildMirrorMemoryMiddleware(),
-  ];
-
   const normalizeSubagentSpec = (input: SubAgent): SubAgent => {
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(input);
 
-    // Only "fork" bakes mirrored middleware in statically; "dynamic" gets it at recompile time.
-    const shouldMirrorStatically =
-      input.mode === "fork" &&
-      isCacheAlignedForkSpec(input.mode, input.model, model, finalSystemPrompt);
+    const shouldMirrorStatically = isCacheAlignedForkSpec({
+      mode: input.mode,
+      specModel: input.model,
+      parentModel: model,
+      parentSystemPrompt: finalSystemPrompt,
+    });
     const mirroredCustomMiddleware = shouldMirrorStatically
       ? customMiddleware
       : [];
@@ -428,7 +424,6 @@ export function createDeepAgent<
       subagents: inlineSubagents,
       generalPurposeAgent: false,
       parentSystemPrompt: finalSystemPrompt,
-      parentMirrorMiddleware: buildMirrorMiddleware,
     }),
     // Automatically summarizes conversation history when token limits are approached.
     // Uses createSummarizationMiddleware (deepagents version) with backend support

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -384,7 +384,7 @@ export function createDeepAgent<
     .map((item) =>
       "runnable" in item
         ? item
-        : "systemPrompt" in item
+        : item.systemPrompt != null
           ? normalizeSubagentSpec(item)
           : normalizeForkedSubagentSpec(item),
     );

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -35,6 +35,7 @@ import { createToolExclusionMiddleware } from "./middleware/tool_exclusion.js";
 import { mergeMiddlewareStack } from "./middleware/utils.js";
 import {
   GENERAL_PURPOSE_SUBAGENT,
+  isCacheAlignedForkSpec,
   type CompiledSubAgent,
 } from "./middleware/subagents.js";
 import type { AsyncSubAgent } from "./middleware/async_subagents.js";
@@ -252,6 +253,19 @@ export function createDeepAgent<
     ];
   }
 
+  // Hoisted above subagent construction so fork-mode specs can reuse this string.
+  const promptConfig = normalizeSystemPrompt(systemPrompt);
+  const activeBasePrompt =
+    promptConfig.base !== undefined
+      ? promptConfig.base
+      : harnessProfile.baseSystemPrompt;
+  const finalSystemPrompt = assemblePromptParts([
+    promptConfig.prefix,
+    activeBasePrompt,
+    promptConfig.suffix,
+    harnessProfile.systemPromptSuffix,
+  ]);
+
   /**
    * Process subagents to add SkillsMiddleware for those with their own skills.
    *
@@ -289,13 +303,33 @@ export function createDeepAgent<
 
   const normalizeSubagentSpec = (input: SubAgent): SubAgent => {
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(input);
+
+    const cacheAligned = isCacheAlignedForkSpec(
+      input.mode,
+      input.model,
+      model,
+      finalSystemPrompt,
+    );
+    const mirroredCustomMiddleware = cacheAligned ? customMiddleware : [];
+    const mirroredMemoryMiddleware =
+      cacheAligned && memory && memory.length > 0
+        ? [
+            createMemoryMiddleware({
+              backend,
+              sources: memory,
+              addCacheControl: anthropicModel,
+            }),
+          ]
+        : [];
+
     let subagentMiddleware = mergeMiddlewareStack(
       subagentDefaultMiddleware,
-      input.middleware ?? [],
+      [...(input.middleware ?? []), ...mirroredCustomMiddleware],
       [
         // Resolve profile middleware per stack so factories create fresh instances.
         ...resolveMiddleware(harnessProfile.extraMiddleware),
         ...cacheMiddleware,
+        ...mirroredMemoryMiddleware,
       ],
     );
 
@@ -382,6 +416,7 @@ export function createDeepAgent<
       defaultInterruptOn: interruptOn,
       subagents: inlineSubagents,
       generalPurposeAgent: false,
+      parentSystemPrompt: finalSystemPrompt,
     }),
     // Automatically summarizes conversation history when token limits are approached.
     // Uses createSummarizationMiddleware (deepagents version) with backend support
@@ -449,19 +484,6 @@ export function createDeepAgent<
       createToolExclusionMiddleware(harnessProfile.excludedTools),
     );
   }
-
-  // Compatibility assembly: prefix -> profile base -> suffix -> profile suffix.
-  const promptConfig = normalizeSystemPrompt(systemPrompt);
-  const activeBasePrompt =
-    promptConfig.base !== undefined
-      ? promptConfig.base
-      : harnessProfile.baseSystemPrompt;
-  const finalSystemPrompt = assemblePromptParts([
-    promptConfig.prefix,
-    activeBasePrompt,
-    promptConfig.suffix,
-    harnessProfile.systemPromptSuffix,
-  ]);
 
   const agent = createAgent({
     model,

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -35,8 +35,8 @@ import { createToolExclusionMiddleware } from "./middleware/tool_exclusion.js";
 import { mergeMiddlewareStack } from "./middleware/utils.js";
 import {
   GENERAL_PURPOSE_SUBAGENT,
-  isCacheAlignedForkSpec,
   type CompiledSubAgent,
+  type ForkedSubAgent,
 } from "./middleware/subagents.js";
 import type { AsyncSubAgent } from "./middleware/async_subagents.js";
 import type {
@@ -274,7 +274,7 @@ export function createDeepAgent<
    * If a custom subagent needs skills, it must specify its own `skills` array.
    */
   const createSubagentDefaultMiddleware = (
-    input: SubAgent,
+    input: SubAgent | ForkedSubAgent,
   ): AgentMiddleware[] => {
     const effectivePermissions = input.permissions ?? permissions;
 
@@ -313,19 +313,20 @@ export function createDeepAgent<
         ]
       : [];
 
-  const normalizeSubagentSpec = (input: SubAgent): SubAgent => {
+  const buildSubagentMiddleware = (
+    input: SubAgent | ForkedSubAgent,
+    isForkable: boolean,
+  ): AgentMiddleware[] => {
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(input);
 
-    const shouldMirrorStatically = isCacheAlignedForkSpec({
-      mode: input.mode,
-      specModel: input.model,
-      parentModel: model,
-      parentSystemPrompt: finalSystemPrompt,
-    });
-    const mirroredCustomMiddleware = shouldMirrorStatically
-      ? customMiddleware
-      : [];
-    const mirroredMemoryMiddleware = shouldMirrorStatically
+    const shouldMirror =
+      isForkable &&
+      (input.model === undefined || input.model === model) &&
+      finalSystemPrompt != null &&
+      finalSystemPrompt !== "";
+
+    const mirroredCustomMiddleware = shouldMirror ? customMiddleware : [];
+    const mirroredMemoryMiddleware = shouldMirror
       ? buildMirrorMemoryMiddleware()
       : [];
 
@@ -346,12 +347,22 @@ export function createDeepAgent<
       );
     }
 
-    return {
-      ...input,
-      tools: input.tools ?? [],
-      middleware: subagentMiddleware,
-    };
+    return subagentMiddleware;
   };
+
+  const normalizeSubagentSpec = (input: SubAgent): SubAgent => ({
+    ...input,
+    tools: input.tools ?? [],
+    middleware: buildSubagentMiddleware(input, /* isForkable */ false),
+  });
+
+  const normalizeForkedSubagentSpec = (
+    input: ForkedSubAgent,
+  ): ForkedSubAgent => ({
+    ...input,
+    tools: input.tools ?? [],
+    middleware: buildSubagentMiddleware(input, /* isForkable */ true),
+  });
 
   const allSubagents = subagents as readonly AnySubAgent[];
 
@@ -364,11 +375,19 @@ export function createDeepAgent<
   // Process sync subagents:
   // - CompiledSubAgent: use as-is (already has its own middleware baked in)
   // - SubAgent: apply the default deep-agent subagent middleware stack
+  // - ForkedSubAgent: same stack, plus model-matched mirrored middleware
   const inlineSubagents = allSubagents
     .filter(
-      (item): item is SubAgent | CompiledSubAgent => !isAsyncSubAgent(item),
+      (item): item is SubAgent | CompiledSubAgent | ForkedSubAgent =>
+        !isAsyncSubAgent(item),
     )
-    .map((item) => ("runnable" in item ? item : normalizeSubagentSpec(item)));
+    .map((item) =>
+      "runnable" in item
+        ? item
+        : "systemPrompt" in item
+          ? normalizeSubagentSpec(item)
+          : normalizeForkedSubagentSpec(item),
+    );
 
   const gpConfig = harnessProfile.generalPurposeSubagent;
   const gpDisabled = gpConfig?.enabled === false;

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -35,6 +35,7 @@ import { createToolExclusionMiddleware } from "./middleware/tool_exclusion.js";
 import { mergeMiddlewareStack } from "./middleware/utils.js";
 import {
   GENERAL_PURPOSE_SUBAGENT,
+  isForkedSubAgent,
   type CompiledSubAgent,
   type ForkedSubAgent,
 } from "./middleware/subagents.js";
@@ -253,6 +254,17 @@ export function createDeepAgent<
     ];
   }
 
+  let memoryMiddleware: AgentMiddleware[] = [];
+  if (memory && memory.length > 0) {
+    memoryMiddleware = [
+      createMemoryMiddleware({
+        backend,
+        sources: memory,
+        addCacheControl: anthropicModel,
+      }),
+    ];
+  }
+
   // Hoisted above subagent construction so fork-mode specs can reuse this string.
   const promptConfig = normalizeSystemPrompt(systemPrompt);
   const activeBasePrompt =
@@ -301,43 +313,20 @@ export function createDeepAgent<
     ];
   };
 
-  // Fresh memory middleware for a cache-aligned fork spec.
-  const buildMirrorMemoryMiddleware = (): AgentMiddleware[] =>
-    memory && memory.length > 0
-      ? [
-          createMemoryMiddleware({
-            backend,
-            sources: memory,
-            addCacheControl: anthropicModel,
-          }),
-        ]
-      : [];
-
   const buildSubagentMiddleware = (
     input: SubAgent | ForkedSubAgent,
     isForkable: boolean,
   ): AgentMiddleware[] => {
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(input);
 
-    const shouldMirror =
-      isForkable &&
-      (input.model === undefined || input.model === model) &&
-      finalSystemPrompt != null &&
-      finalSystemPrompt !== "";
-
-    const mirroredCustomMiddleware = shouldMirror ? customMiddleware : [];
-    const mirroredMemoryMiddleware = shouldMirror
-      ? buildMirrorMemoryMiddleware()
-      : [];
-
     let subagentMiddleware = mergeMiddlewareStack(
       subagentDefaultMiddleware,
-      [...(input.middleware ?? []), ...mirroredCustomMiddleware],
+      [...(input.middleware ?? []), ...memoryMiddleware],
       [
         // Resolve profile middleware per stack so factories create fresh instances.
         ...resolveMiddleware(harnessProfile.extraMiddleware),
         ...cacheMiddleware,
-        ...mirroredMemoryMiddleware,
+        ...(isForkable ? memoryMiddleware : []),
       ],
     );
 
@@ -384,9 +373,9 @@ export function createDeepAgent<
     .map((item) =>
       "runnable" in item
         ? item
-        : item.systemPrompt != null
-          ? normalizeSubagentSpec(item)
-          : normalizeForkedSubagentSpec(item),
+        : isForkedSubAgent(item)
+          ? normalizeForkedSubagentSpec(item)
+          : normalizeSubagentSpec(item),
     );
 
   const gpConfig = harnessProfile.generalPurposeSubagent;
@@ -478,15 +467,7 @@ export function createDeepAgent<
     // Optional Anthropic cache controls.
     ...cacheMiddleware,
     // Optional memory support.
-    ...(memory && memory.length > 0
-      ? [
-          createMemoryMiddleware({
-            backend,
-            sources: memory,
-            addCacheControl: anthropicModel,
-          }),
-        ]
-      : []),
+    ...memoryMiddleware,
     // Optional human-in-the-loop tool interrupts.
     ...(interruptOn ? [humanInTheLoopMiddleware({ interruptOn })] : []),
   ];

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -301,26 +301,37 @@ export function createDeepAgent<
     ];
   };
 
+  // Fresh memory middleware for a cache-aligned fork spec.
+  const buildMirrorMemoryMiddleware = (): AgentMiddleware[] =>
+    memory && memory.length > 0
+      ? [
+          createMemoryMiddleware({
+            backend,
+            sources: memory,
+            addCacheControl: anthropicModel,
+          }),
+        ]
+      : [];
+
+  // Mirror middleware for a "dynamic" spec's per-call recompile.
+  const buildMirrorMiddleware = (): AgentMiddleware[] => [
+    ...customMiddleware,
+    ...buildMirrorMemoryMiddleware(),
+  ];
+
   const normalizeSubagentSpec = (input: SubAgent): SubAgent => {
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(input);
 
-    const cacheAligned = isCacheAlignedForkSpec(
-      input.mode,
-      input.model,
-      model,
-      finalSystemPrompt,
-    );
-    const mirroredCustomMiddleware = cacheAligned ? customMiddleware : [];
-    const mirroredMemoryMiddleware =
-      cacheAligned && memory && memory.length > 0
-        ? [
-            createMemoryMiddleware({
-              backend,
-              sources: memory,
-              addCacheControl: anthropicModel,
-            }),
-          ]
-        : [];
+    // Only "fork" bakes mirrored middleware in statically; "dynamic" gets it at recompile time.
+    const shouldMirrorStatically =
+      input.mode === "fork" &&
+      isCacheAlignedForkSpec(input.mode, input.model, model, finalSystemPrompt);
+    const mirroredCustomMiddleware = shouldMirrorStatically
+      ? customMiddleware
+      : [];
+    const mirroredMemoryMiddleware = shouldMirrorStatically
+      ? buildMirrorMemoryMiddleware()
+      : [];
 
     let subagentMiddleware = mergeMiddlewareStack(
       subagentDefaultMiddleware,
@@ -417,6 +428,7 @@ export function createDeepAgent<
       subagents: inlineSubagents,
       generalPurposeAgent: false,
       parentSystemPrompt: finalSystemPrompt,
+      parentMirrorMiddleware: buildMirrorMiddleware,
     }),
     // Automatically summarizes conversation history when token limits are approached.
     // Uses createSummarizationMiddleware (deepagents version) with backend support

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -321,7 +321,7 @@ export function createDeepAgent<
 
     let subagentMiddleware = mergeMiddlewareStack(
       subagentDefaultMiddleware,
-      [...(input.middleware ?? []), ...memoryMiddleware],
+      input.middleware ?? [],
       [
         // Resolve profile middleware per stack so factories create fresh instances.
         ...resolveMiddleware(harnessProfile.extraMiddleware),

--- a/libs/deepagents/src/browser.ts
+++ b/libs/deepagents/src/browser.ts
@@ -97,6 +97,7 @@ export {
   type MemoryMiddlewareOptions,
   type SubAgent,
   type CompiledSubAgent,
+  type ForkedSubAgent,
   type AsyncSubAgentMiddlewareOptions,
   type AsyncSubAgent,
   type AsyncTask,

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -102,6 +102,7 @@ export {
   type MemoryMiddlewareOptions,
   type SubAgent,
   type CompiledSubAgent,
+  type ForkedSubAgent,
   type AsyncSubAgentMiddlewareOptions,
   type AsyncSubAgent,
   type AsyncTask,

--- a/libs/deepagents/src/middleware/index.ts
+++ b/libs/deepagents/src/middleware/index.ts
@@ -13,6 +13,7 @@ export {
   type SubAgentMiddlewareOptions,
   type SubAgent,
   type CompiledSubAgent,
+  type ForkedSubAgent,
   // Constants for building custom subagent configurations
   GENERAL_PURPOSE_SUBAGENT,
   DEFAULT_GENERAL_PURPOSE_DESCRIPTION,

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -1903,6 +1903,30 @@ describe("middleware override by name", () => {
     );
   });
 
+  it("does NOT bake mirrored middleware into a dynamic-mode subagent's cached graph, even when cache-aligned", () => {
+    const custom = namedMiddleware("MarkerMiddleware");
+
+    createDeepAgent({
+      model: fakeModel,
+      name: "main",
+      systemPrompt: "PARENT_PROMPT",
+      middleware: [custom],
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a worker.",
+          mode: "dynamic",
+        },
+      ],
+    });
+
+    const middleware = getMiddlewareStack("worker");
+    expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
+      false,
+    );
+  });
+
   it("replaces default main-agent middleware with same-name custom middleware", () => {
     const custom = createCustomSummarizationMiddleware();
 

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -454,6 +454,7 @@ describe("ForkedSubAgent", () => {
               args: {
                 description: "UNIQUE_TASK_MARKER",
                 subagent_type: "worker",
+                mode: "fork",
               },
             },
           ],
@@ -472,6 +473,7 @@ describe("ForkedSubAgent", () => {
         {
           name: "worker",
           description: "A worker agent",
+          mode: "fork",
         },
       ],
     });
@@ -574,6 +576,7 @@ describe("ForkedSubAgent", () => {
               args: {
                 description: "UNIQUE_TASK_MARKER",
                 subagent_type: "worker",
+                mode: "fork",
               },
             },
           ],
@@ -593,6 +596,7 @@ describe("ForkedSubAgent", () => {
           name: "worker",
           description: "A worker agent",
           model: workerModel,
+          mode: "fork",
         },
       ],
     });
@@ -1736,6 +1740,7 @@ describe("middleware override by name", () => {
         {
           name: "worker",
           description: "A worker agent",
+          mode: "fork",
         },
       ],
     });
@@ -1760,6 +1765,7 @@ describe("middleware override by name", () => {
           name: "worker",
           description: "A worker agent",
           model: workerModel,
+          mode: "fork",
         },
       ],
     });

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -337,7 +337,7 @@ describe("Subagent summarization state isolation", () => {
   });
 });
 
-describe("Subagent mode: fork/dynamic", () => {
+describe("Subagent mode: fork", () => {
   let invokeSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -372,6 +372,22 @@ describe("Subagent mode: fork/dynamic", () => {
     new AIMessage("Got it, remembering BANANA42."),
     new HumanMessage("Now delegate to the worker"),
   ];
+
+  it("throws at construction for an invalid mode value", () => {
+    expect(() =>
+      createDeepAgent({
+        model: new FakeListChatModel({ responses: ["Done"] }),
+        subagents: [
+          {
+            name: "worker",
+            description: "A worker agent",
+            systemPrompt: "You are a worker.",
+            mode: "dynamic" as unknown as "fork",
+          },
+        ],
+      }),
+    ).toThrow(/invalid mode 'dynamic'/);
+  });
 
   it("should NOT include prior history for the default handoff mode", async () => {
     const model = new FakeListChatModel({
@@ -546,224 +562,6 @@ describe("Subagent mode: fork/dynamic", () => {
       .join("\n");
     expect(text).not.toContain("PARALLEL_CALL_TEXT_SHOULD_NOT_LEAK");
     expect(text).not.toContain("get_weather");
-  });
-
-  it('mode: dynamic forks only when the model passes mode: "fork" on the call', async () => {
-    const model = new FakeListChatModel({
-      responses: [
-        new AIMessage({
-          content: "",
-          tool_calls: [
-            {
-              id: `call_${Date.now()}`,
-              name: "task",
-              args: {
-                description: "UNIQUE_TASK_MARKER",
-                subagent_type: "worker",
-                mode: "fork",
-              },
-            },
-          ],
-        }) as unknown as string,
-        "Worker done",
-        "Done",
-      ],
-    });
-
-    const checkpointer = new MemorySaver();
-    const agent = createDeepAgent({
-      model,
-      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
-      checkpointer,
-      subagents: [
-        {
-          name: "worker",
-          description: "A worker agent",
-          systemPrompt: "You are a specialized worker.",
-          mode: "dynamic",
-        },
-      ],
-    });
-
-    await agent.invoke(
-      { messages: priorHistory },
-      {
-        configurable: { thread_id: `test-mode-dynamic-fork-${Date.now()}` },
-        recursionLimit: 50,
-      },
-    );
-
-    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
-    expect(workerCall).toBeDefined();
-    const text = workerCall!
-      .map((m) => (typeof m.content === "string" ? m.content : ""))
-      .join("\n");
-    expect(text).toContain("BANANA42");
-    const systemMessage = workerCall!.find(SystemMessage.isInstance);
-    expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
-  });
-
-  it("does NOT throw on duplicate middleware names when a dynamic spec forks with a custom SummarizationMiddleware", async () => {
-    const model = new FakeListChatModel({
-      responses: [
-        new AIMessage({
-          content: "",
-          tool_calls: [
-            {
-              id: `call_${Date.now()}`,
-              name: "task",
-              args: {
-                description: "UNIQUE_TASK_MARKER",
-                subagent_type: "worker",
-                mode: "fork",
-              },
-            },
-          ],
-        }) as unknown as string,
-        "Worker done",
-        "Done",
-      ],
-    });
-
-    const checkpointer = new MemorySaver();
-    const agent = createDeepAgent({
-      model,
-      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
-      checkpointer,
-      middleware: [
-        createSummarizationMiddleware({ backend: new StateBackend() }),
-      ],
-      subagents: [
-        {
-          name: "worker",
-          description: "A worker agent",
-          systemPrompt: "You are a specialized worker.",
-          mode: "dynamic",
-        },
-      ],
-    });
-
-    await expect(
-      agent.invoke(
-        { messages: priorHistory },
-        {
-          configurable: {
-            thread_id: `test-mode-dynamic-fork-dup-middleware-${Date.now()}`,
-          },
-          recursionLimit: 50,
-        },
-      ),
-    ).resolves.toBeDefined();
-  });
-
-  it("mode: dynamic stays isolated when the model omits mode on the call", async () => {
-    const model = new FakeListChatModel({
-      responses: [
-        new AIMessage({
-          content: "",
-          tool_calls: [
-            {
-              id: `call_${Date.now()}`,
-              name: "task",
-              args: {
-                description: "UNIQUE_TASK_MARKER",
-                subagent_type: "worker",
-              },
-            },
-          ],
-        }) as unknown as string,
-        "Worker done",
-        "Done",
-      ],
-    });
-
-    const checkpointer = new MemorySaver();
-    const agent = createDeepAgent({
-      model,
-      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
-      checkpointer,
-      subagents: [
-        {
-          name: "worker",
-          description: "A worker agent",
-          systemPrompt: "You are a specialized worker.",
-          mode: "dynamic",
-        },
-      ],
-    });
-
-    await agent.invoke(
-      { messages: priorHistory },
-      {
-        configurable: { thread_id: `test-mode-dynamic-handoff-${Date.now()}` },
-        recursionLimit: 50,
-      },
-    );
-
-    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
-    expect(workerCall).toBeDefined();
-    const text = workerCall!
-      .map((m) => (typeof m.content === "string" ? m.content : ""))
-      .join("\n");
-    expect(text).not.toContain("BANANA42");
-    const systemMessage = workerCall!.find(SystemMessage.isInstance);
-    expect(systemMessage?.text).toContain("You are a specialized worker");
-    expect(systemMessage?.text).not.toContain("PARENT_ROOT_PROMPT_MARKER");
-  });
-
-  it("mode: fork ignores a model-supplied mode argument — dev setting always wins", async () => {
-    const model = new FakeListChatModel({
-      responses: [
-        new AIMessage({
-          content: "",
-          tool_calls: [
-            {
-              id: `call_${Date.now()}`,
-              name: "task",
-              args: {
-                description: "UNIQUE_TASK_MARKER",
-                subagent_type: "worker",
-                mode: "handoff",
-              },
-            },
-          ],
-        }) as unknown as string,
-        "Worker done",
-        "Done",
-      ],
-    });
-
-    const checkpointer = new MemorySaver();
-    const agent = createDeepAgent({
-      model,
-      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
-      checkpointer,
-      subagents: [
-        {
-          name: "worker",
-          description: "A worker agent",
-          systemPrompt: "You are a specialized worker.",
-          mode: "fork",
-        },
-      ],
-    });
-
-    await agent.invoke(
-      { messages: priorHistory },
-      {
-        configurable: {
-          thread_id: `test-mode-fork-dev-override-${Date.now()}`,
-        },
-        recursionLimit: 50,
-      },
-    );
-
-    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
-    expect(workerCall).toBeDefined();
-    const text = workerCall!
-      .map((m) => (typeof m.content === "string" ? m.content : ""))
-      .join("\n");
-    expect(text).toContain("BANANA42");
   });
 
   it("should NOT swap the system prompt when the fork spec's model differs from the parent's", async () => {
@@ -1946,30 +1744,6 @@ describe("middleware override by name", () => {
           description: "A worker agent",
           systemPrompt: "You are a worker.",
           mode: "fork",
-        },
-      ],
-    });
-
-    const middleware = getMiddlewareStack("worker");
-    expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
-      false,
-    );
-  });
-
-  it("does NOT bake mirrored middleware into a dynamic-mode subagent's cached graph, even when cache-aligned", () => {
-    const custom = namedMiddleware("MarkerMiddleware");
-
-    createDeepAgent({
-      model: fakeModel,
-      name: "main",
-      systemPrompt: "PARENT_PROMPT",
-      middleware: [custom],
-      subagents: [
-        {
-          name: "worker",
-          description: "A worker agent",
-          systemPrompt: "You are a worker.",
-          mode: "dynamic",
         },
       ],
     });

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -35,7 +35,10 @@ import type { ChainValues } from "@langchain/core/utils/types";
 import { createDeepAgent } from "../agent.js";
 import { StateBackend } from "../backends/state.js";
 import { createSkillsMiddleware } from "./skills.js";
-import { createSummarizationMiddleware } from "./summarization.js";
+import {
+  createSummarizationMiddleware,
+  getEffectiveMessages,
+} from "./summarization.js";
 import { mergeMiddleware } from "./utils.js";
 import { createFileData } from "../backends/utils.js";
 import { createMockBackend } from "./test.js";
@@ -382,7 +385,7 @@ describe("ForkedSubAgent", () => {
             name: "worker",
             description: "A worker agent",
             systemPrompt: "You are a worker.",
-            mode: "dynamic" as unknown as "fork",
+            mode: "dynamic" as unknown as "handoff",
           },
         ],
       }),
@@ -715,12 +718,10 @@ describe("ForkedSubAgent", () => {
     ];
     const event = { cutoffIndex: 2, summaryMessage, filePath: null };
 
-    // Mirrors the executor's own reconstruction logic.
     const trimmed = rawMessages.slice(0, -1);
-    const effective = [
-      event.summaryMessage,
-      ...trimmed.slice(event.cutoffIndex),
-    ];
+    const effective = getEffectiveMessages(trimmed, {
+      _summarizationEvent: event,
+    });
 
     expect(effective).toEqual([summaryMessage, rawMessages[2], rawMessages[3]]);
   });

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("langchain", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -334,6 +334,551 @@ describe("Subagent summarization state isolation", () => {
 
     expect(filtered).not.toHaveProperty("_summarizationEvent");
     expect(filtered).not.toHaveProperty("_summarizationSessionId");
+  });
+});
+
+describe("Subagent mode: fork/dynamic", () => {
+  let invokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    invokeSpy = vi.spyOn(FakeListChatModel.prototype, "invoke");
+  });
+
+  afterEach(() => {
+    invokeSpy.mockRestore();
+  });
+
+  function findCallContaining(
+    spy: ReturnType<typeof vi.spyOn>,
+    marker: string,
+  ): BaseMessage[] | undefined {
+    for (const call of spy.mock.calls) {
+      const messages = call[0] as BaseMessage[] | undefined;
+      if (!messages) continue;
+      const text = messages
+        .map((m) => (typeof m.content === "string" ? m.content : ""))
+        .join("\n");
+      if (text.includes(marker)) return messages;
+    }
+    return undefined;
+  }
+
+  // Seeded directly as the initial `messages` array (single invoke() call)
+  // rather than built up across two separate invoke() calls — FakeListChatModel's
+  // response-cycling counter isn't guaranteed to survive across separate
+  // top-level invoke() calls sharing one model instance.
+  const priorHistory = [
+    new HumanMessage("Remember the passphrase: BANANA42"),
+    new AIMessage("Got it, remembering BANANA42."),
+    new HumanMessage("Now delegate to the worker"),
+  ];
+
+  it("should NOT include prior history for the default handoff mode", async () => {
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a specialized worker.",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: priorHistory },
+      {
+        configurable: { thread_id: `test-mode-handoff-${Date.now()}` },
+        recursionLimit: 50,
+      },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
+    expect(workerCall).toBeDefined();
+    const text = workerCall!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).not.toContain("BANANA42");
+  });
+
+  it("should include prior history and the parent's exact system prompt for mode: fork", async () => {
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a specialized worker.",
+          mode: "fork",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: priorHistory },
+      {
+        configurable: { thread_id: `test-mode-fork-${Date.now()}` },
+        recursionLimit: 50,
+      },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
+    expect(workerCall).toBeDefined();
+
+    const text = workerCall!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).toContain("BANANA42");
+
+    const systemMessage = workerCall!.find(SystemMessage.isInstance);
+    expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
+    expect(systemMessage?.text).not.toContain("You are a specialized worker");
+
+    // Own systemPrompt is relocated into the trailing message as a preamble.
+    expect(text).toContain("You are a specialized worker");
+    expect(text).toContain("UNIQUE_TASK_MARKER");
+  });
+
+  it("should exclude the in-flight AIMessage, including a parallel sibling tool call", async () => {
+    const echoTool = tool(async () => "sunny", {
+      name: "get_weather",
+      description: "Get the weather",
+      schema: z.object({}),
+    });
+
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "PARALLEL_CALL_TEXT_SHOULD_NOT_LEAK",
+          tool_calls: [
+            {
+              id: `call_task_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+              },
+            },
+            {
+              id: `call_weather_${Date.now()}`,
+              name: "get_weather",
+              args: {},
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      tools: [echoTool],
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a worker.",
+          mode: "fork",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: [new HumanMessage("Test")] },
+      {
+        configurable: { thread_id: `test-mode-fork-parallel-${Date.now()}` },
+        recursionLimit: 50,
+      },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
+    expect(workerCall).toBeDefined();
+    const text = workerCall!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).not.toContain("PARALLEL_CALL_TEXT_SHOULD_NOT_LEAK");
+    expect(text).not.toContain("get_weather");
+  });
+
+  it('mode: dynamic forks only when the model passes mode: "fork" on the call', async () => {
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+                mode: "fork",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a specialized worker.",
+          mode: "dynamic",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: priorHistory },
+      {
+        configurable: { thread_id: `test-mode-dynamic-fork-${Date.now()}` },
+        recursionLimit: 50,
+      },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
+    expect(workerCall).toBeDefined();
+    const text = workerCall!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).toContain("BANANA42");
+    const systemMessage = workerCall!.find(SystemMessage.isInstance);
+    expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
+  });
+
+  it("mode: dynamic stays isolated when the model omits mode on the call", async () => {
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a specialized worker.",
+          mode: "dynamic",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: priorHistory },
+      {
+        configurable: { thread_id: `test-mode-dynamic-handoff-${Date.now()}` },
+        recursionLimit: 50,
+      },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
+    expect(workerCall).toBeDefined();
+    const text = workerCall!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).not.toContain("BANANA42");
+    const systemMessage = workerCall!.find(SystemMessage.isInstance);
+    expect(systemMessage?.text).toContain("You are a specialized worker");
+    expect(systemMessage?.text).not.toContain("PARENT_ROOT_PROMPT_MARKER");
+  });
+
+  it("mode: fork ignores a model-supplied mode argument — dev setting always wins", async () => {
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+                mode: "handoff",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a specialized worker.",
+          mode: "fork",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: priorHistory },
+      {
+        configurable: {
+          thread_id: `test-mode-fork-dev-override-${Date.now()}`,
+        },
+        recursionLimit: 50,
+      },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
+    expect(workerCall).toBeDefined();
+    const text = workerCall!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).toContain("BANANA42");
+  });
+
+  it("should NOT swap the system prompt when the fork spec's model differs from the parent's", async () => {
+    const mainModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+    const workerModel = new FakeListChatModel({ responses: ["Worker done"] });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model: mainModel,
+      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a specialized worker.",
+          model: workerModel,
+          mode: "fork",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: priorHistory },
+      {
+        configurable: {
+          thread_id: `test-mode-fork-model-mismatch-${Date.now()}`,
+        },
+        recursionLimit: 50,
+      },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "UNIQUE_TASK_MARKER");
+    expect(workerCall).toBeDefined();
+
+    // History still forks (context inheritance is model-independent)...
+    const text = workerCall!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).toContain("BANANA42");
+
+    // ...but the system prompt is NOT swapped, since there's no cache
+    // benefit to a mismatched model — the worker keeps its own.
+    const systemMessage = workerCall!.find(SystemMessage.isInstance);
+    expect(systemMessage?.text).toContain("You are a specialized worker");
+    expect(systemMessage?.text).not.toContain("PARENT_ROOT_PROMPT_MARKER");
+  });
+
+  it("should fork message history into a CompiledSubAgent without throwing or touching its system prompt", async () => {
+    let capturedMessages: BaseMessage[] | undefined;
+    const compiledWorkerModel = new FakeListChatModel({
+      responses: ["Worker done"],
+    });
+    const compiledWorker = createAgent({
+      model: compiledWorkerModel,
+      systemPrompt: "You are a compiled worker.",
+    });
+    const originalInvoke = compiledWorker.invoke.bind(compiledWorker);
+    compiledWorker.invoke = (async (state: any, config: any) => {
+      capturedMessages = state.messages;
+      return originalInvoke(state, config);
+    }) as typeof compiledWorker.invoke;
+
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    expect(() =>
+      createDeepAgent({
+        model,
+        checkpointer,
+        subagents: [
+          {
+            name: "worker",
+            description: "A compiled worker agent",
+            runnable: compiledWorker,
+            mode: "fork",
+          },
+        ],
+      }),
+    ).not.toThrow();
+
+    const agent = createDeepAgent({
+      model,
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "A compiled worker agent",
+          runnable: compiledWorker,
+          mode: "fork",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: priorHistory },
+      {
+        configurable: { thread_id: `test-compiled-fork-${Date.now()}` },
+        recursionLimit: 50,
+      },
+    );
+
+    expect(capturedMessages).toBeDefined();
+    const text = capturedMessages!
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(text).toContain("BANANA42");
+    expect(text).toContain("UNIQUE_TASK_MARKER");
+  });
+
+  it("should reconstruct the already-summarized effective view, not raw history, when forking", () => {
+    const summaryMessage = new HumanMessage({
+      content: "Here is a summary of the conversation to date: earlier stuff",
+    });
+    const rawMessages: BaseMessage[] = [
+      new HumanMessage("msg0"),
+      new HumanMessage("msg1"),
+      new HumanMessage("msg2"),
+      new HumanMessage("msg3"),
+      new AIMessage({
+        content: "",
+        tool_calls: [{ id: "call_1", name: "task", args: {} }],
+      }),
+    ];
+    const event = { cutoffIndex: 2, summaryMessage, filePath: null };
+
+    // Mirrors the executor's own reconstruction logic.
+    const trimmed = rawMessages.slice(0, -1);
+    const effective = [
+      event.summaryMessage,
+      ...trimmed.slice(event.cutoffIndex),
+    ];
+
+    expect(effective).toEqual([summaryMessage, rawMessages[2], rawMessages[3]]);
   });
 });
 
@@ -1333,6 +1878,29 @@ describe("middleware override by name", () => {
     const merged = mergeMiddleware([original], [first, second]);
 
     expect(merged).toEqual([second]);
+  });
+
+  it("does NOT mirror custom middleware into a fork-mode subagent when the parent has no system prompt", () => {
+    const custom = namedMiddleware("MarkerMiddleware");
+
+    createDeepAgent({
+      model: fakeModel,
+      name: "main",
+      middleware: [custom],
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a worker.",
+          mode: "fork",
+        },
+      ],
+    });
+
+    const middleware = getMiddlewareStack("worker");
+    expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
+      false,
+    );
   });
 
   it("replaces default main-agent middleware with same-name custom middleware", () => {

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -337,7 +337,7 @@ describe("Subagent summarization state isolation", () => {
   });
 });
 
-describe("Subagent mode: fork", () => {
+describe("ForkedSubAgent", () => {
   let invokeSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -439,7 +439,7 @@ describe("Subagent mode: fork", () => {
     expect(text).not.toContain("BANANA42");
   });
 
-  it("should include prior history and the parent's exact system prompt for mode: fork", async () => {
+  it("should include prior history and the parent's exact system prompt for a ForkedSubAgent", async () => {
     const model = new FakeListChatModel({
       responses: [
         new AIMessage({
@@ -469,8 +469,6 @@ describe("Subagent mode: fork", () => {
         {
           name: "worker",
           description: "A worker agent",
-          systemPrompt: "You are a specialized worker.",
-          mode: "fork",
         },
       ],
     });
@@ -493,11 +491,10 @@ describe("Subagent mode: fork", () => {
 
     const systemMessage = workerCall!.find(SystemMessage.isInstance);
     expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
-    expect(systemMessage?.text).not.toContain("You are a specialized worker");
 
-    // Own systemPrompt is relocated into the trailing message as a preamble.
-    expect(text).toContain("You are a specialized worker");
-    expect(text).toContain("UNIQUE_TASK_MARKER");
+    // No own systemPrompt to relocate — the trailing message is bare.
+    const lastMessage = workerCall![workerCall!.length - 1];
+    expect(lastMessage.content).toBe("UNIQUE_TASK_MARKER");
   });
 
   it("should exclude the in-flight AIMessage, including a parallel sibling tool call", async () => {
@@ -541,8 +538,6 @@ describe("Subagent mode: fork", () => {
         {
           name: "worker",
           description: "A worker agent",
-          systemPrompt: "You are a worker.",
-          mode: "fork",
         },
       ],
     });
@@ -564,7 +559,7 @@ describe("Subagent mode: fork", () => {
     expect(text).not.toContain("get_weather");
   });
 
-  it("should NOT swap the system prompt when the fork spec's model differs from the parent's", async () => {
+  it("should still inherit the parent's system prompt for a ForkedSubAgent even when its model differs", async () => {
     const mainModel = new FakeListChatModel({
       responses: [
         new AIMessage({
@@ -594,9 +589,7 @@ describe("Subagent mode: fork", () => {
         {
           name: "worker",
           description: "A worker agent",
-          systemPrompt: "You are a specialized worker.",
           model: workerModel,
-          mode: "fork",
         },
       ],
     });
@@ -620,11 +613,11 @@ describe("Subagent mode: fork", () => {
       .join("\n");
     expect(text).toContain("BANANA42");
 
-    // ...but the system prompt is NOT swapped, since there's no cache
-    // benefit to a mismatched model — the worker keeps its own.
+    // ...and the system prompt is still the parent's — a ForkedSubAgent has
+    // no own prompt to fall back to, so model mismatch only means no cache
+    // benefit, not a different prompt.
     const systemMessage = workerCall!.find(SystemMessage.isInstance);
-    expect(systemMessage?.text).toContain("You are a specialized worker");
-    expect(systemMessage?.text).not.toContain("PARENT_ROOT_PROMPT_MARKER");
+    expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
   });
 
   it("should fork message history into a CompiledSubAgent without throwing or touching its system prompt", async () => {
@@ -1731,7 +1724,7 @@ describe("middleware override by name", () => {
     expect(merged).toEqual([second]);
   });
 
-  it("does NOT mirror custom middleware into a fork-mode subagent when the parent has no system prompt", () => {
+  it("does NOT mirror custom middleware into a ForkedSubAgent when the parent has no system prompt", () => {
     const custom = namedMiddleware("MarkerMiddleware");
 
     createDeepAgent({
@@ -1742,8 +1735,6 @@ describe("middleware override by name", () => {
         {
           name: "worker",
           description: "A worker agent",
-          systemPrompt: "You are a worker.",
-          mode: "fork",
         },
       ],
     });
@@ -1751,6 +1742,52 @@ describe("middleware override by name", () => {
     const middleware = getMiddlewareStack("worker");
     expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
       false,
+    );
+  });
+
+  it("does NOT mirror custom middleware into a ForkedSubAgent when its model differs from the parent's", () => {
+    const custom = namedMiddleware("MarkerMiddleware");
+    const workerModel = new FakeListChatModel({ responses: ["hello"] });
+
+    createDeepAgent({
+      model: fakeModel,
+      name: "main",
+      systemPrompt: "PARENT_PROMPT",
+      middleware: [custom],
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          model: workerModel,
+        },
+      ],
+    });
+
+    const middleware = getMiddlewareStack("worker");
+    expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
+      false,
+    );
+  });
+
+  it("mirrors custom middleware into a ForkedSubAgent when its model matches the parent's", () => {
+    const custom = namedMiddleware("MarkerMiddleware");
+
+    createDeepAgent({
+      model: fakeModel,
+      name: "main",
+      systemPrompt: "PARENT_PROMPT",
+      middleware: [custom],
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+        },
+      ],
+    });
+
+    const middleware = getMiddlewareStack("worker");
+    expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
+      true,
     );
   });
 

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -603,6 +603,59 @@ describe("Subagent mode: fork/dynamic", () => {
     expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
   });
 
+  it("does NOT throw on duplicate middleware names when a dynamic spec forks with a custom SummarizationMiddleware", async () => {
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: {
+                description: "UNIQUE_TASK_MARKER",
+                subagent_type: "worker",
+                mode: "fork",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      systemPrompt: "PARENT_ROOT_PROMPT_MARKER",
+      checkpointer,
+      middleware: [
+        createSummarizationMiddleware({ backend: new StateBackend() }),
+      ],
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          systemPrompt: "You are a specialized worker.",
+          mode: "dynamic",
+        },
+      ],
+    });
+
+    await expect(
+      agent.invoke(
+        { messages: priorHistory },
+        {
+          configurable: {
+            thread_id: `test-mode-dynamic-fork-dup-middleware-${Date.now()}`,
+          },
+          recursionLimit: 50,
+        },
+      ),
+    ).resolves.toBeDefined();
+  });
+
   it("mode: dynamic stays isolated when the model omits mode on the call", async () => {
     const model = new FakeListChatModel({
       responses: [

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -1770,28 +1770,6 @@ describe("middleware override by name", () => {
     );
   });
 
-  it("mirrors custom middleware into a ForkedSubAgent when its model matches the parent's", () => {
-    const custom = namedMiddleware("MarkerMiddleware");
-
-    createDeepAgent({
-      model: fakeModel,
-      name: "main",
-      systemPrompt: "PARENT_PROMPT",
-      middleware: [custom],
-      subagents: [
-        {
-          name: "worker",
-          description: "A worker agent",
-        },
-      ],
-    });
-
-    const middleware = getMiddlewareStack("worker");
-    expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
-      true,
-    );
-  });
-
   it("replaces default main-agent middleware with same-name custom middleware", () => {
     const custom = createCustomSummarizationMiddleware();
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -283,8 +283,8 @@ export interface ForkedSubAgent extends SubAgentBase {
 
 export function isForkedSubAgent(value: unknown): value is ForkedSubAgent {
   if (typeof value !== "object" || value == null) return false;
-  if ("mode" in value && value.mode !== "fork") return false;
-  if ("systemPrompt" in value && value.systemPrompt !== undefined) return false;
+  if (!("mode" in value)) return false;
+  if (value.mode !== "fork") return false;
   return true;
 }
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -43,8 +43,8 @@ export const DEFAULT_SUBAGENT_PROMPT =
 
 /**
  * State keys excluded when passing state to subagents and when returning
- * updates from subagents. Fork-mode subagents re-inject summarization keys
- * after reconstructing the effective message view.
+ * updates from subagents. Summarization keys are excluded because their
+ * cutoffIndex is only valid against the message list it was computed from.
  */
 const EXCLUDED_STATE_KEYS = [
   "messages",
@@ -107,16 +107,11 @@ export interface CompiledSubAgent<
 }
 
 /**
- * Specification for a subagent that can be dynamically created.
- *
- * When using `createDeepAgent`, subagents automatically receive a default middleware
- * stack (filesystemMiddleware, summarizationMiddleware, etc.) before any custom
- * `middleware` specified in this spec. Add `todoListMiddleware` explicitly to opt in.
+ * Fields shared by both {@link SubAgent} and {@link ForkedSubAgent}.
  *
  * Required fields:
  * - `name`: Identifier used to select this subagent in the task tool
  * - `description`: Shown to the model for subagent selection
- * - `systemPrompt`: The system prompt for the subagent
  *
  * Optional fields:
  * - `model`: Override the default model for this subagent
@@ -124,27 +119,13 @@ export interface CompiledSubAgent<
  * - `middleware`: Additional middleware appended after defaults
  * - `interruptOn`: Human-in-the-loop configuration for specific tools
  * - `skills`: Skill source paths for SkillsMiddleware (e.g., `["/skills/user/", "/skills/project/"]`)
- *
- * @example
- * ```typescript
- * const researcher: SubAgent = {
- *   name: "researcher",
- *   description: "Research assistant for complex topics",
- *   systemPrompt: "You are a research assistant.",
- *   tools: [webSearchTool],
- *   skills: ["/skills/research/"],
- * };
- * ```
  */
-export interface SubAgent {
+interface SubAgentBase {
   /** Identifier used to select this subagent in the task tool */
   name: string;
 
   /** Description shown to the model for subagent selection */
   description: string;
-
-  /** The system prompt to use for the agent */
-  systemPrompt: string;
 
   /** The tools to use for the agent (tool instances, not names). Defaults to defaultTools */
   tools?: StructuredTool[];
@@ -228,39 +209,57 @@ export interface SubAgent {
    * ```
    */
   permissions?: FilesystemPermission[];
-
-  /**
-   * Context mode. `"fork"` inherits the parent's conversation history
-   * and system prompt. `"handoff"` (default) is fully isolated.
-   */
-  mode?: "handoff" | "fork";
-}
-
-export interface CacheAlignedForkSpecOptions {
-  mode: "handoff" | "fork" | undefined;
-  specModel: LanguageModelLike | string | undefined;
-  parentModel: LanguageModelLike | string;
-  parentSystemPrompt: string | SystemMessage | null | undefined;
 }
 
 /**
- * Whether a fork spec qualifies for cache-aligned treatment (system prompt
- * swap, mirrored middleware). Shared by `agent.ts` and `getSubagents()` so
- * the two can't drift apart.
+ * Specification for a subagent that can be dynamically created.
+ *
+ * When using `createDeepAgent`, subagents automatically receive a default middleware
+ * stack (filesystemMiddleware, summarizationMiddleware, etc.) before any custom
+ * `middleware` specified in this spec. Add `todoListMiddleware` explicitly to opt in.
+ *
+ * Always fully isolated — this subagent only ever sees the task description,
+ * never the parent's conversation. Use {@link ForkedSubAgent} to inherit the
+ * parent's history and system prompt instead.
+ *
+ * @example
+ * ```typescript
+ * const researcher: SubAgent = {
+ *   name: "researcher",
+ *   description: "Research assistant for complex topics",
+ *   systemPrompt: "You are a research assistant.",
+ *   tools: [webSearchTool],
+ *   skills: ["/skills/research/"],
+ * };
+ * ```
  */
-export function isCacheAlignedForkSpec({
-  mode,
-  specModel,
-  parentModel,
-  parentSystemPrompt,
-}: CacheAlignedForkSpecOptions): boolean {
-  return (
-    mode === "fork" &&
-    (specModel === undefined || specModel === parentModel) &&
-    parentSystemPrompt != null &&
-    parentSystemPrompt !== ""
-  );
+export interface SubAgent extends SubAgentBase {
+  /** The system prompt to use for the agent */
+  systemPrompt: string | SystemMessage;
 }
+
+/**
+ * Specification for a subagent that inherits the parent's conversation
+ * instead of starting from just the task description.
+ *
+ * Always forks: it inherits the parent's full message history and its exact
+ * system prompt (there's no own prompt to fall back to). Mirrored middleware
+ * is only added when its model matches the parent's, since that's the only
+ * case with a cache benefit to protect. Deliberately has no `systemPrompt`
+ * of its own: since its system slot always carries the parent's prompt,
+ * there's nothing of its own to put there. If you need a subagent with a
+ * distinguishing system prompt, use {@link SubAgent} without forking instead.
+ *
+ * @example
+ * ```typescript
+ * const researcher: ForkedSubAgent = {
+ *   name: "researcher",
+ *   description: "Continues the current investigation with full context",
+ *   tools: [webSearchTool],
+ * };
+ * ```
+ */
+export interface ForkedSubAgent extends SubAgentBase {}
 
 /**
  * Base specification for the general-purpose subagent.
@@ -299,10 +298,11 @@ export function isCacheAlignedForkSpec({
  * });
  * ```
  */
-export const GENERAL_PURPOSE_SUBAGENT: Pick<
-  SubAgent,
-  "name" | "description" | "systemPrompt"
-> = {
+export const GENERAL_PURPOSE_SUBAGENT: {
+  name: string;
+  description: string;
+  systemPrompt: string;
+} = {
   name: "general-purpose",
   description: DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
   systemPrompt: DEFAULT_SUBAGENT_PROMPT,
@@ -399,14 +399,12 @@ function stripInFlightAIMessage(messages: BaseMessage[]): BaseMessage[] {
  * for coalescing any defaults before calling this function.
  *
  * @param spec - Declarative subagent specification. Must specify `model` and `tools`.
- * @param options.systemPromptOverride - Replaces the spec's own system prompt — used for fork's system-prompt swap.
  * @returns A compiled `ReactAgent` ready for task-tool invocation.
  */
 export function createSubAgent(
   spec: SubAgent,
   options?: {
     responseFormat?: CreateAgentParams["responseFormat"];
-    systemPromptOverride?: string | SystemMessage;
   },
 ): ReactAgent {
   if (!spec.model) {
@@ -428,7 +426,7 @@ export function createSubAgent(
 
   return createAgent({
     model: spec.model,
-    systemPrompt: options?.systemPromptOverride ?? spec.systemPrompt,
+    systemPrompt: spec.systemPrompt,
     tools: spec.tools,
     middleware,
     name: spec.name,
@@ -442,7 +440,8 @@ export function createSubAgent(
  * Create subagent instances from specifications.
  *
  * Returns compiled agents, raw specs keyed by name (for on-demand
- * recompilation with dynamic response formats), and descriptions.
+ * recompilation with dynamic response formats), descriptions, and the set
+ * of names that should fork the parent's conversation.
  */
 function getSubagents(options: {
   defaultModel: LanguageModelLike | string;
@@ -450,14 +449,14 @@ function getSubagents(options: {
   defaultMiddleware: AgentMiddleware[] | null;
   generalPurposeMiddleware: AgentMiddleware[] | null;
   defaultInterruptOn: Record<string, boolean | InterruptOnConfig> | null;
-  subagents: (SubAgent | CompiledSubAgent)[];
+  subagents: (SubAgent | CompiledSubAgent | ForkedSubAgent)[];
   generalPurposeAgent: boolean;
   parentSystemPrompt?: string | SystemMessage | null;
 }): {
   agents: Record<string, ReactAgent | Runnable>;
   specsByName: Record<string, SubAgent | CompiledSubAgent>;
   descriptions: string[];
-  subagentSystemPrompts: Record<string, string>;
+  forkModeNames: Set<string>;
 } {
   const {
     defaultModel,
@@ -476,7 +475,7 @@ function getSubagents(options: {
   const agents: Record<string, ReactAgent | Runnable> = {};
   const specsByName: Record<string, SubAgent | CompiledSubAgent> = {};
   const subagentDescriptions: string[] = [];
-  const subagentSystemPrompts: Record<string, string> = {};
+  const forkModeNames = new Set<string>();
 
   if (generalPurposeAgent) {
     const generalPurposeMiddleware = [...generalPurposeMiddlewareBase];
@@ -503,13 +502,10 @@ function getSubagents(options: {
   }
 
   for (const agentParams of subagents) {
-    if (
-      agentParams.mode != null &&
-      agentParams.mode !== "handoff" &&
-      agentParams.mode !== "fork"
-    ) {
+    const rawMode = (agentParams as { mode?: unknown }).mode;
+    if (rawMode != null && rawMode !== "handoff" && rawMode !== "fork") {
       throw new Error(
-        `SubAgent '${agentParams.name}' has invalid mode '${agentParams.mode}' — must be "handoff" or "fork".`,
+        `SubAgent '${agentParams.name}' has invalid mode '${rawMode}' — must be "handoff" or "fork".`,
       );
     }
 
@@ -520,7 +516,9 @@ function getSubagents(options: {
     if ("runnable" in agentParams) {
       agents[agentParams.name] = agentParams.runnable;
       specsByName[agentParams.name] = agentParams;
-    } else {
+      if (agentParams.mode === "fork") forkModeNames.add(agentParams.name);
+    } else if ("systemPrompt" in agentParams) {
+      // Plain SubAgent — never forks, keeps its own prompt untouched.
       const resolvedSpec: SubAgent = {
         ...agentParams,
         model: agentParams.model ?? defaultModel,
@@ -531,23 +529,25 @@ function getSubagents(options: {
         ],
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
-
-      const systemPromptOverride = isCacheAlignedForkSpec({
-        mode: resolvedSpec.mode,
-        specModel: agentParams.model,
-        parentModel: defaultModel,
-        parentSystemPrompt,
-      })
-        ? (parentSystemPrompt ?? undefined)
-        : undefined;
-      if (systemPromptOverride != null) {
-        subagentSystemPrompts[resolvedSpec.name] = resolvedSpec.systemPrompt;
-      }
-
-      agents[agentParams.name] = createSubAgent(resolvedSpec, {
-        systemPromptOverride,
-      });
+      agents[agentParams.name] = createSubAgent(resolvedSpec);
       specsByName[agentParams.name] = resolvedSpec;
+    } else {
+      // ForkedSubAgent — always forks, always inherits the parent's exact
+      // system prompt directly; there's no own prompt to fall back to.
+      const resolvedSpec: SubAgent = {
+        ...agentParams,
+        systemPrompt: parentSystemPrompt ?? "",
+        model: agentParams.model ?? defaultModel,
+        tools: agentParams.tools ?? defaultTools,
+        middleware: [
+          ...defaultSubagentMiddleware,
+          ...(agentParams.middleware ?? []),
+        ],
+        interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
+      };
+      agents[agentParams.name] = createSubAgent(resolvedSpec);
+      specsByName[agentParams.name] = resolvedSpec;
+      forkModeNames.add(agentParams.name);
     }
   }
 
@@ -555,7 +555,7 @@ function getSubagents(options: {
     agents,
     specsByName,
     descriptions: subagentDescriptions,
-    subagentSystemPrompts,
+    forkModeNames,
   };
 }
 
@@ -568,7 +568,7 @@ function createTaskTool(options: {
   defaultMiddleware: AgentMiddleware[] | null;
   generalPurposeMiddleware: AgentMiddleware[] | null;
   defaultInterruptOn: Record<string, boolean | InterruptOnConfig> | null;
-  subagents: (SubAgent | CompiledSubAgent)[];
+  subagents: (SubAgent | CompiledSubAgent | ForkedSubAgent)[];
   generalPurposeAgent: boolean;
   taskDescription: string | null;
   parentSystemPrompt?: string | SystemMessage | null;
@@ -589,7 +589,7 @@ function createTaskTool(options: {
     agents: subagentGraphs,
     specsByName,
     descriptions: subagentDescriptions,
-    subagentSystemPrompts,
+    forkModeNames,
   } = getSubagents({
     defaultModel,
     defaultTools,
@@ -645,8 +645,7 @@ function createTaskTool(options: {
         );
       }
 
-      const spec = specsByName[subagent_type];
-      const shouldFork = spec.mode === "fork";
+      const shouldFork = forkModeNames.has(subagent_type);
 
       const subagent = selectSubagent(subagent_type, config);
 
@@ -663,11 +662,10 @@ function createTaskTool(options: {
         const effective = event
           ? [event.summaryMessage, ...trimmed.slice(event.cutoffIndex)]
           : trimmed;
-        const ownSystemPrompt = subagentSystemPrompts[subagent_type];
-        const content = ownSystemPrompt
-          ? `${ownSystemPrompt}\n\n${description}`
-          : description;
-        subagentState.messages = [...effective, new HumanMessage({ content })];
+        subagentState.messages = [
+          ...effective,
+          new HumanMessage({ content: description }),
+        ];
       } else {
         subagentState.messages = [new HumanMessage({ content: description })];
       }
@@ -750,14 +748,14 @@ export interface SubAgentMiddlewareOptions {
   /** The tool configs for the default general-purpose subagent */
   defaultInterruptOn?: Record<string, boolean | InterruptOnConfig> | null;
   /** A list of additional subagents to provide to the agent */
-  subagents?: (SubAgent | CompiledSubAgent)[];
+  subagents?: (SubAgent | CompiledSubAgent | ForkedSubAgent)[];
   /** Full system prompt override */
   systemPrompt?: string | null;
   /** Whether to include the general-purpose agent */
   generalPurposeAgent?: boolean;
   /** Custom description for the task tool */
   taskDescription?: string | null;
-  /** Reused by `mode: "fork"` subagents for cache alignment */
+  /** Inherited by `ForkedSubAgent`s and `mode: "fork"` compiled subagents */
   parentSystemPrompt?: string | SystemMessage | null;
 }
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -22,7 +22,6 @@ import type { Runnable } from "@langchain/core/runnables";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { FilesystemPermission } from "../permissions/types.js";
 import type { SummarizationEvent } from "./summarization.js";
-import { mergeMiddleware } from "./utils.js";
 
 export type { AgentMiddleware };
 
@@ -102,10 +101,9 @@ export interface CompiledSubAgent<
   /**
    * Context mode. `"fork"` inherits the parent's conversation history
    * (but not its system prompt — that's baked into the runnable).
-   * `"dynamic"` lets the model choose per call via the task tool's
-   * `mode` argument. `"handoff"` (default) is fully isolated.
+   * `"handoff"` (default) is fully isolated.
    */
-  mode?: "handoff" | "fork" | "dynamic";
+  mode?: "handoff" | "fork";
 }
 
 /**
@@ -233,29 +231,35 @@ export interface SubAgent {
 
   /**
    * Context mode. `"fork"` inherits the parent's conversation history
-   * and system prompt. `"dynamic"` lets the model choose per call via
-   * the task tool's `mode` argument. `"handoff"` (default) is fully isolated.
+   * and system prompt. `"handoff"` (default) is fully isolated.
    */
-  mode?: "handoff" | "fork" | "dynamic";
+  mode?: "handoff" | "fork";
+}
+
+export interface CacheAlignedForkSpecOptions {
+  mode: "handoff" | "fork" | undefined;
+  specModel: LanguageModelLike | string | undefined;
+  parentModel: LanguageModelLike | string;
+  parentSystemPrompt: string | SystemMessage | null | undefined;
 }
 
 /**
- * Whether a fork/dynamic spec qualifies for cache-aligned treatment
- * (system prompt swap, mirrored middleware). Shared by `agent.ts` and
- * `getSubagents()` so the two can't drift apart.
+ * Whether a fork spec qualifies for cache-aligned treatment (system prompt
+ * swap, mirrored middleware). Shared by `agent.ts` and `getSubagents()` so
+ * the two can't drift apart.
  */
-export function isCacheAlignedForkSpec(
-  mode: "handoff" | "fork" | "dynamic" | undefined,
-  specModel: LanguageModelLike | string | undefined,
-  parentModel: LanguageModelLike | string,
-  parentSystemPrompt: string | SystemMessage | null | undefined,
-): boolean {
-  const isForkable = mode === "fork" || mode === "dynamic";
-  const modelMatchesParent =
-    specModel === undefined || specModel === parentModel;
-  const hasParentSystemPrompt =
-    parentSystemPrompt != null && parentSystemPrompt !== "";
-  return isForkable && modelMatchesParent && hasParentSystemPrompt;
+export function isCacheAlignedForkSpec({
+  mode,
+  specModel,
+  parentModel,
+  parentSystemPrompt,
+}: CacheAlignedForkSpecOptions): boolean {
+  return (
+    mode === "fork" &&
+    (specModel === undefined || specModel === parentModel) &&
+    parentSystemPrompt != null &&
+    parentSystemPrompt !== ""
+  );
 }
 
 /**
@@ -378,12 +382,9 @@ function returnCommandWithStateUpdate(
 
 /** Drop the trailing in-flight AIMessage with unresolved tool_calls. */
 function stripInFlightAIMessage(messages: BaseMessage[]): BaseMessage[] {
-  const last = messages[messages.length - 1];
+  const last = messages.at(-1);
   const hasPendingToolCalls =
-    last != null &&
-    AIMessage.isInstance(last) &&
-    Array.isArray(last.tool_calls) &&
-    last.tool_calls.length > 0;
+    AIMessage.isInstance(last) && (last.tool_calls?.length ?? 0) > 0;
   return hasPendingToolCalls ? messages.slice(0, -1) : messages;
 }
 
@@ -398,6 +399,7 @@ function stripInFlightAIMessage(messages: BaseMessage[]): BaseMessage[] {
  * for coalescing any defaults before calling this function.
  *
  * @param spec - Declarative subagent specification. Must specify `model` and `tools`.
+ * @param options.systemPromptOverride - Replaces the spec's own system prompt — used for fork's system-prompt swap.
  * @returns A compiled `ReactAgent` ready for task-tool invocation.
  */
 export function createSubAgent(
@@ -405,7 +407,6 @@ export function createSubAgent(
   options?: {
     responseFormat?: CreateAgentParams["responseFormat"];
     systemPromptOverride?: string | SystemMessage;
-    extraMiddleware?: AgentMiddleware[];
   },
 ): ReactAgent {
   if (!spec.model) {
@@ -415,10 +416,7 @@ export function createSubAgent(
     throw new Error(`SubAgent '${spec.name}' must specify 'tools'`);
   }
 
-  const middleware: AgentMiddleware[] = mergeMiddleware(
-    spec.middleware ?? [],
-    options?.extraMiddleware ?? [],
-  );
+  const middleware: AgentMiddleware[] = [...(spec.middleware ?? [])];
 
   if (spec.interruptOn) {
     middleware.push(
@@ -505,6 +503,16 @@ function getSubagents(options: {
   }
 
   for (const agentParams of subagents) {
+    if (
+      agentParams.mode != null &&
+      agentParams.mode !== "handoff" &&
+      agentParams.mode !== "fork"
+    ) {
+      throw new Error(
+        `SubAgent '${agentParams.name}' has invalid mode '${agentParams.mode}' — must be "handoff" or "fork".`,
+      );
+    }
+
     subagentDescriptions.push(
       `- ${agentParams.name}: ${agentParams.description}`,
     );
@@ -524,19 +532,18 @@ function getSubagents(options: {
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
 
-      const cacheAligned = isCacheAlignedForkSpec(
-        resolvedSpec.mode,
-        agentParams.model,
-        defaultModel,
+      const cacheAligned = isCacheAlignedForkSpec({
+        mode: resolvedSpec.mode,
+        specModel: agentParams.model,
+        parentModel: defaultModel,
         parentSystemPrompt,
-      );
+      });
       if (cacheAligned) {
         subagentSystemPrompts[resolvedSpec.name] = resolvedSpec.systemPrompt;
       }
-      const systemPromptOverride =
-        resolvedSpec.mode === "fork" && cacheAligned
-          ? (parentSystemPrompt ?? undefined)
-          : undefined;
+      const systemPromptOverride = cacheAligned
+        ? (parentSystemPrompt ?? undefined)
+        : undefined;
 
       agents[agentParams.name] = createSubAgent(resolvedSpec, {
         systemPromptOverride,
@@ -566,7 +573,6 @@ function createTaskTool(options: {
   generalPurposeAgent: boolean;
   taskDescription: string | null;
   parentSystemPrompt?: string | SystemMessage | null;
-  parentMirrorMiddleware?: (() => AgentMiddleware[]) | null;
 }) {
   const {
     defaultModel,
@@ -578,7 +584,6 @@ function createTaskTool(options: {
     generalPurposeAgent,
     taskDescription,
     parentSystemPrompt = null,
-    parentMirrorMiddleware = null,
   } = options;
 
   const {
@@ -600,7 +605,6 @@ function createTaskTool(options: {
   function selectSubagent(
     subagentType: string,
     config: Record<string, any>,
-    shouldFork: boolean,
   ): Runnable {
     const spec = specsByName[subagentType];
 
@@ -615,29 +619,11 @@ function createTaskTool(options: {
     if ("runnable" in spec) {
       return subagentGraphs[subagentType] as Runnable;
     }
-
-    // "dynamic" only recompiles when this call actually forks; "fork" only
-    // recompiles when something else (responseFormat) forces it anyway.
-    const isForkingThisCall =
-      shouldFork && subagentSystemPrompts[subagentType] != null;
-    const needsRecompile =
-      responseFormat != null || (isForkingThisCall && spec.mode === "dynamic");
-    if (!needsRecompile) {
+    if (responseFormat == null) {
       return subagentGraphs[subagentType] as Runnable;
     }
 
-    return createSubAgent(spec, {
-      ...(responseFormat != null && { responseFormat }),
-      ...(isForkingThisCall && {
-        systemPromptOverride: parentSystemPrompt ?? undefined,
-      }),
-      ...(isForkingThisCall &&
-        spec.mode === "dynamic" && {
-          extraMiddleware: parentMirrorMiddleware
-            ? parentMirrorMiddleware()
-            : [],
-        }),
-    }) as unknown as Runnable;
+    return createSubAgent(spec, { responseFormat }) as unknown as Runnable;
   }
 
   const finalTaskDescription = taskDescription
@@ -649,7 +635,6 @@ function createTaskTool(options: {
       input: {
         description: string;
         subagent_type: string;
-        mode?: "handoff" | "fork";
       },
       config,
     ): Promise<Command | string> => {
@@ -665,11 +650,9 @@ function createTaskTool(options: {
       }
 
       const spec = specsByName[subagent_type];
-      const shouldFork =
-        spec.mode === "fork" ||
-        (spec.mode === "dynamic" && input.mode === "fork");
+      const shouldFork = spec.mode === "fork";
 
-      const subagent = selectSubagent(subagent_type, config, shouldFork);
+      const subagent = selectSubagent(subagent_type, config);
 
       const currentState = getCurrentTaskInput<Record<string, unknown>>();
       const subagentState = filterStateForSubagent(currentState);
@@ -751,12 +734,6 @@ function createTaskTool(options: {
           .describe(
             `Name of the agent to use. Available: ${Object.keys(subagentGraphs).join(", ")}`,
           ),
-        mode: z
-          .enum(["handoff", "fork"])
-          .optional()
-          .describe(
-            'Only meaningful for fork-capable agents: "fork" inherits the full conversation history, "handoff" (default) sends only the task description. Ignored for agents that aren\'t fork-capable.',
-          ),
       }),
     },
   );
@@ -787,10 +764,8 @@ export interface SubAgentMiddlewareOptions {
   generalPurposeAgent?: boolean;
   /** Custom description for the task tool */
   taskDescription?: string | null;
-  /** Reused by `mode: "fork"`/`"dynamic"` subagents for cache alignment */
+  /** Reused by `mode: "fork"` subagents for cache alignment */
   parentSystemPrompt?: string | SystemMessage | null;
-  /** Builds fresh mirrored middleware for a `"dynamic"` spec's per-call fork recompile */
-  parentMirrorMiddleware?: (() => AgentMiddleware[]) | null;
 }
 
 /**
@@ -808,7 +783,6 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     generalPurposeAgent = true,
     taskDescription = null,
     parentSystemPrompt = null,
-    parentMirrorMiddleware = null,
   } = options;
 
   const taskTool = createTaskTool({
@@ -820,7 +794,6 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     subagents,
     generalPurposeAgent,
     taskDescription,
-    parentMirrorMiddleware,
     parentSystemPrompt,
   });
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -21,6 +21,7 @@ import type { LanguageModelLike } from "@langchain/core/language_models/base";
 import type { Runnable } from "@langchain/core/runnables";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { FilesystemPermission } from "../permissions/types.js";
+import type { SummarizationEvent } from "./summarization.js";
 
 export type { AgentMiddleware };
 
@@ -42,8 +43,8 @@ export const DEFAULT_SUBAGENT_PROMPT =
 
 /**
  * State keys excluded when passing state to subagents and when returning
- * updates from subagents. Summarization keys are excluded because their
- * cutoffIndex is only valid against the message list it was computed from.
+ * updates from subagents. Fork-mode subagents re-inject summarization keys
+ * after reconstructing the effective message view.
  */
 const EXCLUDED_STATE_KEYS = [
   "messages",
@@ -96,6 +97,14 @@ export interface CompiledSubAgent<
   description: string;
   /** The agent instance */
   runnable: TRunnable;
+
+  /**
+   * Context mode. `"fork"` inherits the parent's conversation history
+   * (but not its system prompt — that's baked into the runnable).
+   * `"dynamic"` lets the model choose per call via the task tool's
+   * `mode` argument. `"handoff"` (default) is fully isolated.
+   */
+  mode?: "handoff" | "fork" | "dynamic";
 }
 
 /**
@@ -220,6 +229,32 @@ export interface SubAgent {
    * ```
    */
   permissions?: FilesystemPermission[];
+
+  /**
+   * Context mode. `"fork"` inherits the parent's conversation history
+   * and system prompt. `"dynamic"` lets the model choose per call via
+   * the task tool's `mode` argument. `"handoff"` (default) is fully isolated.
+   */
+  mode?: "handoff" | "fork" | "dynamic";
+}
+
+/**
+ * Whether a fork/dynamic spec qualifies for cache-aligned treatment
+ * (system prompt swap, mirrored middleware). Shared by `agent.ts` and
+ * `getSubagents()` so the two can't drift apart.
+ */
+export function isCacheAlignedForkSpec(
+  mode: "handoff" | "fork" | "dynamic" | undefined,
+  specModel: LanguageModelLike | string | undefined,
+  parentModel: LanguageModelLike | string,
+  parentSystemPrompt: string | SystemMessage | null | undefined,
+): boolean {
+  const isForkable = mode === "fork" || mode === "dynamic";
+  const modelMatchesParent =
+    specModel === undefined || specModel === parentModel;
+  const hasParentSystemPrompt =
+    parentSystemPrompt != null && parentSystemPrompt !== "";
+  return isForkable && modelMatchesParent && hasParentSystemPrompt;
 }
 
 /**
@@ -340,6 +375,17 @@ function returnCommandWithStateUpdate(
   });
 }
 
+/** Drop the trailing in-flight AIMessage with unresolved tool_calls. */
+function stripInFlightAIMessage(messages: BaseMessage[]): BaseMessage[] {
+  const last = messages[messages.length - 1];
+  const hasPendingToolCalls =
+    last != null &&
+    AIMessage.isInstance(last) &&
+    Array.isArray(last.tool_calls) &&
+    last.tool_calls.length > 0;
+  return hasPendingToolCalls ? messages.slice(0, -1) : messages;
+}
+
 /**
  * Create a runnable agent from a declarative `SubAgent` spec.
  *
@@ -355,7 +401,10 @@ function returnCommandWithStateUpdate(
  */
 export function createSubAgent(
   spec: SubAgent,
-  options?: { responseFormat?: CreateAgentParams["responseFormat"] },
+  options?: {
+    responseFormat?: CreateAgentParams["responseFormat"];
+    systemPromptOverride?: string | SystemMessage;
+  },
 ): ReactAgent {
   if (!spec.model) {
     throw new Error(`SubAgent '${spec.name}' must specify 'model'`);
@@ -376,7 +425,7 @@ export function createSubAgent(
 
   return createAgent({
     model: spec.model,
-    systemPrompt: spec.systemPrompt,
+    systemPrompt: options?.systemPromptOverride ?? spec.systemPrompt,
     tools: spec.tools,
     middleware,
     name: spec.name,
@@ -400,10 +449,12 @@ function getSubagents(options: {
   defaultInterruptOn: Record<string, boolean | InterruptOnConfig> | null;
   subagents: (SubAgent | CompiledSubAgent)[];
   generalPurposeAgent: boolean;
+  parentSystemPrompt?: string | SystemMessage | null;
 }): {
   agents: Record<string, ReactAgent | Runnable>;
   specsByName: Record<string, SubAgent | CompiledSubAgent>;
   descriptions: string[];
+  subagentSystemPrompts: Record<string, string>;
 } {
   const {
     defaultModel,
@@ -413,6 +464,7 @@ function getSubagents(options: {
     defaultInterruptOn,
     subagents,
     generalPurposeAgent,
+    parentSystemPrompt = null,
   } = options;
 
   const defaultSubagentMiddleware = defaultMiddleware || [];
@@ -421,6 +473,7 @@ function getSubagents(options: {
   const agents: Record<string, ReactAgent | Runnable> = {};
   const specsByName: Record<string, SubAgent | CompiledSubAgent> = {};
   const subagentDescriptions: string[] = [];
+  const subagentSystemPrompts: Record<string, string> = {};
 
   if (generalPurposeAgent) {
     const generalPurposeMiddleware = [...generalPurposeMiddlewareBase];
@@ -465,12 +518,34 @@ function getSubagents(options: {
         ],
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
-      agents[agentParams.name] = createSubAgent(resolvedSpec);
+
+      const cacheAligned = isCacheAlignedForkSpec(
+        resolvedSpec.mode,
+        agentParams.model,
+        defaultModel,
+        parentSystemPrompt,
+      );
+      if (cacheAligned) {
+        subagentSystemPrompts[resolvedSpec.name] = resolvedSpec.systemPrompt;
+      }
+      const systemPromptOverride =
+        resolvedSpec.mode === "fork" && cacheAligned
+          ? (parentSystemPrompt ?? undefined)
+          : undefined;
+
+      agents[agentParams.name] = createSubAgent(resolvedSpec, {
+        systemPromptOverride,
+      });
       specsByName[agentParams.name] = resolvedSpec;
     }
   }
 
-  return { agents, specsByName, descriptions: subagentDescriptions };
+  return {
+    agents,
+    specsByName,
+    descriptions: subagentDescriptions,
+    subagentSystemPrompts,
+  };
 }
 
 /**
@@ -485,6 +560,7 @@ function createTaskTool(options: {
   subagents: (SubAgent | CompiledSubAgent)[];
   generalPurposeAgent: boolean;
   taskDescription: string | null;
+  parentSystemPrompt?: string | SystemMessage | null;
 }) {
   const {
     defaultModel,
@@ -495,12 +571,14 @@ function createTaskTool(options: {
     subagents,
     generalPurposeAgent,
     taskDescription,
+    parentSystemPrompt = null,
   } = options;
 
   const {
     agents: subagentGraphs,
     specsByName,
     descriptions: subagentDescriptions,
+    subagentSystemPrompts,
   } = getSubagents({
     defaultModel,
     defaultTools,
@@ -509,16 +587,19 @@ function createTaskTool(options: {
     defaultInterruptOn,
     subagents,
     generalPurposeAgent,
+    parentSystemPrompt,
   });
 
   function selectSubagent(
     subagentType: string,
     config: Record<string, any>,
+    shouldFork: boolean,
   ): Runnable {
+    const spec = specsByName[subagentType];
+
     const responseFormat =
       config.configurable?.[SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY];
     if (responseFormat != null) {
-      const spec = specsByName[subagentType];
       if ("runnable" in spec) {
         throw new Error(
           `responseSchema cannot be used with compiled subagent "${spec.name}"; ` +
@@ -527,6 +608,18 @@ function createTaskTool(options: {
       }
       return createSubAgent(spec, { responseFormat }) as unknown as Runnable;
     }
+
+    const isDynamicForkingCall =
+      shouldFork &&
+      !("runnable" in spec) &&
+      spec.mode === "dynamic" &&
+      subagentSystemPrompts[subagentType] != null;
+    if (isDynamicForkingCall) {
+      return createSubAgent(spec, {
+        systemPromptOverride: parentSystemPrompt ?? undefined,
+      }) as unknown as Runnable;
+    }
+
     return subagentGraphs[subagentType] as Runnable;
   }
 
@@ -536,7 +629,11 @@ function createTaskTool(options: {
 
   return tool(
     async (
-      input: { description: string; subagent_type: string },
+      input: {
+        description: string;
+        subagent_type: string;
+        mode?: "handoff" | "fork";
+      },
       config,
     ): Promise<Command | string> => {
       const { description, subagent_type } = input;
@@ -550,12 +647,40 @@ function createTaskTool(options: {
         );
       }
 
-      const subagent = selectSubagent(subagent_type, config);
+      const spec = specsByName[subagent_type];
+      const shouldFork =
+        spec.mode === "fork" ||
+        (spec.mode === "dynamic" && input.mode === "fork");
+
+      const subagent = selectSubagent(subagent_type, config, shouldFork);
 
       const currentState = getCurrentTaskInput<Record<string, unknown>>();
       const subagentState = filterStateForSubagent(currentState);
-      subagentState.messages = [new HumanMessage({ content: description })];
-      subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
+
+      if (shouldFork) {
+        const rawMessages = (currentState.messages as BaseMessage[]) ?? [];
+        const trimmed = stripInFlightAIMessage(rawMessages);
+        const event = currentState._summarizationEvent as
+          | SummarizationEvent
+          | undefined;
+        const effective = event
+          ? [event.summaryMessage, ...trimmed.slice(event.cutoffIndex)]
+          : trimmed;
+        const ownSystemPrompt = subagentSystemPrompts[subagent_type];
+        const content = ownSystemPrompt
+          ? `${ownSystemPrompt}\n\n${description}`
+          : description;
+        subagentState.messages = [...effective, new HumanMessage({ content })];
+        if (event) {
+          subagentState._summarizationEvent = event;
+        }
+        subagentState._summarizationSessionId =
+          (currentState._summarizationSessionId as string | undefined) ??
+          `session_${crypto.randomUUID().substring(0, 8)}`;
+      } else {
+        subagentState.messages = [new HumanMessage({ content: description })];
+        subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
+      }
 
       const subagentConfig = {
         ...config,
@@ -611,6 +736,12 @@ function createTaskTool(options: {
           .describe(
             `Name of the agent to use. Available: ${Object.keys(subagentGraphs).join(", ")}`,
           ),
+        mode: z
+          .enum(["handoff", "fork"])
+          .optional()
+          .describe(
+            'Only meaningful for fork-capable agents: "fork" inherits the full conversation history, "handoff" (default) sends only the task description. Ignored for agents that aren\'t fork-capable.',
+          ),
       }),
     },
   );
@@ -641,6 +772,8 @@ export interface SubAgentMiddlewareOptions {
   generalPurposeAgent?: boolean;
   /** Custom description for the task tool */
   taskDescription?: string | null;
+  /** Reused by `mode: "fork"`/`"dynamic"` subagents for cache alignment */
+  parentSystemPrompt?: string | SystemMessage | null;
 }
 
 /**
@@ -657,6 +790,7 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     systemPrompt = null,
     generalPurposeAgent = true,
     taskDescription = null,
+    parentSystemPrompt = null,
   } = options;
 
   const taskTool = createTaskTool({
@@ -668,6 +802,7 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     subagents,
     generalPurposeAgent,
     taskDescription,
+    parentSystemPrompt,
   });
 
   return createMiddleware({

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -21,7 +21,7 @@ import type { LanguageModelLike } from "@langchain/core/language_models/base";
 import type { Runnable } from "@langchain/core/runnables";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { FilesystemPermission } from "../permissions/types.js";
-import type { SummarizationEvent } from "./summarization.js";
+import { getEffectiveMessages } from "./summarization.js";
 
 export type { AgentMiddleware };
 
@@ -109,6 +109,10 @@ export interface CompiledSubAgent<
 /**
  * Fields shared by both {@link SubAgent} and {@link ForkedSubAgent}.
  *
+ * Declared here (rather than only on one subtype) so both `systemPrompt` and
+ * `mode` stay visible to anyone adding a new subagent variant — each subtype
+ * narrows both to what it actually allows.
+ *
  * Required fields:
  * - `name`: Identifier used to select this subagent in the task tool
  * - `description`: Shown to the model for subagent selection
@@ -126,6 +130,20 @@ interface SubAgentBase {
 
   /** Description shown to the model for subagent selection */
   description: string;
+
+  /**
+   * The system prompt for the agent. Required on {@link SubAgent}; forbidden
+   * on {@link ForkedSubAgent}, which always inherits the parent's instead.
+   */
+  systemPrompt?: string | SystemMessage;
+
+  /**
+   * Context mode. `"handoff"` (default) is fully isolated — only
+   * {@link SubAgent} allows this. `"fork"` inherits the parent's
+   * conversation history and system prompt — only {@link ForkedSubAgent}
+   * allows this.
+   */
+  mode?: "handoff" | "fork";
 
   /** The tools to use for the agent (tool instances, not names). Defaults to defaultTools */
   tools?: StructuredTool[];
@@ -236,6 +254,9 @@ interface SubAgentBase {
 export interface SubAgent extends SubAgentBase {
   /** The system prompt to use for the agent */
   systemPrompt: string | SystemMessage;
+
+  /** Always isolated. Defaults to `"handoff"` if omitted. */
+  mode?: "handoff";
 }
 
 /**
@@ -259,7 +280,13 @@ export interface SubAgent extends SubAgentBase {
  * };
  * ```
  */
-export interface ForkedSubAgent extends SubAgentBase {}
+export interface ForkedSubAgent extends SubAgentBase {
+  /** A ForkedSubAgent never has its own system prompt — always the parent's. */
+  systemPrompt?: undefined;
+
+  /** Always forks. Defaults to `"fork"` if omitted. */
+  mode?: "fork";
+}
 
 /**
  * Base specification for the general-purpose subagent.
@@ -502,7 +529,7 @@ function getSubagents(options: {
   }
 
   for (const agentParams of subagents) {
-    const rawMode = (agentParams as { mode?: unknown }).mode;
+    const rawMode = agentParams.mode;
     if (rawMode != null && rawMode !== "handoff" && rawMode !== "fork") {
       throw new Error(
         `SubAgent '${agentParams.name}' has invalid mode '${rawMode}' — must be "handoff" or "fork".`,
@@ -517,10 +544,11 @@ function getSubagents(options: {
       agents[agentParams.name] = agentParams.runnable;
       specsByName[agentParams.name] = agentParams;
       if (agentParams.mode === "fork") forkModeNames.add(agentParams.name);
-    } else if ("systemPrompt" in agentParams) {
+    } else if (agentParams.systemPrompt != null) {
       // Plain SubAgent — never forks, keeps its own prompt untouched.
       const resolvedSpec: SubAgent = {
         ...agentParams,
+        mode: "handoff",
         model: agentParams.model ?? defaultModel,
         tools: agentParams.tools ?? defaultTools,
         middleware: [
@@ -534,9 +562,12 @@ function getSubagents(options: {
     } else {
       // ForkedSubAgent — always forks, always inherits the parent's exact
       // system prompt directly; there's no own prompt to fall back to.
+      // `mode` is omitted here (not "handoff"): the real fork signal is
+      // forkModeNames below — SubAgent's own `mode` type can't hold "fork".
       const resolvedSpec: SubAgent = {
         ...agentParams,
         systemPrompt: parentSystemPrompt ?? "",
+        mode: undefined,
         model: agentParams.model ?? defaultModel,
         tools: agentParams.tools ?? defaultTools,
         middleware: [
@@ -656,12 +687,7 @@ function createTaskTool(options: {
         const trimmed = stripInFlightAIMessage(
           (currentState.messages as BaseMessage[]) ?? [],
         );
-        const event = currentState._summarizationEvent as
-          | SummarizationEvent
-          | undefined;
-        const effective = event
-          ? [event.summaryMessage, ...trimmed.slice(event.cutoffIndex)]
-          : trimmed;
+        const effective = getEffectiveMessages(trimmed, currentState);
         subagentState.messages = [
           ...effective,
           new HumanMessage({ content: description }),

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -22,6 +22,7 @@ import type { Runnable } from "@langchain/core/runnables";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { FilesystemPermission } from "../permissions/types.js";
 import type { SummarizationEvent } from "./summarization.js";
+import { mergeMiddleware } from "./utils.js";
 
 export type { AgentMiddleware };
 
@@ -414,10 +415,10 @@ export function createSubAgent(
     throw new Error(`SubAgent '${spec.name}' must specify 'tools'`);
   }
 
-  const middleware: AgentMiddleware[] = [
-    ...(spec.middleware ?? []),
-    ...(options?.extraMiddleware ?? []),
-  ];
+  const middleware: AgentMiddleware[] = mergeMiddleware(
+    spec.middleware ?? [],
+    options?.extraMiddleware ?? [],
+  );
 
   if (spec.interruptOn) {
     middleware.push(

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -404,6 +404,7 @@ export function createSubAgent(
   options?: {
     responseFormat?: CreateAgentParams["responseFormat"];
     systemPromptOverride?: string | SystemMessage;
+    extraMiddleware?: AgentMiddleware[];
   },
 ): ReactAgent {
   if (!spec.model) {
@@ -413,7 +414,10 @@ export function createSubAgent(
     throw new Error(`SubAgent '${spec.name}' must specify 'tools'`);
   }
 
-  const middleware: AgentMiddleware[] = [...(spec.middleware ?? [])];
+  const middleware: AgentMiddleware[] = [
+    ...(spec.middleware ?? []),
+    ...(options?.extraMiddleware ?? []),
+  ];
 
   if (spec.interruptOn) {
     middleware.push(
@@ -561,6 +565,7 @@ function createTaskTool(options: {
   generalPurposeAgent: boolean;
   taskDescription: string | null;
   parentSystemPrompt?: string | SystemMessage | null;
+  parentMirrorMiddleware?: (() => AgentMiddleware[]) | null;
 }) {
   const {
     defaultModel,
@@ -572,6 +577,7 @@ function createTaskTool(options: {
     generalPurposeAgent,
     taskDescription,
     parentSystemPrompt = null,
+    parentMirrorMiddleware = null,
   } = options;
 
   const {
@@ -599,28 +605,38 @@ function createTaskTool(options: {
 
     const responseFormat =
       config.configurable?.[SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY];
-    if (responseFormat != null) {
-      if ("runnable" in spec) {
-        throw new Error(
-          `responseSchema cannot be used with compiled subagent "${spec.name}"; ` +
-            "dynamic schemas require a declarative SubAgent spec.",
-        );
-      }
-      return createSubAgent(spec, { responseFormat }) as unknown as Runnable;
+    if (responseFormat != null && "runnable" in spec) {
+      throw new Error(
+        `responseSchema cannot be used with compiled subagent "${spec.name}"; ` +
+          "dynamic schemas require a declarative SubAgent spec.",
+      );
+    }
+    if ("runnable" in spec) {
+      return subagentGraphs[subagentType] as Runnable;
     }
 
-    const isDynamicForkingCall =
-      shouldFork &&
-      !("runnable" in spec) &&
-      spec.mode === "dynamic" &&
-      subagentSystemPrompts[subagentType] != null;
-    if (isDynamicForkingCall) {
-      return createSubAgent(spec, {
+    // "dynamic" only recompiles when this call actually forks; "fork" only
+    // recompiles when something else (responseFormat) forces it anyway.
+    const isForkingThisCall =
+      shouldFork && subagentSystemPrompts[subagentType] != null;
+    const needsRecompile =
+      responseFormat != null || (isForkingThisCall && spec.mode === "dynamic");
+    if (!needsRecompile) {
+      return subagentGraphs[subagentType] as Runnable;
+    }
+
+    return createSubAgent(spec, {
+      ...(responseFormat != null && { responseFormat }),
+      ...(isForkingThisCall && {
         systemPromptOverride: parentSystemPrompt ?? undefined,
-      }) as unknown as Runnable;
-    }
-
-    return subagentGraphs[subagentType] as Runnable;
+      }),
+      ...(isForkingThisCall &&
+        spec.mode === "dynamic" && {
+          extraMiddleware: parentMirrorMiddleware
+            ? parentMirrorMiddleware()
+            : [],
+        }),
+    }) as unknown as Runnable;
   }
 
   const finalTaskDescription = taskDescription
@@ -671,9 +687,7 @@ function createTaskTool(options: {
           ? `${ownSystemPrompt}\n\n${description}`
           : description;
         subagentState.messages = [...effective, new HumanMessage({ content })];
-        if (event) {
-          subagentState._summarizationEvent = event;
-        }
+        // Not re-adding _summarizationEvent: cutoffIndex already applied above.
         subagentState._summarizationSessionId =
           (currentState._summarizationSessionId as string | undefined) ??
           `session_${crypto.randomUUID().substring(0, 8)}`;
@@ -774,6 +788,8 @@ export interface SubAgentMiddlewareOptions {
   taskDescription?: string | null;
   /** Reused by `mode: "fork"`/`"dynamic"` subagents for cache alignment */
   parentSystemPrompt?: string | SystemMessage | null;
+  /** Builds fresh mirrored middleware for a `"dynamic"` spec's per-call fork recompile */
+  parentMirrorMiddleware?: (() => AgentMiddleware[]) | null;
 }
 
 /**
@@ -791,6 +807,7 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     generalPurposeAgent = true,
     taskDescription = null,
     parentSystemPrompt = null,
+    parentMirrorMiddleware = null,
   } = options;
 
   const taskTool = createTaskTool({
@@ -802,6 +819,7 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
     subagents,
     generalPurposeAgent,
     taskDescription,
+    parentMirrorMiddleware,
     parentSystemPrompt,
   });
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -109,20 +109,7 @@ export interface CompiledSubAgent<
 /**
  * Fields shared by both {@link SubAgent} and {@link ForkedSubAgent}.
  *
- * Declared here (rather than only on one subtype) so both `systemPrompt` and
- * `mode` stay visible to anyone adding a new subagent variant — each subtype
- * narrows both to what it actually allows.
- *
- * Required fields:
- * - `name`: Identifier used to select this subagent in the task tool
- * - `description`: Shown to the model for subagent selection
- *
- * Optional fields:
- * - `model`: Override the default model for this subagent
- * - `tools`: Override the default tools for this subagent
- * - `middleware`: Additional middleware appended after defaults
- * - `interruptOn`: Human-in-the-loop configuration for specific tools
- * - `skills`: Skill source paths for SkillsMiddleware (e.g., `["/skills/user/", "/skills/project/"]`)
+ * @internal
  */
 interface SubAgentBase {
   /** Identifier used to select this subagent in the task tool */
@@ -138,10 +125,8 @@ interface SubAgentBase {
   systemPrompt?: string | SystemMessage;
 
   /**
-   * Context mode. `"handoff"` (default) is fully isolated — only
-   * {@link SubAgent} allows this. `"fork"` inherits the parent's
-   * conversation history and system prompt — only {@link ForkedSubAgent}
-   * allows this.
+   * Context mode. `"handoff"` (default) is fully isolated. `"fork"` inherits
+   * the parent's conversation history and system prompt.
    */
   mode?: "handoff" | "fork";
 
@@ -253,9 +238,12 @@ interface SubAgentBase {
  */
 export interface SubAgent extends SubAgentBase {
   /** The system prompt to use for the agent */
-  systemPrompt: string | SystemMessage;
+  systemPrompt?: string | SystemMessage;
 
-  /** Always isolated. Defaults to `"handoff"` if omitted. */
+  /**
+   * Context mode. `"handoff"` (default) is fully isolated. `"fork"` inherits
+   * the parent's conversation history and system prompt.
+   */
   mode?: "handoff";
 }
 
@@ -279,13 +267,25 @@ export interface SubAgent extends SubAgentBase {
  *   tools: [webSearchTool],
  * };
  * ```
+ *
+ * @experimental Forking subagents is experimental and subject to change
  */
 export interface ForkedSubAgent extends SubAgentBase {
   /** A ForkedSubAgent never has its own system prompt — always the parent's. */
   systemPrompt?: undefined;
 
-  /** Always forks. Defaults to `"fork"` if omitted. */
+  /**
+   * Context mode. `"handoff"` (default) is fully isolated. `"fork"` inherits
+   * the parent's conversation history and system prompt.
+   */
   mode?: "fork";
+}
+
+export function isForkedSubAgent(value: unknown): value is ForkedSubAgent {
+  if (typeof value !== "object" || value == null) return false;
+  if ("mode" in value && value.mode !== "fork") return false;
+  if ("systemPrompt" in value && value.systemPrompt !== undefined) return false;
+  return true;
 }
 
 /**
@@ -325,14 +325,11 @@ export interface ForkedSubAgent extends SubAgentBase {
  * });
  * ```
  */
-export const GENERAL_PURPOSE_SUBAGENT: {
-  name: string;
-  description: string;
-  systemPrompt: string;
-} = {
+export const GENERAL_PURPOSE_SUBAGENT = {
   name: "general-purpose",
   description: DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
   systemPrompt: DEFAULT_SUBAGENT_PROMPT,
+  mode: "handoff",
 } as const;
 
 /**
@@ -543,23 +540,8 @@ function getSubagents(options: {
     if ("runnable" in agentParams) {
       agents[agentParams.name] = agentParams.runnable;
       specsByName[agentParams.name] = agentParams;
-      if (agentParams.mode === "fork") forkModeNames.add(agentParams.name);
-    } else if (agentParams.systemPrompt != null) {
-      // Plain SubAgent — never forks, keeps its own prompt untouched.
-      const resolvedSpec: SubAgent = {
-        ...agentParams,
-        mode: "handoff",
-        model: agentParams.model ?? defaultModel,
-        tools: agentParams.tools ?? defaultTools,
-        middleware: [
-          ...defaultSubagentMiddleware,
-          ...(agentParams.middleware ?? []),
-        ],
-        interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
-      };
-      agents[agentParams.name] = createSubAgent(resolvedSpec);
-      specsByName[agentParams.name] = resolvedSpec;
-    } else {
+      if (isForkedSubAgent(agentParams)) forkModeNames.add(agentParams.name);
+    } else if (isForkedSubAgent(agentParams)) {
       // ForkedSubAgent — always forks, always inherits the parent's exact
       // system prompt directly; there's no own prompt to fall back to.
       // `mode` is omitted here (not "handoff"): the real fork signal is
@@ -579,6 +561,21 @@ function getSubagents(options: {
       agents[agentParams.name] = createSubAgent(resolvedSpec);
       specsByName[agentParams.name] = resolvedSpec;
       forkModeNames.add(agentParams.name);
+    } else {
+      // Plain SubAgent — never forks, keeps its own prompt untouched.
+      const resolvedSpec: SubAgent = {
+        ...agentParams,
+        mode: "handoff",
+        model: agentParams.model ?? defaultModel,
+        tools: agentParams.tools ?? defaultTools,
+        middleware: [
+          ...defaultSubagentMiddleware,
+          ...(agentParams.middleware ?? []),
+        ],
+        interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
+      };
+      agents[agentParams.name] = createSubAgent(resolvedSpec);
+      specsByName[agentParams.name] = resolvedSpec;
     }
   }
 
@@ -658,13 +655,7 @@ function createTaskTool(options: {
     : getTaskToolDescription(subagentDescriptions);
 
   return tool(
-    async (
-      input: {
-        description: string;
-        subagent_type: string;
-      },
-      config,
-    ): Promise<Command | string> => {
+    async (input, config): Promise<Command | string> => {
       const { description, subagent_type } = input;
 
       if (!(subagent_type in subagentGraphs)) {

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -532,18 +532,17 @@ function getSubagents(options: {
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
 
-      const cacheAligned = isCacheAlignedForkSpec({
+      const systemPromptOverride = isCacheAlignedForkSpec({
         mode: resolvedSpec.mode,
         specModel: agentParams.model,
         parentModel: defaultModel,
         parentSystemPrompt,
-      });
-      if (cacheAligned) {
-        subagentSystemPrompts[resolvedSpec.name] = resolvedSpec.systemPrompt;
-      }
-      const systemPromptOverride = cacheAligned
+      })
         ? (parentSystemPrompt ?? undefined)
         : undefined;
+      if (systemPromptOverride != null) {
+        subagentSystemPrompts[resolvedSpec.name] = resolvedSpec.systemPrompt;
+      }
 
       agents[agentParams.name] = createSubAgent(resolvedSpec, {
         systemPromptOverride,
@@ -616,10 +615,7 @@ function createTaskTool(options: {
           "dynamic schemas require a declarative SubAgent spec.",
       );
     }
-    if ("runnable" in spec) {
-      return subagentGraphs[subagentType] as Runnable;
-    }
-    if (responseFormat == null) {
+    if ("runnable" in spec || responseFormat == null) {
       return subagentGraphs[subagentType] as Runnable;
     }
 
@@ -658,8 +654,9 @@ function createTaskTool(options: {
       const subagentState = filterStateForSubagent(currentState);
 
       if (shouldFork) {
-        const rawMessages = (currentState.messages as BaseMessage[]) ?? [];
-        const trimmed = stripInFlightAIMessage(rawMessages);
+        const trimmed = stripInFlightAIMessage(
+          (currentState.messages as BaseMessage[]) ?? [],
+        );
         const event = currentState._summarizationEvent as
           | SummarizationEvent
           | undefined;

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -668,14 +668,10 @@ function createTaskTool(options: {
           ? `${ownSystemPrompt}\n\n${description}`
           : description;
         subagentState.messages = [...effective, new HumanMessage({ content })];
-        // Not re-adding _summarizationEvent: cutoffIndex already applied above.
-        subagentState._summarizationSessionId =
-          (currentState._summarizationSessionId as string | undefined) ??
-          `session_${crypto.randomUUID().substring(0, 8)}`;
       } else {
         subagentState.messages = [new HumanMessage({ content: description })];
-        subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
       }
+      subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
 
       const subagentConfig = {
         ...config,

--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -282,6 +282,30 @@ function isSummaryMessage(msg: BaseMessage): boolean {
 }
 
 /**
+ * Reconstruct the effective message list based on any previous summarization event.
+ *
+ * After summarization, instead of using all messages from state, we use the summary
+ * message plus messages after the cutoff index. This avoids full state rewrites.
+ */
+export function getEffectiveMessages(
+  messages: BaseMessage[],
+  state: Record<string, unknown>,
+): BaseMessage[] {
+  const event = state._summarizationEvent as SummarizationEvent | undefined;
+
+  // If no summarization event, return all messages as-is
+  if (!event) {
+    return messages;
+  }
+
+  // Build effective messages: summary message, then messages from cutoff onward
+  const result: BaseMessage[] = [event.summaryMessage];
+  result.push(...messages.slice(event.cutoffIndex));
+
+  return result;
+}
+
+/**
  * Create summarization middleware with backend support for conversation history offloading.
  *
  * This middleware:
@@ -975,30 +999,6 @@ export function createSummarizationMiddleware(
       content,
       additional_kwargs: { lc_source: "summarization" },
     });
-  }
-
-  /**
-   * Reconstruct the effective message list based on any previous summarization event.
-   *
-   * After summarization, instead of using all messages from state, we use the summary
-   * message plus messages after the cutoff index. This avoids full state rewrites.
-   */
-  function getEffectiveMessages(
-    messages: BaseMessage[],
-    state: Record<string, unknown>,
-  ): BaseMessage[] {
-    const event = state._summarizationEvent as SummarizationEvent | undefined;
-
-    // If no summarization event, return all messages as-is
-    if (!event) {
-      return messages;
-    }
-
-    // Build effective messages: summary message, then messages from cutoff onward
-    const result: BaseMessage[] = [event.summaryMessage];
-    result.push(...messages.slice(event.cutoffIndex));
-
-    return result;
   }
 
   /**

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -32,7 +32,10 @@ import type {
   StateDefinitionInit,
   StreamTransformer,
 } from "@langchain/langgraph";
-import type { CompiledSubAgent } from "./middleware/subagents.js";
+import type {
+  CompiledSubAgent,
+  ForkedSubAgent,
+} from "./middleware/subagents.js";
 import type {
   ASYNC_TASK_TOOL_NAMES,
   FILESYSTEM_TOOL_NAMES,
@@ -82,8 +85,12 @@ type InferDeepAgentStreamExtensions<
     ? P & InferDeepAgentStreamExtensions<Rest>
     : Record<string, unknown>;
 
-/** Any subagent specification — sync, compiled, or async. */
-export type AnySubAgent = SubAgent | CompiledSubAgent | AsyncSubAgent;
+/** Any subagent specification — sync, compiled, forked, or async. */
+export type AnySubAgent =
+  | SubAgent
+  | CompiledSubAgent
+  | ForkedSubAgent
+  | AsyncSubAgent;
 
 // TODO: import TypedToolStrategy from "langchain" once exported from the top-level entry point
 // (currently only available via "langchain/dist/agents/responses.js")
@@ -473,10 +480,10 @@ export type InferSubagentByName<T, TName extends string> =
  * ```
  */
 export type InferSubagentReactAgentType<
-  TSubagent extends SubAgent | CompiledSubAgent,
+  TSubagent extends SubAgent | CompiledSubAgent | ForkedSubAgent,
 > = TSubagent extends CompiledSubAgent
   ? TSubagent["runnable"]
-  : TSubagent extends SubAgent
+  : TSubagent extends SubAgent | ForkedSubAgent
     ? ReactAgent<
         AgentTypeConfig<
           ResponseFormatUndefined,


### PR DESCRIPTION
## Summary

Replaces the `mode` field on `SubAgent` with a new `ForkedSubAgent` type for opt-in conversation forking. A `ForkedSubAgent` has no `systemPrompt` of its own — it always inherits the parent's message history and exact system prompt, plus mirrored middleware when its model matches the parent's. `CompiledSubAgent` keeps its existing `mode: "handoff" | "fork"` field, unchanged.

## Changes

- New `ForkedSubAgent` type — same shape as `SubAgent` minus `systemPrompt`; always forks.
- `SubAgent` no longer has a `mode` field — always isolated (same as before this feature existed).
- `CompiledSubAgent.mode` unchanged.
- Mirrored middleware (memory/custom) only added when the model matches the parent's; the system prompt itself is inherited unconditionally either way.
- Updated fork test coverage in `subagent.test.ts` for the new type.