### PR TITLE
fix(deepagents): backport Python's fork cache-parity and recursion-safety fixes

### DIFF
--- a/.changeset/forked-subagent-conversation.md
+++ b/.changeset/forked-subagent-conversation.md
@@ -1,0 +1,5 @@
+---
+"deepagents": minor
+---
+
+Add experimental conversation forking for subagents (`mode: "fork"`), inheriting the parent's message history and system prompt for prompt-cache reuse.

--- a/.changeset/forked-subagent-conversation.md
+++ b/.changeset/forked-subagent-conversation.md
@@ -1,5 +1,5 @@
 ---
-"deepagents": minor
+"deepagents": patch
 ---
 
 Add experimental conversation forking for subagents (`mode: "fork"`), inheriting the parent's message history and system prompt for prompt-cache reuse.

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -370,7 +370,8 @@ export function createDeepAgent<
 
   const normalizeSubagentSpec = (input: SubAgent): SubAgent => ({
     ...input,
-    tools: input.tools ?? [],
+    // Leave `tools` untouched when omitted — getSubagents() falls back to
+    // the parent's tools in that case; coercing to `[]` here would defeat that.
     middleware: buildSubagentMiddleware(input),
   });
 
@@ -378,7 +379,8 @@ export function createDeepAgent<
     input: ForkedSubAgent,
   ): ForkedSubAgent => ({
     ...input,
-    tools: input.tools ?? [],
+    // Leave `tools` untouched when omitted — getSubagents() falls back to
+    // the parent's tools in that case; coercing to `[]` here would defeat that.
     middleware: buildSubagentMiddleware(input),
   });
 

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -36,6 +36,7 @@ import { mergeMiddlewareStack } from "./middleware/utils.js";
 import {
   GENERAL_PURPOSE_SUBAGENT,
   isForkedSubAgent,
+  createParentSystemMessageMiddleware,
   type CompiledSubAgent,
   type ForkedSubAgent,
 } from "./middleware/subagents.js";
@@ -334,7 +335,6 @@ export function createDeepAgent<
 
   const buildSubagentMiddleware = (
     input: SubAgent | ForkedSubAgent,
-    isForkable: boolean,
   ): AgentMiddleware[] => {
     const subagentProfile = resolveSubagentProfile(input.model);
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(
@@ -349,7 +349,6 @@ export function createDeepAgent<
         // Resolve profile middleware per stack so factories create fresh instances.
         ...resolveMiddleware(subagentProfile.extraMiddleware),
         ...cacheMiddleware,
-        ...(isForkable ? memoryMiddleware : []),
       ],
     );
 
@@ -372,7 +371,7 @@ export function createDeepAgent<
   const normalizeSubagentSpec = (input: SubAgent): SubAgent => ({
     ...input,
     tools: input.tools ?? [],
-    middleware: buildSubagentMiddleware(input, /* isForkable */ false),
+    middleware: buildSubagentMiddleware(input),
   });
 
   const normalizeForkedSubagentSpec = (
@@ -380,7 +379,7 @@ export function createDeepAgent<
   ): ForkedSubAgent => ({
     ...input,
     tools: input.tools ?? [],
-    middleware: buildSubagentMiddleware(input, /* isForkable */ true),
+    middleware: buildSubagentMiddleware(input),
   });
 
   const allSubagents = subagents as readonly AnySubAgent[];
@@ -513,6 +512,9 @@ export function createDeepAgent<
     const excluded = harnessProfile.excludedMiddleware;
     middleware = middleware.filter((entry) => !excluded.has(entry.name));
   }
+
+  // Must run after everything that can mutate the system message, but before tool exclusion below (which must stay last).
+  middleware.push(createParentSystemMessageMiddleware());
 
   // Apply profile tool exclusions via a filtering middleware that runs
   // after all tool-injecting middleware.

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -513,8 +513,14 @@ export function createDeepAgent<
     middleware = middleware.filter((entry) => !excluded.has(entry.name));
   }
 
+  // Capturing the system message costs a state write per model call, so only pay for it when a declarative fork will consume it.
+  const hasDeclarativeFork = inlineSubagents.some(
+    (item) => !("runnable" in item) && isForkedSubAgent(item),
+  );
   // Must run after everything that can mutate the system message, but before tool exclusion below (which must stay last).
-  middleware.push(createParentSystemMessageMiddleware());
+  if (hasDeclarativeFork) {
+    middleware.push(createParentSystemMessageMiddleware());
+  }
 
   // Apply profile tool exclusions via a filtering middleware that runs
   // after all tool-injecting middleware.

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -445,6 +445,51 @@ describe("ForkedSubAgent", () => {
     ).toThrow(/ForkedSubAgent 'worker' cannot set skills/);
   });
 
+  it.each([
+    { label: "no subagents", subagents: undefined, expected: false },
+    {
+      label: "isolated (handoff) subagent",
+      subagents: [
+        {
+          name: "worker",
+          description: "Starts fresh.",
+          systemPrompt: "You are a worker.",
+        },
+      ],
+      expected: false,
+    },
+    {
+      label: "declarative fork subagent",
+      subagents: [
+        {
+          name: "worker",
+          description: "Continues with context.",
+          mode: "fork" as const,
+        },
+      ],
+      expected: true,
+    },
+  ])(
+    "only installs parentSystemMessageMiddleware for a declarative fork ($label)",
+    ({ subagents, expected }) => {
+      createAgentMock.mockClear();
+      createDeepAgent({
+        model: new FakeListChatModel({ responses: ["Done"] }),
+        systemPrompt: "PARENT_PROMPT",
+        subagents,
+      });
+
+      const calls = createAgentMock.mock.calls;
+      const mainAgentCall = calls[calls.length - 1][0] as unknown as {
+        middleware: AgentMiddleware[];
+      };
+      const installed = mainAgentCall.middleware.some(
+        (m) => m.name === "parentSystemMessageMiddleware",
+      );
+      expect(installed).toBe(expected);
+    },
+  );
+
   it("should NOT include prior history for the default handoff mode", async () => {
     const model = new FakeListChatModel({
       responses: [

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -65,6 +65,42 @@ function getAllSystemPromptsFromSpy(
   return systemPrompts;
 }
 
+// Works around FakeListChatModel always replaying its first response across a subagent's own multiple calls.
+class SequentialFakeChatModel extends FakeListChatModel {
+  private sharedCounter: { i: number };
+
+  constructor(params: {
+    responses: (string | AIMessage)[];
+    counter?: { i: number };
+  }) {
+    super({ responses: params.responses as unknown as string[] });
+    this.sharedCounter = params.counter ?? { i: 0 };
+  }
+
+  private currentResponse(): unknown {
+    return (this.responses as unknown[])[this.sharedCounter.i];
+  }
+
+  private incrementResponse(): void {
+    if (this.sharedCounter.i < this.responses.length - 1) {
+      this.sharedCounter.i += 1;
+    } else {
+      this.sharedCounter.i = 0;
+    }
+  }
+
+  override bindTools(tools: Parameters<FakeListChatModel["bindTools"]>[0]) {
+    const bound = super.bindTools(tools) as unknown as {
+      bound?: SequentialFakeChatModel;
+    } & SequentialFakeChatModel;
+    const inner = bound.bound ?? bound;
+    inner.sharedCounter = this.sharedCounter;
+    (inner as any)._currentResponse = this.currentResponse.bind(inner);
+    (inner as any)._incrementResponse = this.incrementResponse.bind(inner);
+    return bound;
+  }
+}
+
 const TEST_SKILL_MD = `---
 name: test-skill
 description: A test skill for subagent isolation tests
@@ -392,6 +428,23 @@ describe("ForkedSubAgent", () => {
     ).toThrow(/invalid mode 'dynamic'/);
   });
 
+  it("throws at construction when a ForkedSubAgent declares skills", () => {
+    // `as any` bypasses the `skills?: undefined` compile-time guard to exercise the runtime check.
+    expect(() =>
+      createDeepAgent({
+        model: new FakeListChatModel({ responses: ["Done"] }),
+        subagents: [
+          {
+            name: "worker",
+            description: "A worker agent",
+            mode: "fork",
+            skills: ["/skills/user/"],
+          } as any,
+        ],
+      }),
+    ).toThrow(/ForkedSubAgent 'worker' cannot set skills/);
+  });
+
   it("should NOT include prior history for the default handoff mode", async () => {
     const model = new FakeListChatModel({
       responses: [
@@ -497,9 +550,129 @@ describe("ForkedSubAgent", () => {
     const systemMessage = workerCall!.find(SystemMessage.isInstance);
     expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
 
-    // No own systemPrompt to relocate — the trailing message is bare.
+    // The trailing message carries the fork identity preamble ahead of the bare task description.
     const lastMessage = workerCall![workerCall!.length - 1];
-    expect(lastMessage.content).toBe("UNIQUE_TASK_MARKER");
+    expect(lastMessage.content).toContain(
+      "you are that subagent, not the one being asked to delegate further",
+    );
+    expect(lastMessage.content).toMatch(/UNIQUE_TASK_MARKER$/);
+  });
+
+  it("replays the parent's just-computed skills-injected system message into a fork, not a stale static copy", async () => {
+    const taskToolCallId = `call_${Date.now()}`;
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: taskToolCallId,
+              name: "task",
+              args: {
+                description: "continue investigating",
+                subagent_type: "worker",
+              },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createDeepAgent({
+      model,
+      skills: ["/skills/"],
+      checkpointer,
+      subagents: [
+        {
+          name: "worker",
+          description: "Continues the investigation with full context",
+          mode: "fork",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      {
+        messages: [new HumanMessage("Investigate this")],
+        files: {
+          "/skills/test-skill/SKILL.md": createFileData(TEST_SKILL_MD),
+        },
+      },
+      {
+        configurable: { thread_id: `test-fork-skills-${Date.now()}` },
+        recursionLimit: 50,
+      },
+    );
+
+    const systemPrompts = getAllSystemPromptsFromSpy(invokeSpy);
+    expect(systemPrompts[0]).toContain("Skills System");
+
+    const forkPrompts = systemPrompts
+      .slice(1)
+      .filter((p) => p.includes("Skills System"));
+    expect(forkPrompts.length).toBeGreaterThan(0);
+    expect(forkPrompts[0]).toContain("test-skill");
+  });
+
+  it("refuses a fork's own attempt to delegate again, rather than recursing", async () => {
+    const parentModel = new SequentialFakeChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "call_worker",
+              name: "task",
+              args: { description: "continue", subagent_type: "worker" },
+            },
+          ],
+        }),
+        "parent done",
+      ],
+    });
+
+    const workerModel = new SequentialFakeChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "call_worker_2",
+              name: "task",
+              args: { description: "delegate again", subagent_type: "worker" },
+            },
+          ],
+        }),
+        "worker done after refusal",
+      ],
+    });
+
+    const agent = createDeepAgent({
+      model: parentModel,
+      subagents: [
+        {
+          name: "worker",
+          description: "Continues with context.",
+          model: workerModel,
+          mode: "fork",
+        },
+      ],
+    });
+
+    const result = await agent.invoke(
+      { messages: [new HumanMessage("start")] },
+      { recursionLimit: 10 },
+    );
+
+    const messages = result.messages as BaseMessage[];
+    const toolMessage = messages.find(ToolMessage.isInstance);
+    expect(toolMessage?.content).toBe("worker done after refusal");
+
+    const lastMessage = messages[messages.length - 1];
+    expect(lastMessage?.content).toBe("parent done");
   });
 
   it("should exclude the in-flight AIMessage, including a parallel sibling tool call", async () => {

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -1807,6 +1807,39 @@ describe("lc_agent_name propagation for subagents", () => {
   });
 });
 
+describe("Subagent tool inheritance", () => {
+  beforeEach(() => {
+    createAgentMock.mockClear();
+  });
+
+  it("inherits the parent's tools when a declarative subagent omits its own, for both handoff and fork", () => {
+    const parentTool = tool(async () => "logs", {
+      name: "read_logs",
+      description: "Read logs",
+      schema: z.object({}),
+    });
+
+    createDeepAgent({
+      model: new FakeListChatModel({ responses: ["ok"] }),
+      tools: [parentTool],
+      subagents: [
+        { name: "handoff-worker", description: "a worker" },
+        { name: "fork-worker", description: "a worker", mode: "fork" },
+      ],
+    });
+
+    const toolsByAgentName = new Map(
+      createAgentMock.mock.calls.map((call) => [
+        (call[0] as { name?: string }).name,
+        (call[0] as { tools?: unknown[] }).tools,
+      ]),
+    );
+
+    expect(toolsByAgentName.get("handoff-worker")).toEqual([parentTool]);
+    expect(toolsByAgentName.get("fork-worker")).toEqual([parentTool]);
+  });
+});
+
 describe("createSubAgent", () => {
   const fakeModel = new FakeListChatModel({ responses: ["hello"] });
 

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -42,7 +42,11 @@ import {
 import { mergeMiddleware } from "./utils.js";
 import { createFileData } from "../backends/utils.js";
 import { createMockBackend } from "./test.js";
-import { createSubAgent, filterStateForSubagent } from "./subagents.js";
+import {
+  createSubAgent,
+  createSubAgentMiddleware,
+  filterStateForSubagent,
+} from "./subagents.js";
 import { registerHarnessProfile } from "../profiles/index.js";
 
 const createAgentMock = vi.mocked(createAgent);
@@ -922,6 +926,41 @@ describe("ForkedSubAgent", () => {
       .join("\n");
     expect(text).toContain("BANANA42");
     expect(text).toContain("UNIQUE_TASK_MARKER");
+  });
+
+  it("tells the parent a compiled fork only inherits history, not system prompt", () => {
+    const compiledWorker = createAgent({
+      model: new FakeListChatModel({ responses: ["ok"] }),
+    });
+
+    const middleware = createSubAgentMiddleware({
+      defaultModel: new FakeListChatModel({ responses: ["ok"] }),
+      generalPurposeAgent: false,
+      subagents: [
+        {
+          name: "declarative-fork",
+          description: "Forks declaratively",
+          mode: "fork",
+        },
+        {
+          name: "compiled-fork",
+          description: "Forks via a compiled runnable",
+          runnable: compiledWorker,
+          mode: "fork",
+        },
+      ],
+    });
+
+    const taskTool = middleware.tools![0];
+    expect(taskTool.description).toContain(
+      "declarative-fork: Forks declaratively (inherits your full conversation and system prompt — no need to restate context here)",
+    );
+    expect(taskTool.description).toContain(
+      "compiled-fork: Forks via a compiled runnable (inherits your conversation history — its system prompt is fixed in its own runnable)",
+    );
+    expect(taskTool.description).not.toContain(
+      "compiled-fork: Forks via a compiled runnable (inherits your full conversation and system prompt",
+    );
   });
 
   it("should reconstruct the already-summarized effective view, not raw history, when forking", () => {

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -465,7 +465,7 @@ function stripInFlightAIMessage(messages: BaseMessage[]): BaseMessage[] {
 }
 
 const ParentSystemMessageStateSchema = z.object({
-  _deepagentsParentSystemMessage: z.instanceof(SystemMessage).optional(),
+  [PARENT_SYSTEM_MESSAGE_KEY]: z.instanceof(SystemMessage).optional(),
 });
 
 // Captures the parent's fully-resolved system message into state so a fork can replay it verbatim.
@@ -476,7 +476,7 @@ export function createParentSystemMessageMiddleware(): AgentMiddleware {
     wrapModelCall: async (request, handler) => {
       await handler(request);
       return new Command({
-        update: { _deepagentsParentSystemMessage: request.systemMessage },
+        update: { [PARENT_SYSTEM_MESSAGE_KEY]: request.systemMessage },
       });
     },
   });
@@ -488,7 +488,7 @@ function createForkSystemMessageMiddleware(): AgentMiddleware {
     name: "forkSystemMessageMiddleware",
     stateSchema: ParentSystemMessageStateSchema,
     wrapModelCall: async (request, handler) => {
-      const parentMessage = request.state._deepagentsParentSystemMessage;
+      const parentMessage = request.state[PARENT_SYSTEM_MESSAGE_KEY];
       if (parentMessage != null) {
         return handler({ ...request, systemMessage: parentMessage });
       }
@@ -498,7 +498,7 @@ function createForkSystemMessageMiddleware(): AgentMiddleware {
 }
 
 const ForkedContextStateSchema = z.object({
-  _deepagentsForkedContext: z.boolean().optional(),
+  [FORKED_CONTEXT_KEY]: z.boolean().optional(),
 });
 
 // Gives a fork a real (but recursion-refusing) `task` tool; must be a separate object from the parent's, and the flag must be set via `beforeAgent` — `getCurrentTaskInput()` won't see it if only seeded on the initial invoke() input.
@@ -509,7 +509,7 @@ function createForkTaskToolMiddleware(
     name: "forkTaskToolMiddleware",
     stateSchema: ForkedContextStateSchema,
     tools: [taskTool],
-    beforeAgent: () => ({ _deepagentsForkedContext: true }),
+    beforeAgent: () => ({ [FORKED_CONTEXT_KEY]: true }),
   });
 }
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -91,17 +91,28 @@ function getTaskToolDescription(subagentDescriptions: string[]): string {
   `;
 }
 
-// Appended to a forked subagent's line so the model knows it can skip restating context.
+// Appended to a declarative forked subagent's line so the model knows it can skip restating context.
 const FORKED_SUBAGENT_TOOL_NOTE =
   " (inherits your full conversation and system prompt — no need to restate context here)";
+
+// A compiled fork's runnable bakes in its own system prompt (see CompiledSubAgent.mode),
+// so it only inherits conversation history — never claim system-prompt inheritance for it.
+const COMPILED_FORKED_SUBAGENT_TOOL_NOTE =
+  " (inherits your conversation history — its system prompt is fixed in its own runnable)";
 
 /** Render one subagent's listing line for the task tool description. */
 function describeSubagentForTool(
   name: string,
   description: string,
   forked: boolean,
+  compiled = false,
 ): string {
-  return `- ${name}: ${description}${forked ? FORKED_SUBAGENT_TOOL_NOTE : ""}`;
+  const suffix = forked
+    ? compiled
+      ? COMPILED_FORKED_SUBAGENT_TOOL_NOTE
+      : FORKED_SUBAGENT_TOOL_NOTE
+    : "";
+  return `- ${name}: ${description}${suffix}`;
 }
 
 // Marks the replayed delegation as already-happened, so the fork doesn't mistake it as a fresh request.
@@ -631,12 +642,14 @@ function getSubagents(options: {
     }
 
     const forked = isForkedSubAgent(agentParams);
+    const compiled = "runnable" in agentParams;
 
     subagentDescriptions.push(
       describeSubagentForTool(
         agentParams.name,
         agentParams.description,
         forked,
+        compiled,
       ),
     );
 
@@ -742,6 +755,7 @@ function createTaskTool(options: {
         spec.name,
         spec.description,
         isForkedSubAgent(spec),
+        "runnable" in spec,
       ),
     ),
   ];

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -41,6 +41,15 @@ export const SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY =
 export const DEFAULT_SUBAGENT_PROMPT =
   "In order to complete the objective that the user asks of you, you have access to a number of standard tools.";
 
+// Carries the parent's post-middleware system message into a fork so it can replay it verbatim.
+const PARENT_SYSTEM_MESSAGE_KEY = "_deepagentsParentSystemMessage";
+
+// Set on a forked subagent's own initial state; lets the task tool refuse recursive delegation.
+const FORKED_CONTEXT_KEY = "_deepagentsForkedContext";
+
+const FORK_RECURSION_REFUSAL =
+  "You are a subagent and cannot delegate to another subagent. Complete this task yourself instead of calling this tool again.";
+
 /**
  * State keys excluded when passing state to subagents and when returning
  * updates from subagents. Summarization keys are excluded because their
@@ -54,6 +63,8 @@ const EXCLUDED_STATE_KEYS = [
   "memoryContents",
   "_summarizationEvent",
   "_summarizationSessionId",
+  PARENT_SYSTEM_MESSAGE_KEY,
+  FORKED_CONTEXT_KEY,
 ] as const;
 
 /**
@@ -65,20 +76,45 @@ export const DEFAULT_GENERAL_PURPOSE_DESCRIPTION =
 
 function getTaskToolDescription(subagentDescriptions: string[]): string {
   return context`
-    Launch an ephemeral subagent to handle a complex, multi-step task in an isolated context window.
+    Launch an ephemeral subagent to handle a complex, multi-step task.
 
     Available agent types and the tools they have access to:
     ${subagentDescriptions.join("\n")}
 
     Specify subagent_type to select the agent. Usage notes:
     - Launch multiple agents concurrently when their tasks are independent, using a single message with multiple tool calls.
-    - Each invocation is stateless: the agent sees only the prompt you give it and returns a single final report. Put full detail in the prompt and state exactly what it should return.
+    - Each invocation is stateless by default: the agent sees only the prompt you give it and returns a single final report. Put full detail in the prompt and state exactly what it should return — unless an agent type below says it inherits your conversation instead.
     - The agent's report is not shown to the user; relay a summary yourself.
-    - Tell the agent whether to create content, analyze, or only research, since it cannot see the user's intent.
+    - Tell the agent whether to create content, analyze, or only research, since it can't necessarily see the user's intent unless it inherits your conversation, as noted per agent type below.
     - If an agent's description says to use it proactively, do so without waiting to be asked.
     - When only general-purpose is available, use it for any complex, context-heavy task; it has the same capabilities as the main agent.
   `;
 }
+
+// Appended to a forked subagent's line so the model knows it can skip restating context.
+const FORKED_SUBAGENT_TOOL_NOTE =
+  " (inherits your full conversation and system prompt — no need to restate context here)";
+
+/** Render one subagent's listing line for the task tool description. */
+function describeSubagentForTool(
+  name: string,
+  description: string,
+  forked: boolean,
+): string {
+  return `- ${name}: ${description}${forked ? FORKED_SUBAGENT_TOOL_NOTE : ""}`;
+}
+
+// Marks the replayed delegation as already-happened, so the fork doesn't mistake it as a fresh request.
+const FORK_TASK_PREAMBLE =
+  "[The messages above are a prior conversation you are continuing as the " +
+  "subagent that was just invoked. Any mention in them of delegating to a " +
+  "subagent already happened — you are that subagent, not the one being " +
+  "asked to delegate further. If you try to delegate to another subagent " +
+  "yourself, it will be refused — complete this task directly. Use the " +
+  "specific facts, figures, and identifiers already established in that " +
+  "conversation when completing the task below — do not answer " +
+  "generically when exact details are already available above. Your " +
+  "actual task is below.]\n\n";
 
 /**
  * Type definitions for pre-compiled agents.
@@ -276,6 +312,9 @@ export interface ForkedSubAgent extends SubAgentBase {
   /** A ForkedSubAgent never has its own system prompt — always the parent's. */
   systemPrompt?: undefined;
 
+  /** A ForkedSubAgent cannot declare its own skills — the inherited system message would discard them. */
+  skills?: undefined;
+
   /**
    * Always `"fork"`. Required (not defaulted) so this can't structurally
    * collapse into a plain `SubAgent` — see `isForkedSubAgent` below.
@@ -414,6 +453,55 @@ function stripInFlightAIMessage(messages: BaseMessage[]): BaseMessage[] {
   return hasPendingToolCalls ? messages.slice(0, -1) : messages;
 }
 
+const ParentSystemMessageStateSchema = z.object({
+  _deepagentsParentSystemMessage: z.instanceof(SystemMessage).optional(),
+});
+
+// Captures the parent's fully-resolved system message into state so a fork can replay it verbatim.
+export function createParentSystemMessageMiddleware(): AgentMiddleware {
+  return createMiddleware({
+    name: "parentSystemMessageMiddleware",
+    stateSchema: ParentSystemMessageStateSchema,
+    wrapModelCall: async (request, handler) => {
+      await handler(request);
+      return new Command({
+        update: { _deepagentsParentSystemMessage: request.systemMessage },
+      });
+    },
+  });
+}
+
+// Replays the parent's captured system message verbatim, required for Anthropic's cache to hit.
+function createForkSystemMessageMiddleware(): AgentMiddleware {
+  return createMiddleware({
+    name: "forkSystemMessageMiddleware",
+    stateSchema: ParentSystemMessageStateSchema,
+    wrapModelCall: async (request, handler) => {
+      const parentMessage = request.state._deepagentsParentSystemMessage;
+      if (parentMessage != null) {
+        return handler({ ...request, systemMessage: parentMessage });
+      }
+      return handler(request);
+    },
+  });
+}
+
+const ForkedContextStateSchema = z.object({
+  _deepagentsForkedContext: z.boolean().optional(),
+});
+
+// Gives a fork a real (but recursion-refusing) `task` tool; must be a separate object from the parent's, and the flag must be set via `beforeAgent` — `getCurrentTaskInput()` won't see it if only seeded on the initial invoke() input.
+function createForkTaskToolMiddleware(
+  taskTool: StructuredTool,
+): AgentMiddleware {
+  return createMiddleware({
+    name: "forkTaskToolMiddleware",
+    stateSchema: ForkedContextStateSchema,
+    tools: [taskTool],
+    beforeAgent: () => ({ _deepagentsForkedContext: true }),
+  });
+}
+
 /**
  * Create a runnable agent from a declarative `SubAgent` spec.
  *
@@ -478,6 +566,8 @@ function getSubagents(options: {
   subagents: (SubAgent | CompiledSubAgent | ForkedSubAgent)[];
   generalPurposeAgent: boolean;
   parentSystemPrompt?: string | SystemMessage | null;
+  /** The exact tool instance forked subagents mirror — see `createTaskTool`. */
+  mirroredTaskTool: StructuredTool;
 }): {
   agents: Record<string, ReactAgent | Runnable>;
   specsByName: Record<string, SubAgent | CompiledSubAgent>;
@@ -493,6 +583,7 @@ function getSubagents(options: {
     subagents,
     generalPurposeAgent,
     parentSystemPrompt = null,
+    mirroredTaskTool,
   } = options;
 
   const defaultSubagentMiddleware = defaultMiddleware || [];
@@ -523,7 +614,11 @@ function getSubagents(options: {
     agents["general-purpose"] = createSubAgent(gpSpec);
     specsByName["general-purpose"] = gpSpec;
     subagentDescriptions.push(
-      `- general-purpose: ${DEFAULT_GENERAL_PURPOSE_DESCRIPTION}`,
+      describeSubagentForTool(
+        "general-purpose",
+        DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
+        false,
+      ),
     );
   }
 
@@ -535,19 +630,29 @@ function getSubagents(options: {
       );
     }
 
+    const forked = isForkedSubAgent(agentParams);
+
     subagentDescriptions.push(
-      `- ${agentParams.name}: ${agentParams.description}`,
+      describeSubagentForTool(
+        agentParams.name,
+        agentParams.description,
+        forked,
+      ),
     );
 
     if ("runnable" in agentParams) {
       agents[agentParams.name] = agentParams.runnable;
       specsByName[agentParams.name] = agentParams;
-      if (isForkedSubAgent(agentParams)) forkModeNames.add(agentParams.name);
-    } else if (isForkedSubAgent(agentParams)) {
-      // ForkedSubAgent — always forks, always inherits the parent's exact
-      // system prompt directly; there's no own prompt to fall back to.
-      // `mode` is omitted here (not "handoff"): the real fork signal is
-      // forkModeNames below — SubAgent's own `mode` type can't hold "fork".
+      if (forked) forkModeNames.add(agentParams.name);
+    } else if (forked) {
+      // Cast around the `skills?: undefined` type guard to check it at runtime too.
+      const rawSkills = (agentParams as { skills?: unknown }).skills;
+      if (Array.isArray(rawSkills) && rawSkills.length > 0) {
+        throw new Error(
+          `ForkedSubAgent '${agentParams.name}' cannot set skills; the parent's system message would discard it.`,
+        );
+      }
+      // The static systemPrompt is just a construction-time baseline; forkSystemMessageMiddleware overrides it every call.
       const resolvedSpec: SubAgent = {
         ...agentParams,
         systemPrompt: parentSystemPrompt ?? "",
@@ -557,6 +662,8 @@ function getSubagents(options: {
         middleware: [
           ...defaultSubagentMiddleware,
           ...(agentParams.middleware ?? []),
+          createForkSystemMessageMiddleware(),
+          createForkTaskToolMiddleware(mirroredTaskTool),
         ],
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
@@ -615,21 +722,38 @@ function createTaskTool(options: {
     parentSystemPrompt = null,
   } = options;
 
-  const {
-    agents: subagentGraphs,
-    specsByName,
-    descriptions: subagentDescriptions,
-    forkModeNames,
-  } = getSubagents({
-    defaultModel,
-    defaultTools,
-    defaultMiddleware,
-    generalPurposeMiddleware,
-    defaultInterruptOn,
-    subagents,
-    generalPurposeAgent,
-    parentSystemPrompt,
-  });
+  // Computed from raw specs so the mirrored task tool below shares this exact description string.
+  const subagentNames = [
+    ...(generalPurposeAgent ? ["general-purpose"] : []),
+    ...subagents.map((spec) => spec.name),
+  ];
+  const subagentDescriptions = [
+    ...(generalPurposeAgent
+      ? [
+          describeSubagentForTool(
+            "general-purpose",
+            DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
+            false,
+          ),
+        ]
+      : []),
+    ...subagents.map((spec) =>
+      describeSubagentForTool(
+        spec.name,
+        spec.description,
+        isForkedSubAgent(spec),
+      ),
+    ),
+  ];
+
+  const finalTaskDescription = taskDescription
+    ? taskDescription
+    : getTaskToolDescription(subagentDescriptions);
+
+  // Populated below by getSubagents(); runTask only reads these once actually invoked.
+  let subagentGraphs: Record<string, ReactAgent | Runnable> = {};
+  let specsByName: Record<string, SubAgent | CompiledSubAgent> = {};
+  let forkModeNames: Set<string> = new Set();
 
   function selectSubagent(
     subagentType: string,
@@ -652,101 +776,139 @@ function createTaskTool(options: {
     return createSubAgent(spec, { responseFormat }) as unknown as Runnable;
   }
 
-  const finalTaskDescription = taskDescription
-    ? taskDescription
-    : getTaskToolDescription(subagentDescriptions);
+  async function runTask(
+    input: { description: string; subagent_type: string },
+    config: Record<string, any>,
+  ): Promise<Command | string> {
+    const { description, subagent_type } = input;
 
-  return tool(
-    async (input, config): Promise<Command | string> => {
-      const { description, subagent_type } = input;
+    const currentState = getCurrentTaskInput<Record<string, unknown>>();
+    if (currentState[FORKED_CONTEXT_KEY]) {
+      return FORK_RECURSION_REFUSAL;
+    }
 
-      if (!(subagent_type in subagentGraphs)) {
-        const allowedTypes = Object.keys(subagentGraphs)
-          .map((k) => `\`${k}\``)
-          .join(", ");
-        throw new Error(
-          `Error: invoked agent of type ${subagent_type}, the only allowed types are ${allowedTypes}`,
+    if (!(subagent_type in subagentGraphs)) {
+      const allowedTypes = Object.keys(subagentGraphs)
+        .map((k) => `\`${k}\``)
+        .join(", ");
+      throw new Error(
+        `Error: invoked agent of type ${subagent_type}, the only allowed types are ${allowedTypes}`,
+      );
+    }
+
+    const shouldFork = forkModeNames.has(subagent_type);
+
+    const subagent = selectSubagent(subagent_type, config);
+
+    const subagentState = filterStateForSubagent(currentState);
+
+    if (shouldFork) {
+      const trimmed = stripInFlightAIMessage(
+        (currentState.messages as BaseMessage[]) ?? [],
+      );
+      const effective = getEffectiveMessages(trimmed, currentState);
+      subagentState.messages = [
+        ...effective,
+        new HumanMessage({ content: FORK_TASK_PREAMBLE + description }),
+      ];
+      const spec = specsByName[subagent_type];
+      const parentSystemMessage = currentState[PARENT_SYSTEM_MESSAGE_KEY];
+      if (parentSystemMessage != null && !("runnable" in spec)) {
+        subagentState[PARENT_SYSTEM_MESSAGE_KEY] = parentSystemMessage;
+      }
+    } else {
+      subagentState.messages = [new HumanMessage({ content: description })];
+    }
+    subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
+
+    const subagentConfig = {
+      ...config,
+      metadata: {
+        ...config.metadata,
+        lc_agent_name: subagent_type,
+      },
+      configurable: {
+        ...config.configurable,
+        ls_agent_type: "subagent",
+      },
+    };
+    const result = (await subagent.invoke(
+      subagentState,
+      subagentConfig,
+    )) as Record<string, unknown>;
+
+    if (!config.toolCall?.id) {
+      if (result.structuredResponse != null) {
+        return JSON.stringify(result.structuredResponse);
+      }
+      const messages = result.messages as BaseMessage[];
+      const lastMessage = messages?.[messages.length - 1];
+      let content: string | ContentBlock[] =
+        lastMessage?.content || "Task completed";
+      if (Array.isArray(content)) {
+        content = content.filter(
+          (block) => !INVALID_TOOL_MESSAGE_BLOCK_TYPES.includes(block.type),
         );
-      }
-
-      const shouldFork = forkModeNames.has(subagent_type);
-
-      const subagent = selectSubagent(subagent_type, config);
-
-      const currentState = getCurrentTaskInput<Record<string, unknown>>();
-      const subagentState = filterStateForSubagent(currentState);
-
-      if (shouldFork) {
-        const trimmed = stripInFlightAIMessage(
-          (currentState.messages as BaseMessage[]) ?? [],
-        );
-        const effective = getEffectiveMessages(trimmed, currentState);
-        subagentState.messages = [
-          ...effective,
-          new HumanMessage({ content: description }),
-        ];
-      } else {
-        subagentState.messages = [new HumanMessage({ content: description })];
-      }
-      subagentState._summarizationSessionId = `session_${crypto.randomUUID().substring(0, 8)}`;
-
-      const subagentConfig = {
-        ...config,
-        metadata: {
-          ...config.metadata,
-          lc_agent_name: subagent_type,
-        },
-        configurable: {
-          ...config.configurable,
-          ls_agent_type: "subagent",
-        },
-      };
-      const result = (await subagent.invoke(
-        subagentState,
-        subagentConfig,
-      )) as Record<string, unknown>;
-
-      if (!config.toolCall?.id) {
-        if (result.structuredResponse != null) {
-          return JSON.stringify(result.structuredResponse);
+        if (content.length === 0) {
+          return "Task completed";
         }
-        const messages = result.messages as BaseMessage[];
-        const lastMessage = messages?.[messages.length - 1];
-        let content: string | ContentBlock[] =
-          lastMessage?.content || "Task completed";
-        if (Array.isArray(content)) {
-          content = content.filter(
-            (block) => !INVALID_TOOL_MESSAGE_BLOCK_TYPES.includes(block.type),
-          );
-          if (content.length === 0) {
-            return "Task completed";
-          }
-          return content
-            .map((block) =>
-              "text" in block ? block.text : JSON.stringify(block),
-            )
-            .join("\n");
-        }
-        return content;
+        return content
+          .map((block) =>
+            "text" in block ? block.text : JSON.stringify(block),
+          )
+          .join("\n");
       }
+      return content;
+    }
 
-      return returnCommandWithStateUpdate(result, config.toolCall.id);
-    },
-    {
-      name: "task",
-      description: finalTaskDescription,
-      schema: z.object({
-        description: z
-          .string()
-          .describe("The task to execute with the selected agent"),
-        subagent_type: z
-          .string()
-          .describe(
-            `Name of the agent to use. Available: ${Object.keys(subagentGraphs).join(", ")}`,
-          ),
-      }),
-    },
-  );
+    return returnCommandWithStateUpdate(result, config.toolCall.id);
+  }
+
+  const taskToolSchema = z.object({
+    description: z
+      .string()
+      .describe("The task to execute with the selected agent"),
+    subagent_type: z
+      .string()
+      .describe(
+        `Name of the agent to use. Available: ${subagentNames.join(", ")}`,
+      ),
+  });
+
+  const taskTool = tool(runTask, {
+    name: "task",
+    description: finalTaskDescription,
+    schema: taskToolSchema,
+  });
+
+  // A separate wrapper around the same name/description/schema/function, not the same object — see createForkTaskToolMiddleware.
+  const mirroredTaskTool = tool(runTask, {
+    name: "task",
+    description: finalTaskDescription,
+    schema: taskToolSchema,
+  });
+
+  const {
+    agents,
+    specsByName: resolvedSpecsByName,
+    forkModeNames: resolvedForkModeNames,
+  } = getSubagents({
+    defaultModel,
+    defaultTools,
+    defaultMiddleware,
+    generalPurposeMiddleware,
+    defaultInterruptOn,
+    subagents,
+    generalPurposeAgent,
+    parentSystemPrompt,
+    mirroredTaskTool,
+  });
+
+  subagentGraphs = agents;
+  specsByName = resolvedSpecsByName;
+  forkModeNames = resolvedForkModeNames;
+
+  return taskTool;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR backports a set of fixes that landed later in Python
`deepagents`'s equivalent feature (langchain-ai/deepagents#5714)

## What's included

- **Dynamic system-message capture and replay** — a fork now gets the parent's actual composed system message (skills, memory, etc.), not a stale static copy, so the prompt cache can hit.
- **Identity-preserving preamble** — tells a fork it's continuing a prior conversation, not receiving a fresh request.
- **Recursion refusal** — a fork's task tool refuses re-delegation instead of recursing.
- **Tool-description hint for the parent** — marks forked subagents in the task tool listing so the parent knows they don't need context restated.
- **Memory-middleware parity fix** — forks no longer get memoryMiddleware mirrored in, matching Python.

## Testing

- New unit tests: skills-injected system message replay into a fork,
  rejection of `skills` on a `ForkedSubAgent` at construction, a fork's own
  attempt to delegate again being refused rather than recursing, and
  `parentSystemMessageMiddleware` only being installed when a declarative
  fork is actually present.