### PR TITLE
fix(deepagents): scope StoreBackend ls/glob/grep to exact namespace (#772)

### DIFF
--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -1077,7 +1077,10 @@ describe("StoreBackend namespace isolation", () => {
     });
 
     await acme.write("/own.md", "acme's own file");
-    await acmeCorp.write("/secret.md", "acme-corp CONFIDENTIAL revenue figures");
+    await acmeCorp.write(
+      "/secret.md",
+      "acme-corp CONFIDENTIAL revenue figures",
+    );
 
     const ls = await acme.ls("/");
     const lsPaths = ls.files!.map((f) => f.path);

--- a/libs/deepagents/src/backends/store.test.ts
+++ b/libs/deepagents/src/backends/store.test.ts
@@ -1067,3 +1067,35 @@ describe("StoreBackend", () => {
     });
   });
 });
+
+describe("StoreBackend namespace isolation", () => {
+  it("ls/glob/grep only see the backend's exact namespace, not sibling prefixes (#772)", async () => {
+    const { runtime } = makeConfig();
+    const acme = new StoreBackend(runtime, { namespace: ["tenant", "acme"] });
+    const acmeCorp = new StoreBackend(runtime, {
+      namespace: ["tenant", "acme-corp"],
+    });
+
+    await acme.write("/own.md", "acme's own file");
+    await acmeCorp.write("/secret.md", "acme-corp CONFIDENTIAL revenue figures");
+
+    const ls = await acme.ls("/");
+    const lsPaths = ls.files!.map((f) => f.path);
+    expect(lsPaths).toContain("/own.md");
+    expect(lsPaths).not.toContain("/secret.md");
+
+    const glob = await acme.glob("**/*", "/");
+    const globPaths = glob.files!.map((f) => f.path);
+    expect(globPaths).toContain("/own.md");
+    expect(globPaths).not.toContain("/secret.md");
+
+    const grep = await acme.grep("CONFIDENTIAL", "/");
+    expect(grep.matches ?? []).toHaveLength(0);
+
+    // sibling still sees its own file (sanity)
+    const corp = await acmeCorp.ls("/");
+    const corpPaths = corp.files!.map((f) => f.path);
+    expect(corpPaths).toContain("/secret.md");
+    expect(corpPaths).not.toContain("/own.md");
+  });
+});

--- a/libs/deepagents/src/backends/store.ts
+++ b/libs/deepagents/src/backends/store.ts
@@ -186,6 +186,14 @@ export interface StoreBackendOptions<StateT = unknown> extends BackendOptions {
  * isolation patterns (user-scoped, org-scoped, etc.), or falls back
  * to legacy assistant_id-based isolation.
  */
+/**
+ * Deep-equality check for two store namespaces.
+ */
+function namespacesEqual(a: string[] | undefined, b: string[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  return a.every((part, i) => part === b[i]);
+}
+
 export class StoreBackend implements BackendProtocolV2 {
   private stateAndStore: StateAndStore | undefined;
   private storeOverride: BaseStore | undefined;
@@ -441,7 +449,15 @@ export class StoreBackend implements BackendProtocolV2 {
         break;
       }
 
-      allItems.push(...pageItems);
+      // Only accumulate items in *exactly* this backend's namespace. store.search()
+      // matches by namespace prefix, so sibling namespaces sharing a leading string
+      // (e.g. ["tenant","acme"] vs ["tenant","acme-corp"]) would otherwise leak into
+      // ls/glob/grep. read/write use exact get/put and are unaffected.
+      allItems.push(
+        ...pageItems.filter((item: Item) =>
+          namespacesEqual(item.namespace, namespace),
+        ),
+      );
 
       if (pageItems.length < pageSize) {
         break;


### PR DESCRIPTION
### Summary

`StoreBackend` is pinned to a single namespace, but its listing operations (`ls`, `glob`, `grep`) query the underlying store with `store.search(namespace)`, which matches by **namespace prefix**. Sibling namespaces that share a leading string — e.g. `["tenant","acme"]` and `["tenant","acme-corp"]` — leak into each other: one backend's `ls`/`glob`/`grep` returns (and `grep` prints the line contents of) the other's files, even though `read`/`write` correctly use exact `get`/`put`.

Fixes #772.

### Root cause

`searchStorePaginated()` accumulates every item returned by `store.search(namespace)`. Because that search is a prefix match, items from sibling namespaces are included. `read` / `readRaw` / `write` go through `get` / `put`, which match the namespace exactly — which is why the same backend will list and `grep` a file that it then refuses to `read`.

### Fix

Filter the paginated search results down to items whose namespace is **exactly** the backend's namespace, via a small `namespacesEqual` helper. A `StoreBackend` never nests files into sub-namespaces (the file path lives in the item key), so exact-namespace matching is the correct invariant. This repairs `ls`, `glob`, and `grep` in one place, since all three build their file set from `searchStorePaginated`.

### Test

Added a regression test (`StoreBackend namespace isolation`) that mounts two sibling-prefix backends on one store and asserts `ls` / `glob` / `grep` each see only their own namespace, while the sibling still sees its own file.
