### PR TITLE
test(deepagents): de-flake custom StateGraph subagent interrupt test

### DIFF
--- a/libs/deepagents/src/middleware/subagents-hitl.int.test.ts
+++ b/libs/deepagents/src/middleware/subagents-hitl.int.test.ts
@@ -289,13 +289,23 @@ describe("Subagent HITL Integration Tests - interrupt() primitive", () => {
         {
           messages: [
             new HumanMessage(
-              "Use the task tool to launch the document-reviewer sub-agent. " +
-                "Pass it the document 'Q4 Financial Report'.",
+              "Your only job is to call the `task` tool exactly once right now. " +
+                "Set subagent_type to 'document-reviewer' and set description to " +
+                "the document 'Q4 Financial Report'. Do not answer directly, do not " +
+                "explain, and do not ask any questions first — emit the task tool call immediately.",
             ),
           ],
         },
         config,
       );
+
+      // Sanity check: the parent model must have delegated via the task tool.
+      // If it answers directly the sub-agent never runs and no interrupt fires.
+      const taskToolCalled = result.messages
+        .filter(AIMessage.isInstance)
+        .flatMap((msg) => msg.tool_calls || [])
+        .some((tc) => tc.name === "task");
+      expect(taskToolCalled).toBe(true);
 
       // Step 2: Check for interrupt
       expect(result.__interrupt__).toBeDefined();


### PR DESCRIPTION
## Summary

De-flakes the integration test `should handle interrupt() in a custom StateGraph sub-agent` in `libs/deepagents/src/middleware/subagents-hitl.int.test.ts`, which intermittently fails in CI with:

```
AssertionError: expected undefined to be defined
 at src/middleware/subagents-hitl.int.test.ts:301:36   // expect(result.__interrupt__).toBeDefined()
```

## Root cause

The test relies on a **live LLM** deciding to call the `task` tool to delegate to the `document-reviewer` sub-agent. The original prompt only softly suggested this ("Use the task tool to launch the document-reviewer sub-agent"). When the model answers directly instead of delegating, the sub-agent never runs, `interrupt()` never fires, and `result.__interrupt__` is `undefined`, producing the flaky failure.

This is test-prompt flakiness, not a product regression. The interrupt-propagation path is unchanged, and the sibling interrupt tests in the same file (dict-based tools, sequential interrupts) pass in the same runs. The failure toggles pass/fail across commits on an unrelated branch (the delete-tool PR #675) that never touched subagent/interrupt code.

## Changes

- Rewrote the prompt as a strict, imperative instruction: call the `task` tool exactly once immediately, with the correct `subagent_type` and `description`, and do not answer directly.
- Added an explicit assertion that the `task` tool was actually called. If a non-delegating model slips through, the failure now points clearly at "task tool was not called" instead of a confusing `__interrupt__` assertion. This mirrors the existing check in the skipped `CompiledSubAgent` test.

## Testing

- `pnpm typecheck`: no new errors from this file (pre-existing unrelated errors in backend `*.int.test.ts` about a missing `@langchain/sandbox-standard-tests` module remain).
- `oxlint`: clean on the edited file.
- This is a live-LLM integration test (`test:int`) requiring API keys, so it runs in CI's Integration Tests job.
