### PR TITLE
feat(deepagents,acp,node-vfs): report remaining lines for paginated file reads

### DIFF
--- a/.changeset/bright-acp-pages.md
+++ b/.changeset/bright-acp-pages.md
@@ -1,0 +1,7 @@
+---
+"deepagents-acp": patch
+---
+
+fix(filesystem): preserve pagination metadata for ACP-backed reads
+
+Return source ranges, total line counts, and continuation offsets when reading paginated editor buffers through ACP.

--- a/.changeset/calm-files-page.md
+++ b/.changeset/calm-files-page.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+feat(filesystem): report remaining lines for paginated file reads
+
+Add optional read pagination metadata across built-in backends and append a model-facing continuation notice when more source lines remain. Size-based truncation now preserves complete source-line boundaries and recalculates the next offset so subsequent reads do not skip hidden content.

--- a/.changeset/tidy-vfs-pages.md
+++ b/.changeset/tidy-vfs-pages.md
@@ -1,0 +1,7 @@
+---
+"@langchain/node-vfs": patch
+---
+
+fix(filesystem): return pagination metadata for virtual file reads
+
+Include source ranges, total line counts, and continuation offsets for paginated text reads from the Node VFS backend.

--- a/libs/acp/src/acp-filesystem-backend.test.ts
+++ b/libs/acp/src/acp-filesystem-backend.test.ts
@@ -103,6 +103,12 @@ describe("ACPFilesystemBackend", () => {
       const result = await backend.read(path.join(tmpDir, "local.txt"), 1, 2);
 
       expect(result.content).toBe("line1\nline2");
+      expect(result).toMatchObject({
+        totalLines: 5,
+        startLine: 2,
+        endLine: 3,
+        nextOffset: 3,
+      });
     });
 
     it("should pass sessionId in readTextFile call", async () => {

--- a/libs/acp/src/acp-filesystem-backend.ts
+++ b/libs/acp/src/acp-filesystem-backend.ts
@@ -9,6 +9,7 @@
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
 import {
   FilesystemBackend,
+  normalizeReadPagination,
   type WriteResult,
   type ReadResult,
 } from "deepagents";
@@ -60,9 +61,32 @@ export class ACPFilesystemBackend extends FilesystemBackend {
 
       if (offset != null || limit != null) {
         const lines = text.split("\n");
-        const start = offset ?? 0;
-        const end = limit != null ? start + limit : lines.length;
-        text = lines.slice(start, end).join("\n");
+        const totalLines =
+          lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+        const normalized = normalizeReadPagination(
+          offset ?? 0,
+          limit ?? lines.length,
+        );
+        const start = normalized.offset;
+        const readLimit = normalized.limit;
+        const sliceEnd = Math.min(start + readLimit, lines.length);
+        const end = Math.min(sliceEnd, totalLines);
+        const selected = lines.slice(start, sliceEnd);
+        text = selected.join("\n");
+        if (
+          selected.length > 0 &&
+          start >= 0 &&
+          start < totalLines &&
+          readLimit > 0
+        ) {
+          return {
+            content: text,
+            totalLines,
+            startLine: start + 1,
+            endLine: end,
+            nextOffset: end < totalLines ? end : undefined,
+          };
+        }
       }
 
       return { content: text };

--- a/libs/deepagents/src/backends/context-hub.test.ts
+++ b/libs/deepagents/src/backends/context-hub.test.ts
@@ -124,6 +124,27 @@ describe("ContextHubBackend", () => {
     const result = await backend.read("/a.md", 1, 2);
     expect(result.error).toBeUndefined();
     expect(result.content).toBe("2\n3\n");
+    expect(result).toMatchObject({
+      totalLines: 5,
+      startLine: 2,
+      endLine: 3,
+      nextOffset: 3,
+    });
+  });
+
+  it("read paginates whitespace-only content", async () => {
+    const { backend } = makeBackend({
+      "blank.md": { type: "file", content: `${"\n".repeat(100)} ` },
+    });
+
+    const result = await backend.read("/blank.md", 0, 100);
+
+    expect(result).toMatchObject({
+      totalLines: 101,
+      startLine: 1,
+      endLine: 100,
+      nextOffset: 100,
+    });
   });
 
   it("read offset beyond file length returns an error", async () => {

--- a/libs/deepagents/src/backends/context-hub.ts
+++ b/libs/deepagents/src/backends/context-hub.ts
@@ -23,7 +23,7 @@ import type {
   WriteResult,
 } from "./protocol.js";
 import { applyGrepMaxCount } from "./protocol.js";
-import { performStringReplacement } from "./utils.js";
+import { normalizeReadPagination, performStringReplacement } from "./utils.js";
 
 const CONTEXT_URL_COMMIT_PATH_RE = /^\/context\/([^/]+)\/([0-9a-f]{8})$/;
 const LEGACY_URL_COMMIT_PATH_RE = /^\/hub\/([^/]+)\/([^/:]+):([0-9a-f]{8})$/;
@@ -183,8 +183,8 @@ function sliceReadContent(
   content: string,
   offset: number,
   limit: number,
-): { content?: string; error?: string } {
-  if (!content || content.trim() === "") {
+): ReadResult {
+  if (!content) {
     return { content };
   }
 
@@ -199,7 +199,17 @@ function sliceReadContent(
     };
   }
 
-  return { content: lines.slice(startIndex, endIndex).join("") };
+  const selected = lines.slice(startIndex, endIndex);
+  if (selected.length === 0 || offset < 0 || limit <= 0) {
+    return { content: selected.join("") };
+  }
+  return {
+    content: selected.join(""),
+    totalLines: lines.length,
+    startLine: startIndex + 1,
+    endLine: endIndex,
+    nextOffset: endIndex < lines.length ? endIndex : undefined,
+  };
 }
 
 function isLangSmithNotFoundError(error: unknown): boolean {
@@ -885,12 +895,18 @@ export class ContextHubBackend implements BackendProtocolV2 {
       return { error: `File '${filePath}' not found` };
     }
 
-    const sliced = sliceReadContent(content, offset, limit);
+    const { offset: normalizedOffset, limit: normalizedLimit } =
+      normalizeReadPagination(offset, limit);
+    const sliced = sliceReadContent(content, normalizedOffset, normalizedLimit);
     if (sliced.error) {
       return { error: sliced.error };
     }
 
-    return { content: sliced.content ?? "", mimeType: TEXT_MIME_TYPE };
+    return {
+      ...sliced,
+      content: sliced.content ?? "",
+      mimeType: TEXT_MIME_TYPE,
+    };
   }
 
   async readRaw(filePath: string): Promise<ReadRawResult> {

--- a/libs/deepagents/src/backends/filesystem.test.ts
+++ b/libs/deepagents/src/backends/filesystem.test.ts
@@ -328,6 +328,25 @@ describe("FilesystemBackend", () => {
     expect(txt.content).toContain("line3");
   });
 
+  it("should return pagination metadata for partial text reads", async () => {
+    const filePath = path.join(tmpDir, "paginated.txt");
+    await writeFile(filePath, "line1\nline2\nline3\nline4");
+    const backend = new FilesystemBackend({
+      rootDir: tmpDir,
+      virtualMode: false,
+    });
+
+    const result = await backend.read(filePath, 1, 2);
+
+    expect(result.content).toBe("line2\nline3");
+    expect(result).toMatchObject({
+      totalLines: 4,
+      startLine: 2,
+      endLine: 3,
+      nextOffset: 3,
+    });
+  });
+
   it("should handle empty files", async () => {
     const root = tmpDir;
     const filePath = path.join(root, "empty.txt");
@@ -391,6 +410,9 @@ describe("FilesystemBackend", () => {
     const txt = await backend.read(filePath);
     expect(txt.content).toContain("line1");
     expect(txt.content).toContain("line2");
+    expect(txt.totalLines).toBe(2);
+    expect(txt.endLine).toBe(2);
+    expect(txt.nextOffset).toBeUndefined();
   });
 
   it("should handle unicode content", async () => {

--- a/libs/deepagents/src/backends/filesystem.ts
+++ b/libs/deepagents/src/backends/filesystem.ts
@@ -35,6 +35,7 @@ import {
   checkEmptyContent,
   getMimeType,
   isTextMimeType,
+  normalizeReadPagination,
   performStringReplacement,
 } from "./utils.js";
 
@@ -284,18 +285,35 @@ export class FilesystemBackend implements BackendProtocolV2 {
         return { content: emptyMsg, mimeType };
       }
 
+      const { offset: normalizedOffset, limit: normalizedLimit } =
+        normalizeReadPagination(offset, limit);
       const lines = content.split("\n");
-      const startIdx = offset;
-      const endIdx = Math.min(startIdx + limit, lines.length);
+      const totalLines =
+        lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+      const sliceEndIdx = Math.min(
+        normalizedOffset + normalizedLimit,
+        lines.length,
+      );
+      const endIdx = Math.min(normalizedOffset + normalizedLimit, totalLines);
 
-      if (startIdx >= lines.length) {
+      if (normalizedOffset >= totalLines) {
         return {
-          error: `Line offset ${offset} exceeds file length (${lines.length} lines)`,
+          error: `Line offset ${normalizedOffset} exceeds file length (${totalLines} lines)`,
         };
       }
 
-      const selectedLines = lines.slice(startIdx, endIdx);
-      return { content: selectedLines.join("\n"), mimeType };
+      const selectedLines = lines.slice(normalizedOffset, sliceEndIdx);
+      if (selectedLines.length === 0 || normalizedLimit === 0) {
+        return { content: selectedLines.join("\n"), mimeType };
+      }
+      return {
+        content: selectedLines.join("\n"),
+        mimeType,
+        totalLines,
+        startLine: normalizedOffset + 1,
+        endLine: endIdx,
+        nextOffset: endIdx < totalLines ? endIdx : undefined,
+      };
     } catch (e: any) {
       return { error: `Error reading file '${filePath}': ${e.message}` };
     }

--- a/libs/deepagents/src/backends/protocol.ts
+++ b/libs/deepagents/src/backends/protocol.ts
@@ -167,6 +167,23 @@ export interface ReadResult {
   content?: string | Uint8Array;
   /** MIME type of the file, when available */
   mimeType?: string;
+  /**
+   * Total number of logical source lines for a text read, when known.
+   * Omitted for binary reads and for backends that cannot determine it.
+   */
+  totalLines?: number;
+  /**
+   * 1-indexed first source line represented by `content`.
+   * Text pagination fields are optional so older/custom backends remain valid.
+   */
+  startLine?: number;
+  /** 1-indexed last source line represented by `content`. */
+  endLine?: number;
+  /**
+   * 0-indexed offset of the next unread source line.
+   * Omitted when the returned text reaches EOF.
+   */
+  nextOffset?: number;
 }
 
 /**

--- a/libs/deepagents/src/backends/sandbox.test.ts
+++ b/libs/deepagents/src/backends/sandbox.test.ts
@@ -217,6 +217,42 @@ describe("BaseSandbox", () => {
       expect(result.content).toContain("line2");
     });
 
+    it("should return pagination metadata emitted by the sandbox", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.execute = vi.fn().mockResolvedValue({
+        output:
+          "     2\tline2\n     3\tline3\n__DEEPAGENTS_READ_METADATA__\t5\n",
+        exitCode: 0,
+        truncated: false,
+      });
+
+      const result = await sandbox.read("/test.txt", 1, 2);
+
+      expect(result.content).toBe("     2\tline2\n     3\tline3\n");
+      expect(result).toMatchObject({
+        totalLines: 5,
+        startLine: 2,
+        endLine: 3,
+        nextOffset: 3,
+      });
+    });
+
+    it("should strip sandbox metadata from truncated reads", async () => {
+      const sandbox = new MockSandbox();
+      sandbox.execute = vi.fn().mockResolvedValue({
+        output: "     2\tline2\n__DEEPAGENTS_READ_METADATA__\t5\n",
+        exitCode: 0,
+        truncated: true,
+      });
+
+      const result = await sandbox.read("/test.txt", 1, 2);
+
+      expect(result.content).toBe("     2\tline2\n");
+      expect(result.content).not.toContain("__DEEPAGENTS_READ_METADATA__");
+      expect(result.totalLines).toBeUndefined();
+      expect(result.nextOffset).toBeUndefined();
+    });
+
     it("should return error for non-existent file", async () => {
       const sandbox = new MockSandbox();
 

--- a/libs/deepagents/src/backends/sandbox.ts
+++ b/libs/deepagents/src/backends/sandbox.ts
@@ -31,7 +31,11 @@ import type {
   WriteResult,
 } from "./protocol.js";
 import { applyGrepMaxCount } from "./protocol.js";
-import { getMimeType, isTextMimeType } from "./utils.js";
+import {
+  getMimeType,
+  isTextMimeType,
+  normalizeReadPagination,
+} from "./utils.js";
 
 /**
  * Shell-quote a string using single quotes (POSIX).
@@ -232,6 +236,8 @@ function buildFindCommand(searchPath: string): string {
   return `{ ${listing}; } | head -n ${MAX_GLOB_FIND_LINES + 1}`;
 }
 
+const READ_METADATA_PREFIX = "__DEEPAGENTS_READ_METADATA__";
+
 /**
  * Pure POSIX shell command for reading files with line numbers.
  * Uses awk for line numbering with offset/limit — works on any Linux including Alpine.
@@ -256,8 +262,49 @@ function buildReadCommand(
   return [
     `if [ ! -f ${quotedPath} ]; then echo "Error: File not found"; exit 1; fi`,
     `if [ ! -s ${quotedPath} ]; then echo "System reminder: File exists but has empty contents"; exit 0; fi`,
-    `awk 'NR >= ${start} && NR <= ${end} { printf "%6d\\t%s\\n", NR, $0 }' ${quotedPath}`,
+    `awk 'NR >= ${start} && NR <= ${end} { printf "%6d\\t%s\\n", NR, $0 } END { printf "${READ_METADATA_PREFIX}\\t%d\\n", NR }' ${quotedPath}`,
   ].join("; ");
+}
+
+function parseReadOutput(
+  output: string,
+  offset: number,
+  limit: number,
+): ReadResult {
+  const rows = output.split("\n");
+  let metadataIndex = -1;
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    if (rows[index].startsWith(`${READ_METADATA_PREFIX}\t`)) {
+      metadataIndex = index;
+      break;
+    }
+  }
+  if (metadataIndex === -1) {
+    return { content: output };
+  }
+
+  const totalLines = Number(
+    rows[metadataIndex].slice(READ_METADATA_PREFIX.length + 1),
+  );
+  if (!Number.isSafeInteger(totalLines) || totalLines < 0) {
+    return { content: output };
+  }
+
+  const contentRows = rows.slice(0, metadataIndex);
+  const content = contentRows.length > 0 ? `${contentRows.join("\n")}\n` : "";
+  const startOffset = Math.floor(offset);
+  const endOffset = Math.min(startOffset + Math.floor(limit), totalLines);
+  if (startOffset >= totalLines || endOffset <= startOffset) {
+    return { content };
+  }
+
+  return {
+    content,
+    totalLines,
+    startLine: startOffset + 1,
+    endLine: endOffset,
+    nextOffset: endOffset < totalLines ? endOffset : undefined,
+  };
 }
 
 /**
@@ -383,17 +430,32 @@ export abstract class BaseSandbox implements SandboxBackendProtocolV2 {
       return { content: results[0].content, mimeType };
     }
 
-    // limit=0 means return nothing
-    if (limit === 0) return { content: "", mimeType };
+    const { offset: normalizedOffset, limit: normalizedLimit } =
+      normalizeReadPagination(offset, limit);
 
-    const command = buildReadCommand(filePath, offset, limit);
+    // limit=0 means return nothing
+    if (normalizedLimit === 0) return { content: "", mimeType };
+
+    const command = buildReadCommand(
+      filePath,
+      normalizedOffset,
+      normalizedLimit,
+    );
     const result = await this.execute(command);
 
     if (result.exitCode !== 0) {
       return { error: `File '${filePath}' not found` };
     }
 
-    return { content: result.output, mimeType };
+    const parsed = parseReadOutput(
+      result.output,
+      normalizedOffset,
+      normalizedLimit,
+    );
+    return {
+      ...(result.truncated ? { content: parsed.content } : parsed),
+      mimeType,
+    };
   }
 
   /**

--- a/libs/deepagents/src/backends/state.test.ts
+++ b/libs/deepagents/src/backends/state.test.ts
@@ -346,6 +346,12 @@ describe("StateBackend", () => {
     expect(readWithOffset.content).toContain("line4");
     expect(readWithOffset.content).not.toContain("line1");
     expect(readWithOffset.content).not.toContain("line5");
+    expect(readWithOffset).toMatchObject({
+      totalLines: 5,
+      startLine: 3,
+      endLine: 4,
+      nextOffset: 4,
+    });
   });
 
   it("should handle edit with replace_all", () => {

--- a/libs/deepagents/src/backends/state.ts
+++ b/libs/deepagents/src/backends/state.ts
@@ -31,6 +31,7 @@ import {
   isFileDataV1,
   isTextMimeType,
   migrateToFileDataV2,
+  normalizeReadPagination,
   performStringReplacement,
   updateFileData,
 } from "./utils.js";
@@ -235,9 +236,31 @@ export class StateBackend implements BackendProtocolV2 {
         error: `File '${filePath}' has binary content but text MIME type`,
       };
     }
+    const { offset: normalizedOffset, limit: normalizedLimit } =
+      normalizeReadPagination(offset, limit);
     const lines = fileDataV2.content.split("\n");
-    const selected = lines.slice(offset, offset + limit);
-    return { content: selected.join("\n"), mimeType: fileDataV2.mimeType };
+    const totalLines =
+      lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+    const selected = lines.slice(
+      normalizedOffset,
+      normalizedOffset + normalizedLimit,
+    );
+    if (
+      selected.length === 0 ||
+      normalizedOffset >= totalLines ||
+      normalizedLimit === 0
+    ) {
+      return { content: selected.join("\n"), mimeType: fileDataV2.mimeType };
+    }
+    const endOffset = Math.min(normalizedOffset + selected.length, totalLines);
+    return {
+      content: selected.join("\n"),
+      mimeType: fileDataV2.mimeType,
+      totalLines,
+      startLine: normalizedOffset + 1,
+      endLine: endOffset,
+      nextOffset: endOffset < totalLines ? endOffset : undefined,
+    };
   }
 
   /**

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -237,6 +237,12 @@ describe("StoreBackend", () => {
     expect(readWithOffset.content).toContain("line4");
     expect(readWithOffset.content).not.toContain("line1");
     expect(readWithOffset.content).not.toContain("line5");
+    expect(readWithOffset).toMatchObject({
+      totalLines: 5,
+      startLine: 3,
+      endLine: 4,
+      nextOffset: 4,
+    });
   });
 
   it("should handle edit with replace_all", async () => {

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -38,6 +38,7 @@ import {
   isFileDataV1,
   isTextMimeType,
   migrateToFileDataV2,
+  normalizeReadPagination,
   performStringReplacement,
   updateFileData,
 } from "./utils.js";
@@ -559,9 +560,34 @@ export class StoreBackend implements BackendProtocolV2 {
           error: `File '${filePath}' has binary content but text MIME type`,
         };
       }
+      const { offset: normalizedOffset, limit: normalizedLimit } =
+        normalizeReadPagination(offset, limit);
       const lines = fileDataV2.content.split("\n");
-      const selected = lines.slice(offset, offset + limit);
-      return { content: selected.join("\n"), mimeType: fileDataV2.mimeType };
+      const totalLines =
+        lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+      const selected = lines.slice(
+        normalizedOffset,
+        normalizedOffset + normalizedLimit,
+      );
+      if (
+        selected.length === 0 ||
+        normalizedOffset >= totalLines ||
+        normalizedLimit === 0
+      ) {
+        return { content: selected.join("\n"), mimeType: fileDataV2.mimeType };
+      }
+      const endOffset = Math.min(
+        normalizedOffset + selected.length,
+        totalLines,
+      );
+      return {
+        content: selected.join("\n"),
+        mimeType: fileDataV2.mimeType,
+        totalLines,
+        startLine: normalizedOffset + 1,
+        endLine: endOffset,
+        nextOffset: endOffset < totalLines ? endOffset : undefined,
+      };
     } catch (e: any) {
       return { error: e.message };
     }

--- a/libs/deepagents/src/backends/utils.test.ts
+++ b/libs/deepagents/src/backends/utils.test.ts
@@ -4,6 +4,7 @@ import {
   validateFilePath,
   sanitizeToolCallId,
   formatContentWithLineNumbers,
+  formatContentWithLineNumbersAndBoundaries,
   updateFileData,
   fileDataToString,
   checkEmptyContent,
@@ -19,6 +20,7 @@ import {
   adaptSandboxProtocol,
   grepMatchesFromFiles,
   globSearchFiles,
+  normalizeReadPagination,
 } from "./utils.js";
 import type {
   BackendProtocol,
@@ -29,6 +31,13 @@ import type {
   SandboxBackendProtocolV2,
 } from "./protocol.js";
 import { isSandboxBackend } from "./protocol.js";
+
+describe("normalizeReadPagination", () => {
+  it("clamps pagination arguments to non-negative integers", () => {
+    expect(normalizeReadPagination(-1, 2.9)).toEqual({ offset: 0, limit: 2 });
+    expect(normalizeReadPagination(3.8, -5)).toEqual({ offset: 3, limit: 0 });
+  });
+});
 
 describe("validatePath", () => {
   it("should add leading slash if missing", () => {
@@ -184,6 +193,24 @@ describe("formatContentWithLineNumbers", () => {
     const result = formatContentWithLineNumbers("line1\nline2\n");
     const lines = result.split("\n");
     expect(lines.length).toBe(2);
+  });
+
+  it("should return structured boundaries for complete source lines", () => {
+    const result = formatContentWithLineNumbersAndBoundaries("one\ntwo", 10);
+
+    expect(result.sourceLineBoundaries).toEqual([
+      { sourceLine: 10, endOffset: result.text.indexOf("\n") },
+      { sourceLine: 11, endOffset: result.text.length },
+    ]);
+  });
+
+  it("should place a long source line boundary after all continuation rows", () => {
+    const result = formatContentWithLineNumbersAndBoundaries("x".repeat(5001));
+
+    expect(result.text).toContain("1.1\t");
+    expect(result.sourceLineBoundaries).toEqual([
+      { sourceLine: 1, endOffset: result.text.length },
+    ]);
   });
 });
 

--- a/libs/deepagents/src/backends/utils.ts
+++ b/libs/deepagents/src/backends/utils.ts
@@ -34,6 +34,26 @@ export const TOOL_RESULT_TOKEN_LIMIT = 20000; // Same threshold as eviction
 export const TRUNCATION_GUIDANCE =
   "... [results truncated, try being more specific with your parameters]";
 
+/**
+ * Normalize model- or caller-supplied text pagination bounds.
+ *
+ * Every backend must slice content and calculate pagination metadata from the
+ * same normalized values. Otherwise a fractional or negative argument could
+ * return one window while advertising a different `nextOffset`.
+ *
+ * Binary reads do not use this helper because their backend contract ignores
+ * line-based offset and limit values.
+ */
+export function normalizeReadPagination(
+  offset: number,
+  limit: number,
+): { offset: number; limit: number } {
+  return {
+    offset: Number.isFinite(offset) ? Math.max(0, Math.floor(offset)) : 0,
+    limit: Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0,
+  };
+}
+
 const MIME_TYPES: Record<string, string> = {
   // images
   ".png": "image/png",
@@ -160,19 +180,30 @@ export function sanitizeToolCallId(toolCallId: string): string {
   return toolCallId.replace(/\./g, "_").replace(/\//g, "_").replace(/\\/g, "_");
 }
 
+export interface FormattedContentWithLineNumbers {
+  /** Complete line-numbered display text. */
+  text: string;
+  /**
+   * Character offsets immediately after each complete source line.
+   *
+   * A long source line may span several display rows (`12`, `12.1`, ...),
+   * but contributes only one boundary after its final chunk.
+   */
+  sourceLineBoundaries: Array<{ sourceLine: number; endOffset: number }>;
+}
+
 /**
- * Format file content with line numbers (cat -n style).
+ * Format file content with line numbers and structured source-line boundaries.
  *
- * Chunks lines longer than MAX_LINE_LENGTH with continuation markers (e.g., 5.1, 5.2).
- *
- * @param content - File content as string or list of lines
- * @param startLine - Starting line number (default: 1)
- * @returns Formatted content with line numbers and continuation markers
+ * The boundaries let downstream size limiting truncate only after complete
+ * source lines without reparsing the rendered gutter. This keeps presentation
+ * details (padding, tab separators, and continuation labels) encapsulated in
+ * the formatter that creates them.
  */
-export function formatContentWithLineNumbers(
+export function formatContentWithLineNumbersAndBoundaries(
   content: string | string[],
   startLine: number = 1,
-): string {
+): FormattedContentWithLineNumbers {
   let lines: string[];
   if (typeof content === "string") {
     lines = content.split("\n");
@@ -184,38 +215,67 @@ export function formatContentWithLineNumbers(
   }
 
   const resultLines: string[] = [];
+  const sourceLineBoundaries: Array<{
+    sourceLine: number;
+    endOffset: number;
+  }> = [];
+  let renderedLength = 0;
+
+  const appendRow = (
+    row: string,
+    sourceLine: number,
+    completesSourceLine: boolean,
+  ) => {
+    if (resultLines.length > 0) renderedLength += 1; // Inter-row newline.
+    resultLines.push(row);
+    renderedLength += row.length;
+    if (completesSourceLine) {
+      sourceLineBoundaries.push({ sourceLine, endOffset: renderedLength });
+    }
+  };
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const lineNum = i + startLine;
 
     if (line.length <= MAX_LINE_LENGTH) {
-      resultLines.push(
+      appendRow(
         `${lineNum.toString().padStart(LINE_NUMBER_WIDTH)}\t${line}`,
+        lineNum,
+        true,
       );
-    } else {
-      // Split long line into chunks with continuation markers
-      const numChunks = Math.ceil(line.length / MAX_LINE_LENGTH);
-      for (let chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
-        const start = chunkIdx * MAX_LINE_LENGTH;
-        const end = Math.min(start + MAX_LINE_LENGTH, line.length);
-        const chunk = line.substring(start, end);
-        if (chunkIdx === 0) {
-          // First chunk: use normal line number
-          resultLines.push(
-            `${lineNum.toString().padStart(LINE_NUMBER_WIDTH)}\t${chunk}`,
-          );
-        } else {
-          // Continuation chunks: use decimal notation (e.g., 5.1, 5.2)
-          const continuationMarker = `${lineNum}.${chunkIdx}`;
-          resultLines.push(
-            `${continuationMarker.padStart(LINE_NUMBER_WIDTH)}\t${chunk}`,
-          );
-        }
-      }
+      continue;
+    }
+
+    const numChunks = Math.ceil(line.length / MAX_LINE_LENGTH);
+    for (let chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
+      const start = chunkIdx * MAX_LINE_LENGTH;
+      const end = Math.min(start + MAX_LINE_LENGTH, line.length);
+      const chunk = line.substring(start, end);
+      const marker = chunkIdx === 0 ? `${lineNum}` : `${lineNum}.${chunkIdx}`;
+      appendRow(
+        `${marker.padStart(LINE_NUMBER_WIDTH)}\t${chunk}`,
+        lineNum,
+        chunkIdx === numChunks - 1,
+      );
     }
   }
 
-  return resultLines.join("\n");
+  return { text: resultLines.join("\n"), sourceLineBoundaries };
+}
+
+/**
+ * Format file content with line numbers (cat -n style).
+ *
+ * Lines longer than `MAX_LINE_LENGTH` are split into continuation rows such as
+ * `5.1` and `5.2`. Use `formatContentWithLineNumbersAndBoundaries` when a
+ * caller also needs safe source-line truncation points.
+ */
+export function formatContentWithLineNumbers(
+  content: string | string[],
+  startLine: number = 1,
+): string {
+  return formatContentWithLineNumbersAndBoundaries(content, startLine).text;
 }
 
 /**

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -147,6 +147,7 @@ export {
   type BackendFactory,
   type BackendRuntime,
   applyGrepMaxCount,
+  normalizeReadPagination,
   resolveBackend,
   type FileInfo,
   type GrepMatch,

--- a/libs/deepagents/src/middleware/fs.test.ts
+++ b/libs/deepagents/src/middleware/fs.test.ts
@@ -8,6 +8,7 @@ import {
   TOOLS_EXCLUDED_FROM_EVICTION,
 } from "./fs.js";
 import type { FileData, BackendProtocolV2 } from "../backends/protocol.js";
+import { StateBackend } from "../backends/state.js";
 import {
   SystemMessage,
   HumanMessage,
@@ -1148,6 +1149,131 @@ describe("createFilesystemMiddleware", () => {
   });
 
   describe("tools", () => {
+    // Regression test for https://langchain.slack.com/archives/C08HM96QCHG/p1787476952535559
+    it("read_file reports when the default limit returns a partial file", async () => {
+      const lines = Array.from({ length: 1450 }, (_, i) => `line ${i + 1}`);
+      const backend = new StateBackend({
+        state: {
+          files: {
+            "/large.txt": {
+              content: lines,
+              created_at: "2024-01-01T00:00:00Z",
+              modified_at: "2024-01-01T00:00:00Z",
+            },
+          },
+        },
+      } as any);
+      const middleware = createFilesystemMiddleware({ backend });
+      const readFileTool = middleware.tools!.find(
+        (tool) => tool.name === "read_file",
+      );
+
+      const result = await readFileTool!.invoke({ file_path: "/large.txt" });
+
+      expect((result as any)[0].text).toContain(
+        "[Read 100 lines (lines 1-100 of 1450 total). 1350 lines remaining from offset 100.]",
+      );
+    });
+
+    it("read_file reports the source range for an offset read", async () => {
+      const backend = new StateBackend({
+        state: {
+          files: {
+            "/offset.txt": {
+              content: ["one", "two", "three", "four", "five"],
+              created_at: "2024-01-01T00:00:00Z",
+              modified_at: "2024-01-01T00:00:00Z",
+            },
+          },
+        },
+      } as any);
+      const middleware = createFilesystemMiddleware({ backend });
+      const readFileTool = middleware.tools!.find(
+        (tool) => tool.name === "read_file",
+      );
+
+      const result = await readFileTool!.invoke({
+        file_path: "/offset.txt",
+        offset: 2,
+        limit: 2,
+      });
+
+      expect((result as any)[0].text).toContain(
+        "[Read 2 lines (lines 3-4 of 5 total). 1 line remaining from offset 4.]",
+      );
+    });
+
+    it("read_file omits the pagination notice at end of file", async () => {
+      const backend = new StateBackend({
+        state: {
+          files: {
+            "/small.txt": {
+              content: ["one", "two", "three"],
+              created_at: "2024-01-01T00:00:00Z",
+              modified_at: "2024-01-01T00:00:00Z",
+            },
+          },
+        },
+      } as any);
+      const middleware = createFilesystemMiddleware({ backend });
+      const readFileTool = middleware.tools!.find(
+        (tool) => tool.name === "read_file",
+      );
+
+      const result = await readFileTool!.invoke({ file_path: "/small.txt" });
+
+      expect((result as any)[0].text).not.toContain("[Read ");
+    });
+
+    it("read_file remains compatible with backends without pagination metadata", async () => {
+      const backend = createMockBackend();
+      backend.read = vi.fn().mockResolvedValue({
+        content: "one\ntwo\nthree",
+        mimeType: "text/plain",
+      });
+      const middleware = createFilesystemMiddleware({ backend });
+      const readFileTool = middleware.tools!.find(
+        (tool) => tool.name === "read_file",
+      );
+
+      const result = await readFileTool!.invoke({ file_path: "/legacy.txt" });
+
+      expect((result as any)[0].text).not.toContain("[Read ");
+    });
+
+    it("read_file resumes after the last complete line when output is truncated", async () => {
+      const backend = createMockBackend();
+      backend.read = vi.fn().mockResolvedValue({
+        content: Array.from(
+          { length: 10 },
+          (_, i) => `line ${i + 1} ${"x".repeat(80)}`,
+        ).join("\n"),
+        mimeType: "text/plain",
+        totalLines: 20,
+        startLine: 1,
+        endLine: 10,
+        nextOffset: 10,
+      });
+      const middleware = createFilesystemMiddleware({
+        backend,
+        toolTokenLimitBeforeEvict: 150,
+      });
+      const readFileTool = middleware.tools!.find(
+        (tool) => tool.name === "read_file",
+      );
+
+      const result = await readFileTool!.invoke({ file_path: "/large.txt" });
+      const text = (result as any)[0].text as string;
+      const resumeMatch = text.match(/remaining from offset (\d+)\./);
+      const displayedLines = [...text.matchAll(/^\s*(\d+)\t/gm)].map((match) =>
+        Number(match[1]),
+      );
+
+      expect(resumeMatch).not.toBeNull();
+      expect(Number(resumeMatch![1])).toBe(Math.max(...displayedLines));
+      expect(Number(resumeMatch![1])).toBeLessThan(10);
+    });
+
     it("write_file schema should require content", () => {
       const middleware = createFilesystemMiddleware({
         backend: createMockBackend(),

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -30,17 +30,21 @@ import type {
   DeleteResult,
   FileData,
   LsResult,
+  ReadResult,
 } from "../backends/protocol.js";
 import { isSandboxBackend, resolveBackend } from "../backends/protocol.js";
 import { StateBackend } from "../backends/state.js";
 import {
   sanitizeToolCallId,
   formatContentWithLineNumbers,
+  formatContentWithLineNumbersAndBoundaries,
+  type FormattedContentWithLineNumbers,
   formatGrepMatches,
   truncateIfTooLong,
   getMimeType,
   isTextMimeType,
   MAX_LINE_LENGTH,
+  normalizeReadPagination,
 } from "../backends/utils.js";
 
 const INT_FORMATTER = new Intl.NumberFormat("en-US");
@@ -145,6 +149,125 @@ export const MAX_BINARY_READ_SIZE_BYTES = 10 * 1024 * 1024;
 const READ_FILE_TRUNCATION_MSG = `
 
 [Output was truncated due to size limits. The file content is very large. Consider reformatting the file to make it easier to navigate. For example, if this is JSON, use execute(command='jq . {file_path}') to pretty-print it with line breaks. For other formats, you can use appropriate formatting tools to split long lines.]`;
+
+/**
+ * Render backend pagination metadata as guidance for the model.
+ *
+ * Backends own source-level pagination because only they know how much of the
+ * file was read. The middleware owns presentation: it line-numbers the text
+ * and turns optional metadata into a human-readable footer. Keeping the fields
+ * optional preserves compatibility with custom backends that predate this
+ * contract; those reads simply receive no pagination footer.
+ *
+ * `nextOffset` is the signal that the read is partial. A result at EOF omits it,
+ * so complete reads retain their previous output shape.
+ */
+function remainingLinesNotice(readResult: ReadResult): string {
+  const { startLine, endLine, nextOffset, totalLines } = readResult;
+  if (
+    startLine === undefined ||
+    endLine === undefined ||
+    nextOffset === undefined ||
+    !Number.isSafeInteger(startLine) ||
+    !Number.isSafeInteger(endLine) ||
+    !Number.isSafeInteger(nextOffset) ||
+    startLine < 1 ||
+    endLine < startLine ||
+    nextOffset !== endLine ||
+    (totalLines !== undefined &&
+      (!Number.isSafeInteger(totalLines) || totalLines < endLine))
+  ) {
+    return "";
+  }
+
+  const readCount = endLine - startLine + 1;
+  const readUnit = readCount === 1 ? "line" : "lines";
+  if (totalLines === undefined) {
+    return `\n\n[Read ${readCount} ${readUnit} (lines ${startLine}-${endLine}). More lines remain from offset ${nextOffset}.]`;
+  }
+  if (endLine >= totalLines) {
+    return "";
+  }
+
+  const remaining = totalLines - endLine;
+  const remainingUnit = remaining === 1 ? "line" : "lines";
+  return `\n\n[Read ${readCount} ${readUnit} (lines ${startLine}-${endLine} of ${totalLines} total). ${remaining} ${remainingUnit} remaining from offset ${nextOffset}.]`;
+}
+
+/**
+ * Fit a line-numbered read into the middleware's output budget without
+ * publishing a resume offset that skips content the model did not see.
+ *
+ * There are two independent forms of limiting:
+ *
+ * 1. The backend paginates the source file with `offset` and `limit`.
+ * 2. The middleware may further shorten that page to fit its token budget.
+ *
+ * If the backend returned lines 1-100 but the middleware only displayed lines
+ * 1-30, forwarding the backend's original `nextOffset: 100` would silently skip
+ * lines 31-100 on the next read. This function therefore truncates only after a
+ * complete source line and rebuilds the remaining-lines notice using the last
+ * line actually displayed.
+ *
+ * Long source lines may occupy several formatted rows (`12`, `12.1`, ...). The
+ * formatter records a structured boundary only after the final chunk, so this
+ * function does not need to inspect or understand the gutter representation.
+ * If no complete source line can fit beside the truncation message, the function
+ * falls back to character truncation and omits pagination guidance rather than
+ * advertising an unsafe offset.
+ */
+function truncatePaginatedRead(
+  formatted: FormattedContentWithLineNumbers,
+  filePath: string,
+  readResult: ReadResult,
+  tokenLimit: number | null,
+): string {
+  const content = formatted.text;
+  const notice = remainingLinesNotice(readResult);
+  if (
+    !tokenLimit ||
+    content.length + notice.length < NUM_CHARS_PER_TOKEN * tokenLimit
+  ) {
+    return content + notice;
+  }
+
+  const truncationMsg = READ_FILE_TRUNCATION_MSG.replace(
+    "{file_path}",
+    filePath,
+  );
+  const threshold = NUM_CHARS_PER_TOKEN * tokenLimit;
+  if (readResult.startLine !== undefined && readResult.endLine !== undefined) {
+    const finalSourceLine = readResult.endLine;
+    const boundaries = formatted.sourceLineBoundaries.filter(
+      (boundary) => boundary.sourceLine <= finalSourceLine,
+    );
+
+    // Prefer the latest complete source line that leaves room for both notices.
+    for (let index = boundaries.length - 1; index >= 0; index -= 1) {
+      const boundary = boundaries[index];
+      const adjustedResult: ReadResult = {
+        totalLines: readResult.totalLines,
+        startLine: readResult.startLine,
+        endLine: boundary.sourceLine,
+        nextOffset: boundary.sourceLine,
+      };
+      const adjustedNotice = remainingLinesNotice(adjustedResult);
+      if (
+        boundary.endOffset + truncationMsg.length + adjustedNotice.length <=
+        threshold
+      ) {
+        return (
+          content.slice(0, boundary.endOffset) + truncationMsg + adjustedNotice
+        );
+      }
+    }
+  }
+
+  // Without a complete safe boundary, preserve the historical character-level
+  // truncation behavior but omit a pagination footer: guessing would risk skips.
+  const maxContentLength = Math.max(0, threshold - truncationMsg.length);
+  return content.substring(0, maxContentLength) + truncationMsg;
+}
 
 /**
  * Note appended to grep results that were cut short by the match-count cap.
@@ -996,9 +1119,13 @@ function createReadFileTool(
       const resolvedBackend = await resolveBackend(backend, runtime);
       const {
         file_path,
-        offset = DEFAULT_READ_LINE_OFFSET,
-        limit = DEFAULT_READ_LINE_LIMIT,
+        offset: requestedOffset = DEFAULT_READ_LINE_OFFSET,
+        limit: requestedLimit = DEFAULT_READ_LINE_LIMIT,
       } = input;
+      const { offset, limit } = normalizeReadPagination(
+        requestedOffset,
+        requestedLimit,
+      );
 
       const readResult = await resolvedBackend.read(file_path, offset, limit);
       if (readResult.error) {
@@ -1060,29 +1187,39 @@ function createReadFileTool(
 
       // Enforce line limit on result (in case backend returns more)
       const lines = content.split("\n");
+      let paginationResult = readResult;
       if (lines.length > limit) {
         content = lines.slice(0, limit).join("\n");
+        if (
+          limit > 0 &&
+          readResult.startLine !== undefined &&
+          readResult.endLine !== undefined
+        ) {
+          const endLine = Math.min(
+            readResult.startLine + limit - 1,
+            readResult.endLine,
+            readResult.totalLines ?? Number.POSITIVE_INFINITY,
+          );
+          paginationResult = {
+            ...readResult,
+            endLine,
+            nextOffset: endLine,
+          };
+        }
       }
 
-      let formatted = formatContentWithLineNumbers(content, offset + 1);
+      const formatted = formatContentWithLineNumbersAndBoundaries(
+        content,
+        paginationResult.startLine ?? offset + 1,
+      );
+      const output = truncatePaginatedRead(
+        formatted,
+        file_path,
+        paginationResult,
+        toolTokenLimitBeforeEvict,
+      );
 
-      // Check if result exceeds token threshold and truncate if necessary
-      if (
-        toolTokenLimitBeforeEvict &&
-        formatted.length >= NUM_CHARS_PER_TOKEN * toolTokenLimitBeforeEvict
-      ) {
-        // Calculate truncation message length to ensure final result stays under threshold
-        const truncationMsg = READ_FILE_TRUNCATION_MSG.replace(
-          "{file_path}",
-          file_path,
-        );
-        const maxContentLength =
-          NUM_CHARS_PER_TOKEN * toolTokenLimitBeforeEvict -
-          truncationMsg.length;
-        formatted = formatted.substring(0, maxContentLength) + truncationMsg;
-      }
-
-      return [{ type: "text", text: formatted }];
+      return [{ type: "text", text: output }];
     },
     {
       name: "read_file",

--- a/libs/providers/node-vfs/src/backend.int.test.ts
+++ b/libs/providers/node-vfs/src/backend.int.test.ts
@@ -35,6 +35,24 @@ describe.skipIf(isWindows)("VfsBackend Integration", () => {
       expect(relative.content).toContain("Hello from VFS!");
     });
 
+    it("returns pagination metadata for partial text reads", async () => {
+      sandbox = await VfsBackend.create({
+        initialFiles: {
+          "/lines.txt": "one\ntwo\nthree\nfour",
+        },
+      });
+
+      const result = await sandbox.read("/lines.txt", 1, 2);
+
+      expect(result.content).toBe("two\nthree");
+      expect(result).toMatchObject({
+        totalLines: 4,
+        startLine: 2,
+        endLine: 3,
+        nextOffset: 3,
+      });
+    });
+
     it("supports ls for absolute and relative directory paths", async () => {
       sandbox = await VfsBackend.create({
         initialFiles: {

--- a/libs/providers/node-vfs/src/backend.ts
+++ b/libs/providers/node-vfs/src/backend.ts
@@ -30,6 +30,7 @@ import {
   type BackendFactory,
   type WriteResult,
   applyGrepMaxCount,
+  normalizeReadPagination,
 } from "deepagents";
 
 import { VirtualFileSystem } from "node-vfs-polyfill";
@@ -712,7 +713,9 @@ export class VfsBackend implements BackendProtocolV2 {
       return { content: new Uint8Array(content), mimeType };
     }
 
-    if (limit === 0) {
+    const { offset: normalizedOffset, limit: normalizedLimit } =
+      normalizeReadPagination(offset, limit);
+    if (normalizedLimit === 0) {
       return { content: "", mimeType };
     }
 
@@ -720,14 +723,25 @@ export class VfsBackend implements BackendProtocolV2 {
       encoding: "utf-8",
     }) as string;
     const lines = content.split("\n");
-    const start = Math.max(0, offset);
-    const end = Math.max(start, start + Math.max(0, limit));
+    const totalLines =
+      lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+    const start = normalizedOffset;
+    const end = start + normalizedLimit;
 
-    if (start >= lines.length) {
+    if (start >= totalLines) {
       return { content: "", mimeType };
     }
 
-    return { content: lines.slice(start, end).join("\n"), mimeType };
+    const selectedEnd = Math.min(end, lines.length);
+    const logicalEnd = Math.min(end, totalLines);
+    return {
+      content: lines.slice(start, selectedEnd).join("\n"),
+      mimeType,
+      totalLines,
+      startLine: start + 1,
+      endLine: logicalEnd,
+      nextOffset: logicalEnd < totalLines ? logicalEnd : undefined,
+    };
   }
 
   /**


### PR DESCRIPTION
parity followup to langchain-ai/langchain#2142

* Amends protocol interface to report more optional pagination information use to render the truncation lines
  * Updates built-in backends to add this information
* Amends existing formatting methods to propagate line boundary information (we use this to not rely on awkward string matching using existing impl)
* Adds an additional utility to render a notice when we truncate due to line count (the character/ size truncation still happens separately
