### PR TITLE
fix(deepagents): cap sandbox glob find so root searches cannot OOM the host

### DIFF
--- a/.changeset/fix-sandbox-glob-find-oom.md
+++ b/.changeset/fix-sandbox-glob-find-oom.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): cap sandbox glob find so root searches cannot OOM the host
+
+Recursive glob listed every path under the search root (and with `-L` could loop through `/proc/*/root`). Prune virtual filesystems and soft-cap find output so a `glob("**/x", "/")` cannot exhaust the runtime heap.

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -33,7 +33,11 @@ class MockSandbox extends BaseSandbox {
     }
 
     // Simulate find command for glob (find + stat, recursive — no -maxdepth 1)
-    if (command.includes("stat -c") && !command.includes("-maxdepth 1")) {
+    if (
+      command.includes("stat -c") &&
+      !command.includes("-maxdepth 1") &&
+      command.includes("head -n")
+    ) {
       const files = Array.from(this.files.keys());
       const now = Math.floor(Date.now() / 1000);
       const output = files
@@ -726,6 +730,40 @@ describe("BaseSandbox", () => {
 
       await sandbox.glob("*.py", "/");
       expect(sandbox.executedCommands[0]).toMatch(/find\s+-L\s+/);
+    });
+
+    it("should prune virtual filesystems and cap find output", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.addFile("/test.py", "print('hello')");
+
+      await sandbox.glob("*.py", "/");
+      const command = sandbox.executedCommands[0];
+      expect(command).toContain("-path /proc");
+      expect(command).toContain("-path /sys");
+      expect(command).toContain("-path /dev");
+      expect(command).toContain("-path /run");
+      expect(command).toContain("-prune");
+      expect(command).toMatch(/head -n 50001/);
+    });
+
+    it("should mark truncated when find output exceeds the soft cap", async () => {
+      const sandbox = new MockSandbox();
+      const now = Math.floor(Date.now() / 1000);
+      // Soft cap is 50_000; one past that signals truncation.
+      const lines = Array.from(
+        { length: 50_001 },
+        (_, i) => `1\t${now}\tregular file\t/f${i}.txt`,
+      );
+      sandbox.execute = vi.fn().mockResolvedValue({
+        output: lines.join("\n"),
+        exitCode: 0,
+        truncated: false,
+      });
+
+      const result = await sandbox.glob("*.txt", "/");
+      expect(result.error).toBeUndefined();
+      expect(result.truncated).toBe(true);
+      expect(result.files!.length).toBe(50_000);
     });
 
     it("should return empty array for no matches", async () => {

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -766,6 +766,21 @@ describe("BaseSandbox", () => {
       expect(result.files!.length).toBe(50_000);
     });
 
+    it("should mark truncated when the backend truncated output below the cap", async () => {
+      const sandbox = new MockSandbox();
+      const now = Math.floor(Date.now() / 1000);
+      sandbox.execute = vi.fn().mockResolvedValue({
+        output: `1\t${now}\tregular file\t/f0.txt`,
+        exitCode: 0,
+        truncated: true,
+      });
+
+      const result = await sandbox.glob("*.txt", "/");
+      expect(result.error).toBeUndefined();
+      expect(result.truncated).toBe(true);
+      expect(result.files!.length).toBe(1);
+    });
+
     it("should return empty array for no matches", async () => {
       const sandbox = new MockSandbox();
       sandbox.execute = vi.fn().mockResolvedValue({

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -190,23 +190,46 @@ function buildLsCommand(dirPath: string): string {
 }
 
 /**
+ * Soft cap on recursive find lines for sandbox glob.
+ *
+ * Glob currently lists every path under the search root via `find`, then filters
+ * in-process. Without a bound, a root-path recursive glob can stream the whole
+ * container rootfs (and, with `-L`, loop through proc pid root symlinks) into
+ * the host heap and OOM the runtime. Cap the listing; callers mark truncated
+ * when the cap is hit.
+ */
+const MAX_GLOB_FIND_LINES = 50_000;
+
+/**
  * Shell command for listing files recursively with metadata.
  * Same three-way detection as buildLsCommand (GNU -printf / stat -c / BSD stat -f).
+ *
+ * Prunes virtual filesystems (`/proc`, `/sys`, `/dev`, `/run`) so `find -L`
+ * cannot follow proc pid root symlinks back into `/` and loop forever. Caps
+ * stdout so the host process that buffers `execute()` never materializes an
+ * unbounded listing.
  *
  * Output format per line: size\tmtime\ttype\tpath
  */
 function buildFindCommand(searchPath: string): string {
   const quotedPath = shellQuote(searchPath);
-  const findBase = `find -L ${quotedPath} -not -path ${quotedPath}`;
-  return (
+  // Absolute + search-relative prunes: -L can leave the search tree via
+  // symlinks into /proc before the relative prune would apply.
+  const prune =
+    `\\( -path /proc -o -path /sys -o -path /dev -o -path /run ` +
+    `-o -path ${quotedPath}/proc -o -path ${quotedPath}/sys ` +
+    `-o -path ${quotedPath}/dev -o -path ${quotedPath}/run \\) -prune`;
+  const findBase = `find -L ${quotedPath} ${prune} -o -not -path ${quotedPath}`;
+  const listing =
     `if find /dev/null -maxdepth 0 -printf '' 2>/dev/null; then ` +
     `${findBase} -printf '%s\\t%T@\\t%y\\t%p\\n' 2>/dev/null; ` +
     `elif stat -c %s /dev/null >/dev/null 2>&1; then ` +
     `${findBase} -exec sh -c '${STAT_C_SCRIPT}' _ {} +; ` +
     `else ` +
     `${findBase} -exec stat -f '%z\t%m\t%Sp\t%N' {} + 2>/dev/null; ` +
-    `fi || true`
-  );
+    `fi || true`;
+  // Request one past the soft cap so glob() can detect truncation.
+  return `{ ${listing}; } | head -n ${MAX_GLOB_FIND_LINES + 1}`;
 }
 
 /**
@@ -482,11 +505,13 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
     const regex = globToPathRegex(pattern);
     const infos: FileInfo[] = [];
     const lines = result.output.trim().split("\n").filter(Boolean);
+    const truncated = lines.length > MAX_GLOB_FIND_LINES;
+    const limited = truncated ? lines.slice(0, MAX_GLOB_FIND_LINES) : lines;
 
     // Normalise base path (strip trailing /)
     const basePath = path.endsWith("/") ? path.slice(0, -1) : path;
 
-    for (const line of lines) {
+    for (const line of limited) {
       const parsed = parseStatLine(line);
       if (!parsed) continue;
 
@@ -505,7 +530,7 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
       }
     }
 
-    return { files: infos };
+    return { files: infos, truncated };
   }
 
   /**

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -505,8 +505,11 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
     const regex = globToPathRegex(pattern);
     const infos: FileInfo[] = [];
     const lines = result.output.trim().split("\n").filter(Boolean);
-    const truncated = lines.length > MAX_GLOB_FIND_LINES;
-    const limited = truncated ? lines.slice(0, MAX_GLOB_FIND_LINES) : lines;
+    // execute() can cut output before the shell reaches the soft cap, so the
+    // backend's own flag has to be folded in or a partial listing looks complete.
+    const overCap = lines.length > MAX_GLOB_FIND_LINES;
+    const truncated = overCap || result.truncated === true;
+    const limited = overCap ? lines.slice(0, MAX_GLOB_FIND_LINES) : lines;
 
     // Normalise base path (strip trailing /)
     const basePath = path.endsWith("/") ? path.slice(0, -1) : path;


### PR DESCRIPTION
## Summary

Recursive glob listed every path under the search root, and with -L could loop through proc pid root symlinks into the host heap.

- Sandbox `glob` listed the whole search tree via `find -L` and buffered it in the host process, so `glob("**/…", "/")` could OOM the runtime. Prune virtual filesystems and soft-cap find output; mark `truncated` when the cap is hit.

