### PR TITLE
fix(acp): honor per-session workspace roots

### DIFF
--- a/.changeset/session-workspace-roots.md
+++ b/.changeset/session-workspace-roots.md
@@ -1,0 +1,5 @@
+---
+"deepagents-acp": patch
+---
+
+Honor each ACP session's `cwd` when creating filesystem backends and running terminal commands.

--- a/.changeset/session-workspace-roots.md
+++ b/.changeset/session-workspace-roots.md
@@ -2,4 +2,4 @@
 "deepagents-acp": patch
 ---
 
-Honor each ACP session's `cwd` when creating filesystem backends and running terminal commands.
+Honor each ACP session's `cwd` when creating filesystem backends.

--- a/libs/acp/src/cli.int.test.ts
+++ b/libs/acp/src/cli.int.test.ts
@@ -411,6 +411,22 @@ describe("CLI Integration Tests", () => {
       );
     });
 
+    it("should create the CLI filesystem backend from the session cwd", async () => {
+      const sessionCwd = path.join(tempDir, "session-workspace");
+      fs.mkdirSync(sessionCwd);
+
+      const response = await helper.sendRequest("session/new", {
+        cwd: sessionCwd,
+        mcpServers: [],
+      });
+
+      expect(response.error).toBeUndefined();
+      const stderr = helper.getStderr().join("\n");
+      expect(stderr).toContain("Creating FilesystemBackend");
+      expect(stderr).toContain(sessionCwd);
+      expect(stderr).not.toContain("Using custom backend");
+    });
+
     it("should return available modes in new session", async () => {
       const response = await helper.sendRequest("session/new", {
         cwd: process.cwd(),

--- a/libs/acp/src/cli.ts
+++ b/libs/acp/src/cli.ts
@@ -20,7 +20,6 @@
  */
 
 import { DeepAgentsServer } from "./server.js";
-import { FilesystemBackend } from "deepagents";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -307,7 +306,6 @@ async function main(): Promise<void> {
         name: options.name,
         description: options.description,
         model: options.model,
-        backend: new FilesystemBackend({ rootDir: workspaceRoot }),
         skills,
         memory,
       },

--- a/libs/acp/src/server.test.ts
+++ b/libs/acp/src/server.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createDeepAgent } from "deepagents";
 import { DeepAgentsServer } from "./server.js";
 import type {
   DeepAgentConfig,
@@ -332,6 +333,98 @@ describe("DeepAgentsServer handlers", () => {
       expect(result.sessionId).toBeDefined();
       expect(result.sessionId).toMatch(/^sess_/);
       expect(serverAny.sessions.has(result.sessionId)).toBe(true);
+    });
+
+    it("should use the session cwd as its workspace root", async () => {
+      const server = new DeepAgentsServer({
+        agents: { name: "test-agent" },
+        workspaceRoot: "/default/workspace",
+      });
+
+      const serverAny = server as unknown as {
+        handleNewSession: (
+          params: Record<string, unknown>,
+          conn: unknown,
+        ) => Promise<{ sessionId: string }>;
+        sessions: Map<string, SessionState>;
+      };
+
+      const mockConn = { sessionUpdate: vi.fn().mockResolvedValue(undefined) };
+      const { sessionId } = await serverAny.handleNewSession(
+        { cwd: "/session/workspace" },
+        mockConn,
+      );
+
+      expect(serverAny.sessions.get(sessionId)?.workspaceRoot).toBe(
+        "/session/workspace",
+      );
+    });
+
+    it("should fall back to the server workspace for sessions without cwd", async () => {
+      const server = new DeepAgentsServer({
+        agents: { name: "test-agent" },
+        workspaceRoot: "/default/workspace",
+      });
+
+      const serverAny = server as unknown as {
+        handleNewSession: (
+          params: Record<string, unknown>,
+          conn: unknown,
+        ) => Promise<{ sessionId: string }>;
+        sessions: Map<string, SessionState>;
+      };
+
+      const mockConn = { sessionUpdate: vi.fn().mockResolvedValue(undefined) };
+      const { sessionId } = await serverAny.handleNewSession({}, mockConn);
+
+      expect(serverAny.sessions.get(sessionId)?.workspaceRoot).toBe(
+        "/default/workspace",
+      );
+    });
+
+    it("should keep workspace roots isolated across sessions", async () => {
+      const server = new DeepAgentsServer({
+        agents: { name: "test-agent" },
+      });
+
+      const serverAny = server as unknown as {
+        handleNewSession: (
+          params: Record<string, unknown>,
+          conn: unknown,
+        ) => Promise<{ sessionId: string }>;
+        sessions: Map<string, SessionState>;
+        agents: Map<string, unknown>;
+      };
+
+      const mockConn = { sessionUpdate: vi.fn().mockResolvedValue(undefined) };
+      const createAgentMock = vi.mocked(createDeepAgent);
+      const callStart = createAgentMock.mock.calls.length;
+      const first = await serverAny.handleNewSession(
+        { cwd: "/workspace/one" },
+        mockConn,
+      );
+      const second = await serverAny.handleNewSession(
+        { cwd: "/workspace/two" },
+        mockConn,
+      );
+
+      expect(serverAny.sessions.get(first.sessionId)?.workspaceRoot).toBe(
+        "/workspace/one",
+      );
+      expect(serverAny.sessions.get(second.sessionId)?.workspaceRoot).toBe(
+        "/workspace/two",
+      );
+      expect(serverAny.agents.has(first.sessionId)).toBe(true);
+      expect(serverAny.agents.has(second.sessionId)).toBe(true);
+
+      const firstBackend = createAgentMock.mock.calls[callStart]![0]
+        .backend as unknown as {
+        rootDir: string;
+      };
+      const secondBackend = createAgentMock.mock.calls[callStart + 1]![0]
+        .backend as unknown as { rootDir: string };
+      expect(firstBackend.rootDir).toBe("/workspace/one");
+      expect(secondBackend.rootDir).toBe("/workspace/two");
     });
 
     it("should throw for unknown agent", async () => {
@@ -1277,7 +1370,10 @@ describe("Terminal Integration", () => {
       createTerminal: vi.fn().mockResolvedValue(mockTerminal),
     };
 
-    const { sessionId } = await serverAny.handleNewSession({}, mockConn);
+    const { sessionId } = await serverAny.handleNewSession(
+      { cwd: "/session/project" },
+      mockConn,
+    );
     const session = serverAny.sessions.get(sessionId)!;
 
     await serverAny.executeWithTerminal(session, mockConn, {
@@ -1291,7 +1387,7 @@ describe("Terminal Integration", () => {
     expect(createParams.sessionId).toBe(sessionId);
     expect(createParams.command).toBe("/bin/bash");
     expect(createParams.args).toEqual(["-c", "ls -la"]);
-    expect(createParams.cwd).toBe("/project");
+    expect(createParams.cwd).toBe("/session/project");
   });
 
   it("should return error when no command specified", async () => {

--- a/libs/acp/src/server.test.ts
+++ b/libs/acp/src/server.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createDeepAgent } from "deepagents";
 import { DeepAgentsServer } from "./server.js";
+import { ACPFilesystemBackend } from "./acp-filesystem-backend.js";
 import type {
   DeepAgentConfig,
   DeepAgentsServerOptions,
@@ -417,14 +418,62 @@ describe("DeepAgentsServer handlers", () => {
       expect(serverAny.agents.has(first.sessionId)).toBe(true);
       expect(serverAny.agents.has(second.sessionId)).toBe(true);
 
-      const firstBackend = createAgentMock.mock.calls[callStart]![0]
-        .backend as unknown as {
+      const firstCallOptions = createAgentMock.mock.calls[callStart]?.[0];
+      const secondCallOptions = createAgentMock.mock.calls[callStart + 1]?.[0];
+      expect(firstCallOptions).toBeDefined();
+      expect(secondCallOptions).toBeDefined();
+      const firstBackend = firstCallOptions?.backend as unknown as {
         rootDir: string;
       };
-      const secondBackend = createAgentMock.mock.calls[callStart + 1]![0]
-        .backend as unknown as { rootDir: string };
+      const secondBackend = secondCallOptions?.backend as unknown as {
+        rootDir: string;
+      };
       expect(firstBackend.rootDir).toBe("/workspace/one");
       expect(secondBackend.rootDir).toBe("/workspace/two");
+    });
+
+    it("should create an ACP filesystem backend from the session cwd", async () => {
+      const server = new DeepAgentsServer({
+        agents: { name: "test-agent" },
+        workspaceRoot: "/default/workspace",
+      });
+
+      const mockConn = {
+        sessionUpdate: vi.fn().mockResolvedValue(undefined),
+        readTextFile: vi.fn().mockResolvedValue({ text: "" }),
+        writeTextFile: vi.fn().mockResolvedValue({}),
+      };
+      const serverAny = server as unknown as {
+        connection: typeof mockConn;
+        handleInitialize: (params: Record<string, unknown>) => Promise<unknown>;
+        handleNewSession: (
+          params: Record<string, unknown>,
+          conn: typeof mockConn,
+        ) => Promise<{ sessionId: string }>;
+        acpBackends: Map<string, ACPFilesystemBackend>;
+      };
+      serverAny.connection = mockConn;
+      await serverAny.handleInitialize({
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+        },
+      });
+
+      const createAgentMock = vi.mocked(createDeepAgent);
+      const callStart = createAgentMock.mock.calls.length;
+      const { sessionId } = await serverAny.handleNewSession(
+        { cwd: "/session/workspace" },
+        mockConn,
+      );
+
+      const backend = serverAny.acpBackends.get(sessionId);
+      expect(backend).toBeInstanceOf(ACPFilesystemBackend);
+      expect((backend as unknown as { rootDir: string }).rootDir).toBe(
+        "/session/workspace",
+      );
+      const createAgentOptions = createAgentMock.mock.calls[callStart]?.[0];
+      expect(createAgentOptions).toBeDefined();
+      expect(createAgentOptions?.backend).toBe(backend);
     });
 
     it("should throw for unknown agent", async () => {

--- a/libs/acp/src/server.test.ts
+++ b/libs/acp/src/server.test.ts
@@ -420,12 +420,13 @@ describe("DeepAgentsServer handlers", () => {
 
       const firstCallOptions = createAgentMock.mock.calls[callStart]?.[0];
       const secondCallOptions = createAgentMock.mock.calls[callStart + 1]?.[0];
-      expect(firstCallOptions).toBeDefined();
-      expect(secondCallOptions).toBeDefined();
-      const firstBackend = firstCallOptions?.backend as unknown as {
+      if (!firstCallOptions || !secondCallOptions) {
+        throw new Error("Expected one agent to be created for each session");
+      }
+      const firstBackend = firstCallOptions.backend as unknown as {
         rootDir: string;
       };
-      const secondBackend = secondCallOptions?.backend as unknown as {
+      const secondBackend = secondCallOptions.backend as unknown as {
         rootDir: string;
       };
       expect(firstBackend.rootDir).toBe("/workspace/one");

--- a/libs/acp/src/server.ts
+++ b/libs/acp/src/server.ts
@@ -320,6 +320,8 @@ export class DeepAgentsServer {
     this.isRunning = false;
     this.connection = null;
     this.sessions.clear();
+    this.agents.clear();
+    this.acpBackends.clear();
     this.log("Server stopped");
 
     // Close the logger to flush any pending writes
@@ -451,6 +453,10 @@ export class DeepAgentsServer {
     const session: SessionState = {
       id: sessionId,
       agentName,
+      workspaceRoot:
+        typeof params.cwd === "string" && params.cwd
+          ? params.cwd
+          : this.workspaceRoot,
       threadId,
       messages: [],
       createdAt: new Date(),
@@ -460,11 +466,9 @@ export class DeepAgentsServer {
 
     this.sessions.set(sessionId, session);
 
-    if (!this.agents.has(agentName)) {
-      this.createAgent(agentName);
-    }
+    this.createAgent(session);
 
-    const acpBackend = this.acpBackends.get(agentName);
+    const acpBackend = this.acpBackends.get(sessionId);
     if (acpBackend) {
       acpBackend.setSessionId(sessionId);
     }
@@ -521,7 +525,7 @@ export class DeepAgentsServer {
     });
     session.lastActivityAt = new Date();
 
-    const acpBackend = this.acpBackends.get(session.agentName);
+    const acpBackend = this.acpBackends.get(sessionId);
     if (acpBackend) {
       acpBackend.setSessionId(sessionId);
     }
@@ -571,7 +575,7 @@ export class DeepAgentsServer {
       throw new Error(`Session not found: ${sessionId}`);
     }
 
-    const agent = this.agents.get(session.agentName);
+    const agent = this.agents.get(sessionId);
 
     if (!agent) {
       this.log("Prompt failed: agent not found:", session.agentName);
@@ -955,7 +959,7 @@ export class DeepAgentsServer {
         sessionId: session.id,
         command: "/bin/bash",
         args: ["-c", command],
-        cwd: this.workspaceRoot,
+        cwd: session.workspaceRoot,
       } as any);
 
       await this.sendToolCallUpdate(session.id, conn, {
@@ -1222,7 +1226,7 @@ export class DeepAgentsServer {
     const locations = extractToolCallLocations(
       toolCall.name,
       toolCall.args,
-      this.workspaceRoot,
+      this.sessions.get(sessionId)?.workspaceRoot ?? this.workspaceRoot,
     );
 
     await conn.sessionUpdate({
@@ -1302,7 +1306,8 @@ export class DeepAgentsServer {
   /**
    * Create a DeepAgent instance for the given configuration
    */
-  private createAgent(agentName: string): void {
+  private createAgent(session: SessionState): void {
+    const { agentName, workspaceRoot, id: sessionId } = session;
     const config = this.agentConfigs.get(agentName);
 
     if (!config) {
@@ -1320,7 +1325,7 @@ export class DeepAgentsServer {
     });
 
     // Create backend - prefer ACP filesystem if client supports it
-    const backend = this.createBackend(config);
+    const backend = this.createBackend(config, sessionId, workspaceRoot);
 
     const agent = createDeepAgent({
       model: config.model,
@@ -1339,12 +1344,19 @@ export class DeepAgentsServer {
       name: config.name,
     });
 
-    this.agents.set(agentName, agent);
-    this.log("Agent created successfully:", agentName);
+    this.agents.set(sessionId, agent);
+    this.log(
+      "Agent created successfully:",
+      agentName,
+      "for session:",
+      sessionId,
+    );
   }
 
   private createBackend(
     config: DeepAgentConfig,
+    sessionId: string,
+    workspaceRoot: string,
   ): BackendProtocol | BackendFactory {
     if (config.backend) {
       this.log("Using custom backend for agent:", config.name);
@@ -1359,15 +1371,15 @@ export class DeepAgentsServer {
       this.log("Creating ACPFilesystemBackend for agent:", config.name);
       const backend = new ACPFilesystemBackend({
         conn: this.connection,
-        rootDir: this.workspaceRoot,
+        rootDir: workspaceRoot,
       });
-      this.acpBackends.set(config.name, backend);
+      this.acpBackends.set(sessionId, backend);
       return backend;
     }
 
-    this.log("Creating FilesystemBackend:", { rootDir: this.workspaceRoot });
+    this.log("Creating FilesystemBackend:", { rootDir: workspaceRoot });
     return new FilesystemBackend({
-      rootDir: this.workspaceRoot,
+      rootDir: workspaceRoot,
     });
   }
 

--- a/libs/acp/src/types.ts
+++ b/libs/acp/src/types.ts
@@ -181,6 +181,11 @@ export interface SessionState {
   agentName: string;
 
   /**
+   * Workspace root for this session
+   */
+  workspaceRoot: string;
+
+  /**
    * LangGraph thread ID for state persistence
    */
   threadId: string;


### PR DESCRIPTION
## Problem

ACP clients provide a workspace in session/new.cwd, but the server ignored it and reused one agent/backend per configured agent. Filesystem operations could therefore run against the server process workspace, and concurrent sessions could share the wrong backend session ID.

## Fix

- Store a workspace root on each session, falling back to the server default.
- Create the agent and filesystem backend per session so roots and ACP session IDs remain isolated.
- Let the default CLI configuration use the server-selected per-session backend, including ACP filesystem capabilities when available.
- Use the session root for filesystem backends and tool-call locations.
- Add a patch changeset and regression coverage for explicit cwd, fallback behavior, ACP-backed sessions, CLI behavior, and two independent workspaces.

## Test

- pnpm --filter deepagents build
- pnpm --filter deepagents-acp build
- pnpm --filter deepagents-acp test:unit (160 passed)
- pnpm --filter deepagents-acp test:int (33 passed)
- oxlint and oxfmt checks on the changed ACP files

The standalone package typecheck still reports the pre-existing ACP SDK/backend type incompatibilities also present on main; this change adds no new diagnostics.

Closes #654