### PR TITLE
fix(deepagents): return raw file content from BaseSandbox.read()

### DIFF
--- a/.changeset/fix-sandbox-read-double-line-numbers.md
+++ b/.changeset/fix-sandbox-read-double-line-numbers.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+fix(sandbox): return raw file content from BaseSandbox.read()
+
+The sandbox awk command was numbering lines, then read_file numbered them again, so the model saw a doubled gutter. Other backends already return raw content and leave formatting to the middleware — same as Python.

--- a/libs/deepagents/src/backends/composite.ts
+++ b/libs/deepagents/src/backends/composite.ts
@@ -213,7 +213,7 @@ export class CompositeBackend implements BackendProtocolV2 {
    * @param filePath - Absolute file path
    * @param offset - Line offset to start reading from (0-indexed)
    * @param limit - Maximum number of lines to read
-   * @returns Formatted file content with line numbers, or error message
+   * @returns ReadResult with raw content on success or error on failure
    */
   async read(
     filePath: string,

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -227,12 +227,12 @@ export class FilesystemBackend implements BackendProtocolV2 {
   }
 
   /**
-   * Read file content with line numbers.
+   * Read file content.
    *
    * @param filePath - Absolute or relative file path
    * @param offset - Line offset to start reading from (0-indexed)
    * @param limit - Maximum number of lines to read
-   * @returns Formatted file content with line numbers, or error message
+   * @returns ReadResult with raw content on success or error on failure
    */
   async read(
     filePath: string,

--- a/libs/deepagents/src/backends/langsmith.test.ts
+++ b/libs/deepagents/src/backends/langsmith.test.ts
@@ -497,7 +497,7 @@ describe("LangSmithSandbox", () => {
     it("read() delegates to execute() via a shell command", async () => {
       const sandbox = makeSandbox();
       mockRun.mockResolvedValue({
-        stdout: "     1\thello",
+        stdout: "hello",
         stderr: "",
         exit_code: 0,
       });

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -64,15 +64,9 @@ class MockSandbox extends BaseSandbox {
             truncated: false,
           };
         }
-        // Mirror awk's printf format so a gutter added back to the command
-        // shows up here rather than being silently normalized away.
-        const numbered = command.includes("%6d");
-        const output = content
-          .split("\n")
-          .map((line, i) =>
-            numbered ? `${String(i + 1).padStart(6)}\t${line}` : line,
-          )
-          .join("\n");
+        // Always return the page as raw lines. Numbering belongs to the
+        // read_file tool; this mock mirrors the BaseSandbox contract.
+        const output = content.split("\n").join("\n");
         return { output, exitCode: 0, truncated: false };
       }
     }
@@ -229,13 +223,17 @@ describe("BaseSandbox", () => {
       expect(result.content).toBe("line1\nline2\nline3");
     });
 
-    it("does not number lines in the shell command", () => {
+    it("does not number lines in the shell command", async () => {
       const sandbox = new MockSandbox();
       sandbox.addFile("/test.txt", "line1");
 
-      void sandbox.read("/test.txt");
+      await sandbox.read("/test.txt");
 
-      expect(sandbox.executedCommands[0]).not.toContain("%6d");
+      const cmd = sandbox.executedCommands[0];
+      // Pagination may still filter on NR, but printf must emit only the line
+      // body — no width-N line-number field that would double with the tool.
+      expect(cmd).toMatch(/printf "%s\\n"/);
+      expect(cmd).not.toMatch(/printf "[^"]*%\d*d/);
     });
 
     it("should return error for non-existent file", async () => {

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -64,9 +64,14 @@ class MockSandbox extends BaseSandbox {
             truncated: false,
           };
         }
-        const lines = content.split("\n");
-        const output = lines
-          .map((line, i) => `     ${i + 1}\t${line}`)
+        // Mirror awk's printf format so a gutter added back to the command
+        // shows up here rather than being silently normalized away.
+        const numbered = command.includes("%6d");
+        const output = content
+          .split("\n")
+          .map((line, i) =>
+            numbered ? `${String(i + 1).padStart(6)}\t${line}` : line,
+          )
           .join("\n");
         return { output, exitCode: 0, truncated: false };
       }
@@ -211,6 +216,26 @@ describe("BaseSandbox", () => {
       expect(result.error).toBeUndefined();
       expect(result.content).toContain("line1");
       expect(result.content).toContain("line2");
+    });
+
+    it("returns raw content, leaving the gutter to the read_file tool", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.addFile("/test.txt", "line1\nline2\nline3");
+
+      const result = await sandbox.read("/test.txt");
+
+      // A gutter here would be doubled by formatContentWithLineNumbers in the
+      // read_file tool, which numbers every backend's content.
+      expect(result.content).toBe("line1\nline2\nline3");
+    });
+
+    it("does not number lines in the shell command", () => {
+      const sandbox = new MockSandbox();
+      sandbox.addFile("/test.txt", "line1");
+
+      void sandbox.read("/test.txt");
+
+      expect(sandbox.executedCommands[0]).not.toContain("%6d");
     });
 
     it("should return error for non-existent file", async () => {

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -210,8 +210,11 @@ function buildFindCommand(searchPath: string): string {
 }
 
 /**
- * Pure POSIX shell command for reading files with line numbers.
- * Uses awk for line numbering with offset/limit — works on any Linux including Alpine.
+ * Pure POSIX shell command for reading a slice of a file.
+ *
+ * Uses awk to apply offset/limit — works on any Linux including Alpine. Lines
+ * are emitted verbatim: `ReadResult.content` is raw content for every backend,
+ * and the `read_file` tool is what adds the line-number gutter.
  */
 function buildReadCommand(
   filePath: string,
@@ -233,7 +236,7 @@ function buildReadCommand(
   return [
     `if [ ! -f ${quotedPath} ]; then echo "Error: File not found"; exit 1; fi`,
     `if [ ! -s ${quotedPath} ]; then echo "System reminder: File exists but has empty contents"; exit 0; fi`,
-    `awk 'NR >= ${start} && NR <= ${end} { printf "%6d\\t%s\\n", NR, $0 }' ${quotedPath}`,
+    `awk 'NR >= ${start} && NR <= ${end} { printf "%s\\n", $0 }' ${quotedPath}`,
   ].join("; ");
 }
 
@@ -332,7 +335,7 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
   }
 
   /**
-   * Read file content with line numbers.
+   * Read file content.
    *
    * Uses pure POSIX shell (awk) via execute() — only the requested slice
    * is returned over the wire, making this efficient for large files.
@@ -341,7 +344,7 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
    * @param filePath - Absolute file path
    * @param offset - Line offset to start reading from (0-indexed)
    * @param limit - Maximum number of lines to read
-   * @returns Formatted file content with line numbers, or error message
+   * @returns ReadResult with raw content on success or error on failure
    */
   async read(
     filePath: string,

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -1148,6 +1148,25 @@ describe("createFilesystemMiddleware", () => {
   });
 
   describe("tools", () => {
+    it("read_file tool numbers backend content exactly once", async () => {
+      // Backends return raw content and this tool owns the gutter. A backend
+      // that numbers lines itself (the sandbox awk command used to) produced a
+      // doubled gutter like "     1\t     1\t{".
+      const mockBackend = createMockSandboxBackend();
+      mockBackend.read = vi
+        .fn()
+        .mockResolvedValue({ content: "line1\nline2", mimeType: "text/plain" });
+      const middleware = createFilesystemMiddleware({ backend: mockBackend });
+
+      const readFileTool = middleware.tools!.find(
+        (tool) => tool.name === "read_file",
+      ) as any;
+      const result = await readFileTool.invoke({ file_path: "/doc.txt" });
+
+      const text = Array.isArray(result) ? result[0].text : result;
+      expect(text).toBe("     1\tline1\n     2\tline2");
+    });
+
     it("write_file schema should require content", () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),


### PR DESCRIPTION
## Summary

The sandbox awk command was numbering lines, then read_file numbered them again. Other backends already return raw content.

- `BaseSandbox.read()` was emitting `cat -n` style line numbers from awk, and `read_file` numbered the same content again, so the model saw a doubled gutter.
- The sandbox now returns raw file content like the other backends; the tool still owns the single gutter. Python already works this way (`BaseSandbox` paginates raw text, middleware calls `format_content_with_line_numbers` once).

## Test plan
- [x] `pnpm vitest run` in `libs/deepagents` (1384 passed)
- [x] Regression tests for raw sandbox output + single `read_file` gutter
- [x] Changeset added for affected package(s)