### PR TITLE
chore(deepagents): widen langsmith peer range to >=0.7.1 <0.10.0

### DIFF
--- a/.changeset/widen-langsmith-peer-range.md
+++ b/.changeset/widen-langsmith-peer-range.md
@@ -4,6 +4,4 @@
 
 chore(deepagents): widen the `langsmith` peer range to `>=0.7.1 <0.10.0`
 
-`^0.7.1` resolves to at most 0.7.17, the last release on that line, so the range was pinned to a line langsmith has moved off. Because langsmith is a real dependency of `@langchain/core` rather than only a peer, the narrow range split installs across two langsmith copies — including inside this workspace, where `libs/deepagents` resolved 0.7.10 while `langchain` and `@langchain/langgraph` beside it resolved 0.8.9. Two copies means two sets of module-level singletons, so widening collapses them onto one.
-
 The upper bound stops below 0.10.0 rather than 1.0.0 because langsmith is pre-1.0 and ships breaking changes in minor bumps, so a new minor should be adopted deliberately instead of pre-authorized.

--- a/.changeset/widen-langsmith-peer-range.md
+++ b/.changeset/widen-langsmith-peer-range.md
@@ -1,0 +1,9 @@
+---
+"deepagents": patch
+---
+
+chore(deepagents): widen the `langsmith` peer range to `>=0.7.1 <0.10.0`
+
+`^0.7.1` resolves to at most 0.7.17, the last release on that line, so the range was pinned to a line langsmith has moved off. Because langsmith is a real dependency of `@langchain/core` rather than only a peer, the narrow range split installs across two langsmith copies — including inside this workspace, where `libs/deepagents` resolved 0.7.10 while `langchain` and `@langchain/langgraph` beside it resolved 0.8.9. Two copies means two sets of module-level singletons, so widening collapses them onto one.
+
+The upper bound stops below 0.10.0 rather than 1.0.0 because langsmith is pre-1.0 and ships breaking changes in minor bumps, so a new minor should be adopted deliberately instead of pre-authorized.

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -104,7 +104,7 @@
     "@langchain/langgraph-checkpoint": "^1.1.5",
     "@langchain/langgraph-sdk": "^1.9.23",
     "langchain": "^1.5.10",
-    "langsmith": "^0.7.1"
+    "langsmith": ">=0.7.1 <0.10.0"
   },
   "files": [
     "dist/**/*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,8 +632,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       langsmith:
-        specifier: ^0.7.1
-        version: 0.7.10(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
+        specifier: '>=0.7.1 <0.10.0'
+        version: 0.8.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -3181,26 +3181,6 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.2.9
-
-  langsmith@0.7.10:
-    resolution: {integrity: sha512-3EjJx9zGMzqF60eT9JADHF+Hn/T5ayTgEVp4d3M5yvJIJi3q6seX0p5jT8ecBCWBi1kIvvssWrcDxfwgSier7Q==}
-    peerDependencies:
-      '@opentelemetry/api': '*'
-      '@opentelemetry/exporter-trace-otlp-proto': '*'
-      '@opentelemetry/sdk-trace-base': '*'
-      openai: '*'
-      ws: '>=7'
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@opentelemetry/exporter-trace-otlp-proto':
-        optional: true
-      '@opentelemetry/sdk-trace-base':
-        optional: true
-      openai:
-        optional: true
-      ws:
-        optional: true
 
   langsmith@0.8.9:
     resolution: {integrity: sha512-6ikTB5SO+3SlBQ/+oH8K/JzhglxB8AM4RAe5bHzgWSEIHTgTe+b71bSjf1fDvlYuEXoiPn6uP10BbczrbznUnA==}
@@ -6307,16 +6287,6 @@ snapshots:
       - svelte
       - vue
       - ws
-
-  langsmith@0.7.10(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1):
-    dependencies:
-      p-queue: 6.6.2
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/exporter-trace-otlp-proto': 0.220.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
-      openai: 6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3)
-      ws: 8.21.1
 
   langsmith@0.8.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1):
     dependencies:


### PR DESCRIPTION
`langsmith` is declared as `^0.7.1`, which resolves to at most **0.7.17** — the last release on that line. langsmith is now on 0.9.x, so the range is pinned to a line it has moved off.

This matters more than a stale range usually would, because `langsmith` is a real **dependency** of `@langchain/core` (`>=0.5.0 <1.0.0`), not only a peer. So the narrow range doesn't just warn — it splits installs across two langsmith copies, and two copies means two sets of module-level singletons.

That split is already present in this workspace:

```
deepagents link:../../libs/deepagents
└── langsmith 0.7.10          <-- constrained by ^0.7.1
langchain 1.5.10
  └── langsmith 0.8.9
@langchain/langgraph 1.4.12
  └── langsmith 0.8.9
```

After this change the lockfile collapses to a single `langsmith@0.8.9`.

It also currently blocks downstream consumers: a service that bumps to langsmith 0.9.x while depending on deepagents gets both an unmet-peer warning and the dual-copy split, which surfaces as `tsc` errors like *"Types have separate declarations of a private property 'apiKey'"* where a `Client` crosses into `@langchain/core`'s tracer types.

### Why `<0.10.0` and not `<1.0.0`

langsmith is pre-1.0 and ships breaking changes in minor bumps — the generated v2 client paths moved from `/v2/...` to `/api/v2/...` within the 0.7 → 0.8 minor, for example. So a new minor should be adopted deliberately rather than pre-authorized. `<0.10.0` covers every line that exists today and forces a conscious bump at 0.10.

### Why widen rather than move to `^0.9`

Raising the floor to 0.9 would be a breaking change for consumers still on 0.7.x/0.8.x, so it would need a major bump. Widening is backward-compatible and unblocks the same people.

`deepagents`' langsmith surface is small — `Client`, plus `SandboxClient` / `Sandbox` / `LangSmithResourceNotFoundError` / `LangSmithSandboxError` and four option types from `langsmith/experimental/sandbox` — and all of it is present and unchanged across 0.8 and 0.9.

## Test Plan

- [x] `pnpm --filter deepagents typecheck` on the deduped 0.8.9 resolution — clean
- [x] Same, with `langsmith` forced to 0.9.0 — clean
- [x] `pnpm --filter deepagents test:unit` against 0.9.0 — 43 files, 1395 tests passing, no type errors
- [x] `pnpm format:check` and `pnpm lint` — clean
- [x] Maintainer sanity-check on the upper bound; happy to use `<0.9.0` if you'd rather not bless 0.9 yet

One thing I noticed but did not change: `langsmith` is a peer with no corresponding `devDependencies` entry, so CI exercises whatever resolves transitively (0.7.10 before this change, 0.8.9 after) rather than the peer range's edges. Pinning a dev version would make the peer explicitly tested — happy to add it here or leave it as a follow-up.

Authored by Claude (Claude Code).