### PR TITLE
feat(deepagents): add per-subagent recursionLimit override

### DIFF
--- a/.changeset/subagent-recursion-limit.md
+++ b/.changeset/subagent-recursion-limit.md
@@ -1,0 +1,10 @@
+---
+"deepagents": minor
+---
+
+feat(deepagents): add per-subagent `recursionLimit` override
+
+The `SubAgent` interface now accepts an optional `recursionLimit` field that
+overrides the parent agent's ambient recursion limit for that specific subagent.
+This allows bounding expensive delegation or giving research-heavy subagents
+more headroom independently of the parent's ceiling.

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -1592,3 +1592,160 @@ describe("middleware override by name", () => {
     expect(summarization[0]).toBe(custom);
   });
 });
+
+describe("per-subagent recursionLimit", () => {
+  it("should override parent recursionLimit when set on SubAgent spec", async () => {
+    let capturedRecursionLimit: number | undefined;
+
+    const captureConfig = tool(
+      (_input, config) => {
+        capturedRecursionLimit = config.recursionLimit as number | undefined;
+        return "captured";
+      },
+      {
+        name: "capture_config",
+        description: "Captures the recursionLimit from the invoke config",
+        schema: z.object({}),
+      },
+    );
+
+    const subagentModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "capture_call",
+              name: "capture_config",
+              args: {},
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+
+    const parentModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "task_call",
+              name: "task",
+              args: {
+                description: "Do work",
+                subagent_type: "bounded",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+
+    const agent = createDeepAgent({
+      model: parentModel,
+      name: "main-agent",
+      subagents: [
+        {
+          name: "bounded",
+          description: "A bounded subagent",
+          systemPrompt: "Use capture_config then finish.",
+          tools: [captureConfig],
+          model: subagentModel,
+          recursionLimit: 42,
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: [new HumanMessage("Test")] },
+      {
+        configurable: {
+          thread_id: `test-recursion-limit-override-${Date.now()}`,
+        },
+        recursionLimit: 200,
+      },
+    );
+
+    expect(capturedRecursionLimit).toBe(42);
+  });
+
+  it("should inherit parent recursionLimit when not set on SubAgent spec", async () => {
+    let capturedRecursionLimit: number | undefined;
+
+    const captureConfig = tool(
+      (_input, config) => {
+        capturedRecursionLimit = config.recursionLimit as number | undefined;
+        return "captured";
+      },
+      {
+        name: "capture_config",
+        description: "Captures the recursionLimit from the invoke config",
+        schema: z.object({}),
+      },
+    );
+
+    const subagentModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "capture_call",
+              name: "capture_config",
+              args: {},
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+
+    const parentModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "task_call",
+              name: "task",
+              args: {
+                description: "Do work",
+                subagent_type: "unbounded",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+
+    const agent = createDeepAgent({
+      model: parentModel,
+      name: "main-agent",
+      subagents: [
+        {
+          name: "unbounded",
+          description: "A subagent without recursionLimit override",
+          systemPrompt: "Use capture_config then finish.",
+          tools: [captureConfig],
+          model: subagentModel,
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: [new HumanMessage("Test")] },
+      {
+        configurable: {
+          thread_id: `test-recursion-limit-inherit-${Date.now()}`,
+        },
+        recursionLimit: 200,
+      },
+    );
+
+    expect(capturedRecursionLimit).toBe(200);
+  });
+});

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -116,6 +116,9 @@ export interface CompiledSubAgent<
  * - `middleware`: Additional middleware appended after defaults
  * - `interruptOn`: Human-in-the-loop configuration for specific tools
  * - `skills`: Skill source paths for SkillsMiddleware (e.g., `["/skills/user/", "/skills/project/"]`)
+ * - `responseFormat`: Structured output schema for the subagent
+ * - `permissions`: Filesystem permission rules (replaces parent's)
+ * - `recursionLimit`: Override the parent's recursion limit for this subagent
  *
  * @example
  * ```typescript
@@ -583,7 +586,9 @@ function createTaskTool(options: {
 
       const spec = specsByName[subagent_type];
       const perSubagentRecursionLimit =
-        spec && !("runnable" in spec) ? spec.recursionLimit : undefined;
+        !("runnable" in spec) && spec.recursionLimit && spec.recursionLimit > 0
+          ? spec.recursionLimit
+          : undefined;
 
       const subagentConfig = {
         ...config,

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -220,6 +220,30 @@ export interface SubAgent {
    * ```
    */
   permissions?: FilesystemPermission[];
+
+  /**
+   * Recursion limit for this subagent's own graph invocation.
+   *
+   * When set, overrides the parent agent's ambient `recursionLimit` for this
+   * subagent only. Useful for bounding expensive delegation or giving a
+   * research-heavy subagent more headroom than the default.
+   *
+   * Only applies to declarative `SubAgent` specs. Pre-compiled
+   * `CompiledSubAgent` runnables should use `.withConfig()` directly.
+   *
+   * @default undefined (inherits from parent config)
+   *
+   * @example
+   * ```ts
+   * const bounded: SubAgent = {
+   *   name: "bounded",
+   *   description: "Short-lived helper with a tight step ceiling",
+   *   systemPrompt: "You are a focused helper.",
+   *   recursionLimit: 50,
+   * };
+   * ```
+   */
+  recursionLimit?: number;
 }
 
 /**
@@ -557,8 +581,15 @@ function createTaskTool(options: {
       subagentState.messages = [new HumanMessage({ content: description })];
       subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
 
+      const spec = specsByName[subagent_type];
+      const perSubagentRecursionLimit =
+        spec && !("runnable" in spec) ? spec.recursionLimit : undefined;
+
       const subagentConfig = {
         ...config,
+        ...(perSubagentRecursionLimit != null && {
+          recursionLimit: perSubagentRecursionLimit,
+        }),
         metadata: {
           ...config.metadata,
           lc_agent_name: subagent_type,


### PR DESCRIPTION
Fixes #755

## Summary

Adds an optional `recursionLimit` field to the `SubAgent` interface. When set, it overrides the parent agent's ambient recursion limit for that specific subagent's graph invocation.

### Changes

1. **`SubAgent` interface** (`libs/deepagents/src/middleware/subagents.ts`): Added `recursionLimit?: number` field with JSDoc
2. **Task tool invoke site** (same file): Merges the per-subagent recursionLimit into the invoke config when present, before calling `subagent.invoke()`
3. **Tests** (`libs/deepagents/src/middleware/subagent.test.ts`): Two tests verifying override and inheritance behavior
4. **Changeset**: Minor version bump

### Usage

```ts
import { createDeepAgent, type SubAgent } from "deepagents";

const bounded: SubAgent = {
  name: "bounded",
  description: "Short-lived helper with a tight step ceiling",
  systemPrompt: "You are a focused helper.",
  recursionLimit: 50, // overrides parent's 10_000
};

const agent = createDeepAgent({
  model: "claude-sonnet-4-5-20250929",
  subagents: [bounded],
});
```

### Design decisions

- Only applies to declarative `SubAgent` specs. `CompiledSubAgent` (pre-compiled runnables) should use `.withConfig()` directly — they already have that escape hatch.
- When `recursionLimit` is not set, behavior is unchanged (inherits parent config).
- Placed after `permissions` in the interface since it's another per-subagent runtime control.

### Prior art

- Python: [langchain-ai/deepagents#1698](https://github.com/langchain-ai/deepagents/issues/1698), PRs #2012 and #2150
- JS: [#183](https://github.com/langchain-ai/deepagentsjs/pull/183) raised global default but didn't add per-subagent control