### PR TITLE
fix: reject calls to excluded profile tools

### DIFF
--- a/.changeset/tidy-tools-refuse.md
+++ b/.changeset/tidy-tools-refuse.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Reject tool calls excluded by harness profiles instead of only hiding the tools from model requests.

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { createDeepAgent } from "./agent.js";
 import { isAnthropicModel } from "./utils.js";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
-import { todoListMiddleware } from "langchain";
+import { todoListMiddleware, tool } from "langchain";
 import {
+  AIMessage,
   HumanMessage,
   SystemMessage,
+  ToolMessage,
   type BaseMessage,
 } from "@langchain/core/messages";
 import { MemorySaver, StateSchema } from "@langchain/langgraph";
@@ -236,6 +238,60 @@ describe("profile tool exclusions", () => {
 
     expect(toolNames).toContain("read_file");
     expect(toolNames).not.toContain("execute");
+  });
+
+  it("rejects excluded calls while executing allowed calls", async () => {
+    registerHarnessProfile("executiontest", {
+      excludedTools: ["excluded_tool"],
+    });
+    const excludedHandler = vi.fn(() => "excluded");
+    const excludedTool = tool(excludedHandler, {
+      name: "excluded_tool",
+      description: "Excluded tool",
+      schema: z.object({}),
+    });
+    const allowedHandler = vi.fn(() => "allowed");
+    const allowedTool = tool(allowedHandler, {
+      name: "allowed_tool",
+      description: "Allowed tool",
+      schema: z.object({}),
+    });
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            { name: "excluded_tool", args: {}, id: "excluded_call" },
+            { name: "allowed_tool", args: {}, id: "allowed_call" },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+    vi.spyOn(model, "getName").mockReturnValue("ConfigurableModel");
+    (model as any)._defaultConfig = {
+      modelProvider: "executiontest",
+      model: "model",
+    };
+
+    const result = await createDeepAgent({
+      model,
+      tools: [excludedTool, allowedTool],
+    }).invoke({ messages: [new HumanMessage("Run the tools")] });
+    const toolMessages = result.messages.filter(ToolMessage.isInstance);
+
+    expect(excludedHandler).not.toHaveBeenCalled();
+    expect(allowedHandler).toHaveBeenCalledOnce();
+    expect(toolMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "excluded_tool",
+          status: "error",
+          content: "Error: excluded_tool is not available.",
+        }),
+        expect.objectContaining({ name: "allowed_tool", content: "allowed" }),
+      ]),
+    );
   });
 });
 

--- a/libs/deepagents/src/middleware/tool_exclusion.ts
+++ b/libs/deepagents/src/middleware/tool_exclusion.ts
@@ -1,3 +1,4 @@
+import { ToolMessage } from "@langchain/core/messages";
 import { createMiddleware, type AgentMiddleware } from "langchain";
 
 function hasToolName(tool: unknown): tool is { name: string } {
@@ -10,8 +11,9 @@ function hasToolName(tool: unknown): tool is { name: string } {
 }
 
 /**
- * Create middleware that removes excluded tools after all tool-injecting
- * middleware has had a chance to add tools to the request.
+ * Create middleware that hides excluded tools from the model and rejects calls
+ * to them. Exclusions calibrate the agent per model; they are not a security
+ * boundary.
  *
  * @internal
  */
@@ -26,6 +28,18 @@ export function createToolExclusionMiddleware(
         tools: request.tools?.filter(
           (tool) => !hasToolName(tool) || !excludedTools.has(tool.name),
         ),
+      });
+    },
+    wrapToolCall(request, handler) {
+      const { name, id } = request.toolCall;
+      if (!excludedTools.has(name)) {
+        return handler(request);
+      }
+      return new ToolMessage({
+        content: `Error: ${name} is not available.`,
+        tool_call_id: id ?? "",
+        name,
+        status: "error",
       });
     },
   });

--- a/libs/deepagents/src/profiles/harness/types.ts
+++ b/libs/deepagents/src/profiles/harness/types.ts
@@ -94,11 +94,12 @@ export interface HarnessProfileOptions {
   toolDescriptionOverrides?: Record<string, string>;
 
   /**
-   * Tool names to remove from the agent's visible tool set.
+   * Tool names to remove from the agent's visible tool set and reject at the
+   * tool-call boundary.
    *
-   * Applied via a filtering middleware after all tool-injecting
-   * middleware have run, so it catches both user-provided and
-   * middleware-provided tools.
+   * Applied via middleware after all tool-injecting middleware have run, so it
+   * catches both user-provided and middleware-provided tools. Exclusions are
+   * model-facing calibration resolved per model, not a security boundary.
    *
    * @default [] (no tools excluded)
    */
@@ -179,11 +180,12 @@ export interface HarnessProfile {
   toolDescriptionOverrides: Record<string, string>;
 
   /**
-   * Tool names to remove from the agent's visible tool set.
+   * Tool names to remove from the agent's visible tool set and reject at the
+   * tool-call boundary.
    *
-   * Applied via a filtering middleware after all tool-injecting
-   * middleware have run, so it catches both user-provided and
-   * middleware-provided tools.
+   * Applied via middleware after all tool-injecting middleware have run, so it
+   * catches both user-provided and middleware-provided tools. Exclusions are
+   * model-facing calibration resolved per model, not a security boundary.
    */
   excludedTools: Set<string>;
 

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -524,10 +524,7 @@ export interface CreateDeepAgentParams<
 > {
   /** The model to use (model name string or LanguageModelLike instance). Defaults to claude-sonnet-4-5-20250929 */
   model?: BaseLanguageModel | string;
-  /**
-   * Additional tools for the agent. To stop offering a built-in tool to a
-   * model, register a harness profile with `excludedTools`.
-   */
+  /** Tools the agent should have access to */
   tools?: TTools | StructuredTool[];
   /**
    * Custom system instructions. Structured configuration is deprecated and

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -524,7 +524,10 @@ export interface CreateDeepAgentParams<
 > {
   /** The model to use (model name string or LanguageModelLike instance). Defaults to claude-sonnet-4-5-20250929 */
   model?: BaseLanguageModel | string;
-  /** Tools the agent should have access to */
+  /**
+   * Additional tools for the agent. To stop offering a built-in tool to a
+   * model, register a harness profile with `excludedTools`.
+   */
   tools?: TTools | StructuredTool[];
   /**
    * Custom system instructions. Structured configuration is deprecated and


### PR DESCRIPTION
## Description
Ports langchain-ai/deepagents#5809 so harness-profile tool exclusions reject unexpected calls rather than only hiding tools from model requests. Clarifies that exclusions calibrate model behavior and are not a security boundary.

## Test Plan
- [x] Verify an excluded and allowed tool call in the same model turn reject only the excluded call.
- [x] Typecheck and lint the package.

Made by [Open SWE](https://openswe.vercel.app/agents/e82e5fe4-086e-5fab-8242-45e98b42aad7)