### PR TITLE
fix(deepagents): accept permission paths equal to a composite route root

### DIFF
--- a/.changeset/permission-path-equal-route.md
+++ b/.changeset/permission-path-equal-route.md
@@ -4,4 +4,4 @@
 
 fix(deepagents): accept permission paths that exactly equal a composite route
 
-A permission path equal to a single-file mount (e.g. `/instructions.md`) was rejected when the backend supported execution, forcing users to write `/instructions.md/**`. The route-scoping check now also accepts the route root itself, matching Python deepagents. Sibling prefixes such as `/workspace2/**` for route `/workspace` remain rejected.
+A permission path equal to a single-file mount (e.g. `/instructions.md`) was rejected when the backend supported execution, forcing users to write `/instructions.md/**`. The route-scoping check now also accepts the route root itself. Sibling prefixes such as `/workspace2/**` for route `/workspace` remain rejected.

--- a/.changeset/permission-path-equal-route.md
+++ b/.changeset/permission-path-equal-route.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): accept permission paths that exactly equal a composite route
+
+A permission path equal to a single-file mount (e.g. `/instructions.md`) was rejected when the backend supported execution, forcing users to write `/instructions.md/**`. The route-scoping check now also accepts the route root itself, matching Python deepagents. Sibling prefixes such as `/workspace2/**` for route `/workspace` remain rejected.

--- a/libs/deepagents/src/middleware/fs.permissions.test.ts
+++ b/libs/deepagents/src/middleware/fs.permissions.test.ts
@@ -979,6 +979,34 @@ describe("fs tool permissions", () => {
       );
     });
 
+    it("does not throw when a permission path exactly equals a file-mount route", () => {
+      const compositeWithSandbox = {
+        ...createSandboxBackend(),
+        routePrefixes: ["/instructions.md"],
+      } as unknown as BackendProtocolV2;
+
+      expect(() =>
+        createFilesystemMiddleware({
+          backend: compositeWithSandbox,
+          permissions: [deny(["/instructions.md"])],
+        }),
+      ).not.toThrow();
+    });
+
+    it("does not throw when a permission path exactly equals a directory route root", () => {
+      const compositeWithSandbox = {
+        ...createSandboxBackend(),
+        routePrefixes: ["/workspace/"],
+      } as unknown as BackendProtocolV2;
+
+      expect(() =>
+        createFilesystemMiddleware({
+          backend: compositeWithSandbox,
+          permissions: [deny(["/workspace"])],
+        }),
+      ).not.toThrow();
+    });
+
     it("throws when a permission path shares a prefix with but is outside a route (no trailing slash confusion)", () => {
       const compositeWithSandbox = {
         ...createSandboxBackend(),

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -1690,9 +1690,11 @@ function allPathsScopedToRoutes(
 
   return permissions.every((rule) =>
     rule.paths.every((path) =>
-      prefixes.some((prefix) =>
-        path.startsWith(prefix.endsWith("/") ? prefix : `${prefix}/`),
-      ),
+      prefixes.some((prefix) => {
+        const normalizedRoute = prefix.endsWith("/") ? prefix : `${prefix}/`;
+        const routeRoot = normalizedRoute.slice(0, -1);
+        return path === routeRoot || path.startsWith(normalizedRoute);
+      }),
     ),
   );
 }


### PR DESCRIPTION
## Description

When filesystem `permissions` are combined with an execution-capable backend, `createFilesystemMiddleware` requires every permission path to be scoped to a `CompositeBackend` route. That check required a trailing separator, so a permission path that exactly equals a single-file mount (route `/instructions.md`, permission `/instructions.md`) was rejected and users had to write `/instructions.md/**`. Python deepagents accepts the exact form; this syncs JS with it by also accepting the route root itself, mirroring `CompositeBackend.isPathWithinRoute`. It deliberately does not adopt Python's looser bare `startsWith`, so sibling prefixes like `/workspace2/**` for route `/workspace` are still rejected.

## Test Plan
- [ ] `npx vitest run src/middleware/fs.permissions.test.ts` in `libs/deepagents` (new cases: exact file-mount route and exact directory route root are accepted; sibling-prefix and `/**` rejections unchanged).

Made by [Open SWE](https://openswe.vercel.app/agents/2758c734-16e9-54c3-b89f-ce698a566e71)
