### PR TITLE
fix: enforce subagent tool exclusions

### DIFF
--- a/.changeset/calm-agents-exclude.md
+++ b/.changeset/calm-agents-exclude.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Enforce harness-profile tool exclusions inside declarative subagents using each subagent model's profile.

--- a/libs/deepagents/src/agent.test.ts
+++ b/libs/deepagents/src/agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { createDeepAgent } from "./agent.js";
 import { isAnthropicModel } from "./utils.js";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
@@ -14,7 +14,10 @@ import { MemorySaver, StateSchema } from "@langchain/langgraph";
 import { createFileData } from "./backends/utils.js";
 import { ConfigurationError } from "./errors.js";
 import { assertAllDeepAgentQualities } from "./testing/utils.js";
-import { registerHarnessProfile } from "./profiles/harness/index.js";
+import {
+  _resetRegistryForTesting,
+  registerHarnessProfile,
+} from "./profiles/harness/index.js";
 import { z } from "zod/v4";
 
 describe("isAnthropicModel", () => {
@@ -229,6 +232,25 @@ describe("System prompt cache control breakpoints", () => {
 });
 
 describe("profile tool exclusions", () => {
+  afterEach(() => {
+    _resetRegistryForTesting();
+  });
+
+  const createTestTool = (name: string, handler: () => string) =>
+    tool(handler, {
+      name,
+      description: `${name} description`,
+      schema: z.object({}),
+    });
+
+  const setModelProfile = (
+    model: FakeListChatModel,
+    provider: string,
+  ): void => {
+    vi.spyOn(model, "getName").mockReturnValue("ConfigurableModel");
+    (model as any)._defaultConfig = { modelProvider: provider, model: "model" };
+  };
+
   it("removes excluded filesystem tools before agent construction", () => {
     registerHarnessProfile("fstoolstest", { excludedTools: ["execute"] });
 
@@ -245,17 +267,9 @@ describe("profile tool exclusions", () => {
       excludedTools: ["excluded_tool"],
     });
     const excludedHandler = vi.fn(() => "excluded");
-    const excludedTool = tool(excludedHandler, {
-      name: "excluded_tool",
-      description: "Excluded tool",
-      schema: z.object({}),
-    });
+    const excludedTool = createTestTool("excluded_tool", excludedHandler);
     const allowedHandler = vi.fn(() => "allowed");
-    const allowedTool = tool(allowedHandler, {
-      name: "allowed_tool",
-      description: "Allowed tool",
-      schema: z.object({}),
-    });
+    const allowedTool = createTestTool("allowed_tool", allowedHandler);
     const model = new FakeListChatModel({
       responses: [
         new AIMessage({
@@ -268,11 +282,7 @@ describe("profile tool exclusions", () => {
         "Done",
       ],
     });
-    vi.spyOn(model, "getName").mockReturnValue("ConfigurableModel");
-    (model as any)._defaultConfig = {
-      modelProvider: "executiontest",
-      model: "model",
-    };
+    setModelProfile(model, "executiontest");
 
     const result = await createDeepAgent({
       model,
@@ -292,6 +302,152 @@ describe("profile tool exclusions", () => {
         expect.objectContaining({ name: "allowed_tool", content: "allowed" }),
       ]),
     );
+  });
+
+  it("rejects excluded calls inside custom subagents", async () => {
+    registerHarnessProfile("subagenttest", {
+      excludedTools: ["excluded_tool"],
+    });
+    const excludedHandler = vi.fn(() => "excluded");
+    const allowedHandler = vi.fn(() => "allowed");
+    const tools = [
+      createTestTool("excluded_tool", excludedHandler),
+      createTestTool("allowed_tool", allowedHandler),
+    ];
+    const subagentModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            { name: "excluded_tool", args: {}, id: "excluded_call" },
+            { name: "allowed_tool", args: {}, id: "allowed_call" },
+          ],
+        }) as unknown as string,
+        "Subagent done",
+      ],
+    });
+    setModelProfile(subagentModel, "subagenttest");
+    const mainModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              name: "task",
+              args: { description: "Run tools", subagent_type: "worker" },
+              id: "task_call",
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+
+    await createDeepAgent({
+      model: mainModel,
+      subagents: [
+        {
+          name: "worker",
+          description: "Runs tools",
+          systemPrompt: "Run the requested tools.",
+          model: subagentModel,
+          tools,
+        },
+      ],
+    }).invoke({ messages: [new HumanMessage("Delegate the work")] });
+
+    expect(excludedHandler).not.toHaveBeenCalled();
+    expect(allowedHandler).toHaveBeenCalledOnce();
+  });
+
+  it("resolves exclusions from each agent's model profile", async () => {
+    registerHarnessProfile("mainprofile", {
+      excludedTools: ["main_excluded"],
+    });
+    registerHarnessProfile("subprofile", {
+      excludedTools: ["subagent_excluded"],
+    });
+    const mainExcludedHandler = vi.fn(() => "main excluded tool result");
+    const subagentExcludedHandler = vi.fn(
+      () => "subagent excluded tool result",
+    );
+    const tools = [
+      createTestTool("main_excluded", mainExcludedHandler),
+      createTestTool("subagent_excluded", subagentExcludedHandler),
+    ];
+    const mainModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            { name: "main_excluded", args: {}, id: "main_excluded_call" },
+            {
+              name: "subagent_excluded",
+              args: {},
+              id: "main_allowed_call",
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+    setModelProfile(mainModel, "mainprofile");
+    await createDeepAgent({ model: mainModel, tools }).invoke({
+      messages: [new HumanMessage("Run the tools")],
+    });
+
+    expect(mainExcludedHandler).not.toHaveBeenCalled();
+    expect(subagentExcludedHandler).toHaveBeenCalledOnce();
+
+    const subagentModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            { name: "main_excluded", args: {}, id: "sub_allowed_call" },
+            {
+              name: "subagent_excluded",
+              args: {},
+              id: "sub_excluded_call",
+            },
+          ],
+        }) as unknown as string,
+        "Subagent done",
+      ],
+    });
+    setModelProfile(subagentModel, "subprofile");
+    const delegatingModel = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              name: "task",
+              args: { description: "Run tools", subagent_type: "worker" },
+              id: "task_call",
+            },
+          ],
+        }) as unknown as string,
+        "Done",
+      ],
+    });
+    setModelProfile(delegatingModel, "mainprofile");
+
+    await createDeepAgent({
+      model: delegatingModel,
+      subagents: [
+        {
+          name: "worker",
+          description: "Runs tools",
+          systemPrompt: "Run the requested tools.",
+          model: subagentModel,
+          tools,
+        },
+      ],
+    }).invoke({ messages: [new HumanMessage("Delegate the tools")] });
+
+    expect(mainExcludedHandler).toHaveBeenCalledOnce();
+    expect(subagentExcludedHandler).toHaveBeenCalledOnce();
   });
 });
 

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -59,6 +59,7 @@ import {
   resolveHarnessProfile,
   applyProfilePrompt,
   resolveMiddleware,
+  type HarnessProfile,
 } from "./profiles/index.js";
 import {
   isAnthropicModel,
@@ -211,15 +212,31 @@ export function createDeepAgent<
           identifierHint: getModelIdentifier(model),
         });
 
-  const filesystemTools = FILESYSTEM_TOOL_NAMES.filter(
-    (toolName) => !harnessProfile.excludedTools.has(toolName),
-  );
-  const profileFilesystemTools: readonly FsToolName[] | undefined =
-    filesystemTools.length === FILESYSTEM_TOOL_NAMES.length
+  const computeProfileFilesystemTools = (
+    profile: HarnessProfile,
+  ): readonly FsToolName[] | undefined => {
+    const filesystemTools = FILESYSTEM_TOOL_NAMES.filter(
+      (toolName) => !profile.excludedTools.has(toolName),
+    );
+    return filesystemTools.length === FILESYSTEM_TOOL_NAMES.length
       ? undefined
       : filesystemTools.includes("read_file")
         ? filesystemTools
         : ["read_file", ...filesystemTools];
+  };
+  const profileFilesystemTools = computeProfileFilesystemTools(harnessProfile);
+
+  const resolveSubagentProfile = (
+    subagentModel: SubAgent["model"],
+  ): HarnessProfile => {
+    if (subagentModel == null || subagentModel === model) return harnessProfile;
+    return typeof subagentModel === "string"
+      ? resolveHarnessProfile({ spec: subagentModel })
+      : resolveHarnessProfile({
+          providerHint: getModelProvider(subagentModel),
+          identifierHint: getModelIdentifier(subagentModel),
+        });
+  };
 
   const toolOverrides = harnessProfile.toolDescriptionOverrides;
   const effectiveTools: StructuredTool[] =
@@ -288,6 +305,7 @@ export function createDeepAgent<
    */
   const createSubagentDefaultMiddleware = (
     input: SubAgent | ForkedSubAgent,
+    subagentProfile: HarnessProfile,
   ): AgentMiddleware[] => {
     const effectivePermissions = input.permissions ?? permissions;
 
@@ -299,7 +317,7 @@ export function createDeepAgent<
       createFilesystemMiddleware({
         backend,
         permissions: effectivePermissions,
-        tools: profileFilesystemTools,
+        tools: computeProfileFilesystemTools(subagentProfile),
       }),
       // Automatically summarizes conversation history when token limits are approached.
       // Uses createSummarizationMiddleware (deepagents version) with backend support
@@ -318,22 +336,33 @@ export function createDeepAgent<
     input: SubAgent | ForkedSubAgent,
     isForkable: boolean,
   ): AgentMiddleware[] => {
-    const subagentDefaultMiddleware = createSubagentDefaultMiddleware(input);
+    const subagentProfile = resolveSubagentProfile(input.model);
+    const subagentDefaultMiddleware = createSubagentDefaultMiddleware(
+      input,
+      subagentProfile,
+    );
 
     let subagentMiddleware = mergeMiddlewareStack(
       subagentDefaultMiddleware,
       input.middleware ?? [],
       [
         // Resolve profile middleware per stack so factories create fresh instances.
-        ...resolveMiddleware(harnessProfile.extraMiddleware),
+        ...resolveMiddleware(subagentProfile.extraMiddleware),
         ...cacheMiddleware,
         ...(isForkable ? memoryMiddleware : []),
       ],
     );
 
-    if (harnessProfile.excludedMiddleware.size > 0) {
+    if (subagentProfile.excludedMiddleware.size > 0) {
       subagentMiddleware = subagentMiddleware.filter(
-        (middleware) => !harnessProfile.excludedMiddleware.has(middleware.name),
+        (middleware) =>
+          !subagentProfile.excludedMiddleware.has(middleware.name),
+      );
+    }
+
+    if (subagentProfile.excludedTools.size > 0) {
+      subagentMiddleware.push(
+        createToolExclusionMiddleware(subagentProfile.excludedTools),
       );
     }
 

--- a/libs/deepagents/src/profiles/harness/types.ts
+++ b/libs/deepagents/src/profiles/harness/types.ts
@@ -98,8 +98,9 @@ export interface HarnessProfileOptions {
    * tool-call boundary.
    *
    * Applied via middleware after all tool-injecting middleware have run, so it
-   * catches both user-provided and middleware-provided tools. Exclusions are
-   * model-facing calibration resolved per model, not a security boundary.
+   * catches both user-provided and middleware-provided tools. Each declarative
+   * subagent uses the profile resolved for its own model. Exclusions are
+   * model-facing calibration, not a security boundary.
    *
    * @default [] (no tools excluded)
    */
@@ -184,8 +185,9 @@ export interface HarnessProfile {
    * tool-call boundary.
    *
    * Applied via middleware after all tool-injecting middleware have run, so it
-   * catches both user-provided and middleware-provided tools. Exclusions are
-   * model-facing calibration resolved per model, not a security boundary.
+   * catches both user-provided and middleware-provided tools. Each declarative
+   * subagent uses the profile resolved for its own model. Exclusions are
+   * model-facing calibration, not a security boundary.
    */
   excludedTools: Set<string>;
 

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -524,7 +524,10 @@ export interface CreateDeepAgentParams<
 > {
   /** The model to use (model name string or LanguageModelLike instance). Defaults to claude-sonnet-4-5-20250929 */
   model?: BaseLanguageModel | string;
-  /** Tools the agent should have access to */
+  /**
+   * Additional tools for the agent. Passing tools here does not remove built-in
+   * filesystem tools; customize `FilesystemMiddleware` to remove them entirely.
+   */
   tools?: TTools | StructuredTool[];
   /**
    * Custom system instructions. Structured configuration is deprecated and

--- a/libs/deepagents/src/utils.ts
+++ b/libs/deepagents/src/utils.ts
@@ -114,7 +114,9 @@ export function isBedrockConverseModel(
  *
  * @internal
  */
-export function getModelProvider(model: BaseLanguageModel): string | undefined {
+export function getModelProvider(
+  model: BaseLanguageModel | RunnableInterface<unknown, unknown>,
+): string | undefined {
   if (model.getName() === "ConfigurableModel") {
     return (model as any)._defaultConfig?.modelProvider as string | undefined;
   }
@@ -136,7 +138,7 @@ export function getModelProvider(model: BaseLanguageModel): string | undefined {
  * @internal
  */
 export function getModelIdentifier(
-  model: BaseLanguageModel,
+  model: BaseLanguageModel | RunnableInterface<unknown, unknown>,
 ): string | undefined {
   const configurable =
     model.getName() === "ConfigurableModel"


### PR DESCRIPTION
Resolve harness profiles from each declarative subagent's model so profile middleware and filesystem/tool exclusions do not leak across models.