### PR TITLE
feat(sprites): add Fly.io Sprites sandbox provider

### DIFF
--- a/.changeset/sprites-sandbox.md
+++ b/.changeset/sprites-sandbox.md
@@ -1,0 +1,17 @@
+---
+"@langchain/sprites": minor
+---
+
+feat(sprites): add Fly.io Sprites sandbox provider for DeepAgents
+
+Adds `@langchain/sprites` package providing Fly.io Sprites sandbox integration for the DeepAgents framework.
+
+Features:
+
+- Command execution via `execute()` in persistent Linux VMs that boot in 1-2 seconds
+- File operations via `uploadFiles()` and `downloadFiles()`
+- Initial file population via `initialFiles` option
+- Persistent named sandboxes: reconnect with `SpritesSandbox.fromName()` after idle suspend
+- Full-machine `checkpoint()` / `restore()` for rolling back agent changes
+- Direct SDK access via `.client` and `.instance` properties
+- Configurable machine sizing (RAM, CPUs, region, storage), environment variables, labels, and timeouts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,4 @@ jobs:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          SPRITES_TOKEN: ${{ secrets.SPRITES_TOKEN }}

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -87,6 +87,7 @@ jobs:
             quickjs
             node-vfs
             deno
+            sprites
             evals
             examples
             docs

--- a/libs/providers/sprites/.npmignore
+++ b/libs/providers/sprites/.npmignore
@@ -1,0 +1,22 @@
+# Source files
+src/
+*.ts
+!*.d.ts
+
+# Test files
+**/*.test.ts
+**/*.int.test.ts
+vitest.config.ts
+
+# Config
+tsconfig.json
+tsdown.config.ts
+.tsdown/
+
+# Development
+.env
+.env.*
+
+# Editor
+.vscode/
+.idea/

--- a/libs/providers/sprites/LICENSE
+++ b/libs/providers/sprites/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) LangChain, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/libs/providers/sprites/README.md
+++ b/libs/providers/sprites/README.md
@@ -1,6 +1,6 @@
 # @langchain/sprites
 
-[Fly.io Sprites](https://sprites.dev) sandbox backend for [deepagents](https://www.npmjs.com/package/deepagents). This package provides a `SpritesSandbox` implementation of the `SandboxBackendProtocol`, enabling agents to execute commands, read/write files, and manage isolated sandbox environments using Fly.io's Sprites infrastructure.
+[Fly.io Sprites](https://fly.io/sprites) sandbox backend for [deepagents](https://www.npmjs.com/package/deepagents). This package provides a `SpritesSandbox` implementation of the `SandboxBackendProtocol`, enabling agents to execute commands, read/write files, and manage isolated sandbox environments using Fly.io's Sprites infrastructure.
 
 [![npm version](https://img.shields.io/npm/v/@langchain/sprites.svg)](https://www.npmjs.com/package/@langchain/sprites)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -34,7 +34,7 @@ The package requires a Sprites API token:
 
 ### Environment Variable (Recommended)
 
-1. Install the [Sprites CLI](https://sprites.dev/docs) and run `sprite login`
+1. Install the [Sprites CLI](https://docs.sprites.dev) and run `sprite login`
 2. Create an API token
 3. Set it as an environment variable:
 

--- a/libs/providers/sprites/README.md
+++ b/libs/providers/sprites/README.md
@@ -1,0 +1,199 @@
+# @langchain/sprites
+
+[Fly.io Sprites](https://sprites.dev) sandbox backend for [deepagents](https://www.npmjs.com/package/deepagents). This package provides a `SpritesSandbox` implementation of the `SandboxBackendProtocol`, enabling agents to execute commands, read/write files, and manage isolated sandbox environments using Fly.io's Sprites infrastructure.
+
+[![npm version](https://img.shields.io/npm/v/@langchain/sprites.svg)](https://www.npmjs.com/package/@langchain/sprites)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Features
+
+- **Instant Creation**: Sprites are full Linux VMs that boot in 1-2 seconds
+- **Persistent Sandboxes**: Named, stateful environments that suspend when idle (at no cost) and resume with all files and installed packages intact
+- **Checkpoint & Restore**: Snapshot the full filesystem and process state, and roll back in seconds
+- **File Operations**: Upload and download files with full filesystem access
+- **BaseSandbox Integration**: All inherited methods (`read`, `write`, `edit`, `ls`, `grep`, `glob`) work out of the box
+- **Factory Pattern**: Compatible with deepagents' middleware architecture
+- **Full SDK Access**: Access the underlying [Sprites SDK](https://github.com/superfly/sprites-js) via the `instance` and `client` properties for advanced features (services, network policy, port proxying)
+
+## Installation
+
+```bash
+# npm
+npm install @langchain/sprites
+
+# yarn
+yarn add @langchain/sprites
+
+# pnpm
+pnpm add @langchain/sprites
+```
+
+## Authentication Setup
+
+The package requires a Sprites API token:
+
+### Environment Variable (Recommended)
+
+1. Install the [Sprites CLI](https://sprites.dev/docs) and run `sprite login`
+2. Create an API token
+3. Set it as an environment variable:
+
+```bash
+export SPRITES_TOKEN=your_token_here
+```
+
+### Programmatic Configuration
+
+```typescript
+const sandbox = await SpritesSandbox.create({
+  auth: { token: "your_token_here" },
+});
+```
+
+## Usage
+
+### Basic Sandbox Operations
+
+```typescript
+import { SpritesSandbox } from "@langchain/sprites";
+
+const sandbox = await SpritesSandbox.create();
+
+try {
+  const result = await sandbox.execute("echo 'Hello from a Sprite'");
+  console.log(result.output, result.exitCode);
+
+  const encoder = new TextEncoder();
+  await sandbox.uploadFiles([
+    ["app/index.js", encoder.encode("console.log('hi')")],
+  ]);
+  const [file] = await sandbox.downloadFiles(["app/index.js"]);
+} finally {
+  await sandbox.close(); // deletes the Sprite
+}
+```
+
+### With a Deep Agent
+
+```typescript
+import { createDeepAgent } from "deepagents";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { SpritesSandbox } from "@langchain/sprites";
+
+const sandbox = await SpritesSandbox.create();
+
+try {
+  const agent = createDeepAgent({
+    model: new ChatAnthropic({ model: "claude-sonnet-4-5" }),
+    systemPrompt: "You are a coding assistant with sandbox access.",
+    backend: sandbox,
+  });
+
+  const result = await agent.invoke({
+    messages: [
+      { role: "user", content: "Create and run a hello world script" },
+    ],
+  });
+} finally {
+  await sandbox.close();
+}
+```
+
+### Persistent Sandboxes
+
+Sprites are named and persistent. If you don't call `close()`, the Sprite
+suspends when idle and you can pick it up later — with all installed
+packages, files, and state intact:
+
+```typescript
+// Day 1
+const sandbox = await SpritesSandbox.create({ name: "my-agent-env" });
+await sandbox.execute("npm install express");
+
+// Day 2 — resumes in ~1 second
+const sameSandbox = await SpritesSandbox.fromName("my-agent-env");
+await sameSandbox.execute("node server.js");
+```
+
+### Checkpoint and Restore
+
+Snapshot the full machine state before letting an agent loose, and roll back
+if it goes sideways:
+
+```typescript
+const checkpoint = await sandbox.checkpoint("before agent run");
+
+await agent.invoke({ messages: [...] });
+
+// Didn't like the result? Roll everything back.
+await sandbox.restore(checkpoint.id);
+```
+
+### Factories
+
+```typescript
+import {
+  createSpritesSandboxFactory,
+  createSpritesSandboxFactoryFromSandbox,
+} from "@langchain/sprites";
+
+// A fresh sandbox per invocation (async factory)
+const factory = createSpritesSandboxFactory({ timeout: 300 });
+
+// Reuse one sandbox across invocations (sync BackendFactory for middleware)
+const backend = createSpritesSandboxFactoryFromSandbox(sandbox);
+```
+
+## Configuration
+
+| Option            | Description                                        | Default                         |
+| ----------------- | -------------------------------------------------- | ------------------------------- |
+| `name`            | Sprite name (its persistent identity)              | generated `deepagents-<random>` |
+| `config`          | Machine sizing: `{ ramMB, cpus, region, storageGB }` | API defaults                  |
+| `environment`     | Environment variables set in the Sprite            | –                               |
+| `labels`          | Labels for organizing/filtering                    | –                               |
+| `runtime`         | Runtime image variant (`"default"` \| `"dev"`)     | `"default"`                     |
+| `waitForCapacity` | Wait instead of failing at the concurrency limit   | –                               |
+| `timeout`         | Command execution timeout in seconds               | `300`                           |
+| `workdir`         | Working directory for commands and relative paths  | `/home/sprite`                  |
+| `initialFiles`    | Files to create right after the Sprite boots       | –                               |
+| `auth`            | `{ token, baseURL }` overrides                     | env vars                        |
+
+## Error Handling
+
+All errors are `SpritesSandboxError` instances with a structured `code`:
+
+```typescript
+import { SpritesSandboxError } from "@langchain/sprites";
+
+try {
+  await sandbox.execute("some command");
+} catch (error) {
+  if (SpritesSandboxError.isInstance(error)) {
+    console.error(error.code); // e.g. "COMMAND_TIMEOUT"
+  }
+}
+```
+
+Codes: `NOT_INITIALIZED`, `ALREADY_INITIALIZED`, `COMMAND_TIMEOUT`,
+`COMMAND_FAILED`, `AUTHENTICATION_FAILED`, `SANDBOX_CREATION_FAILED`,
+`SANDBOX_NOT_FOUND`, `FILE_OPERATION_FAILED`, `CHECKPOINT_FAILED`.
+
+## Testing
+
+```bash
+# Unit tests (no credentials needed)
+pnpm test:unit
+
+# Integration tests create real Sprites and require SPRITES_TOKEN
+SPRITES_TOKEN=... pnpm test:int
+```
+
+The integration suite runs the `@langchain/sandbox-standard-tests`
+conformance suite plus Sprites-specific tests (persistence, reconnect,
+checkpoint/restore). Test Sprites are named `ci-deepagents-<run>-*` and are
+deleted after the run.
+
+## License
+
+MIT

--- a/libs/providers/sprites/package.json
+++ b/libs/providers/sprites/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@langchain/sprites",
+  "version": "0.0.1",
+  "description": "Fly.io Sprites sandbox backend for deepagents",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rm -rf dist/ .tsdown/",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "pnpm build",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:int": "vitest run --mode int"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/langchain-ai/deepagentsjs.git"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "langgraph",
+    "langchain",
+    "typescript",
+    "llm",
+    "sprites",
+    "fly.io",
+    "sandbox"
+  ],
+  "author": "LangChain",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/langchain-ai/deepagentsjs/issues"
+  },
+  "homepage": "https://github.com/langchain-ai/deepagentsjs#readme",
+  "dependencies": {
+    "@fly/sprites": "^0.2.1"
+  },
+  "peerDependencies": {
+    "deepagents": ">=1.12.0-rc.0"
+  },
+  "devDependencies": {
+    "deepagents": "workspace:*",
+    "@langchain/sandbox-standard-tests": "workspace:*",
+    "@tsconfig/recommended": "^1.0.13",
+    "@types/node": "^26.1.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "dotenv": "^17.2.3",
+    "tsdown": "^0.22.1",
+    "tsx": "^4.21.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.0.18"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/**/*"
+  ]
+}

--- a/libs/providers/sprites/src/auth.test.ts
+++ b/libs/providers/sprites/src/auth.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { getAuthToken, getAuthBaseURL, getAuthCredentials } from "./auth.js";
+
+describe("auth", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.SPRITES_TOKEN;
+    delete process.env.SPRITES_API_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("getAuthToken", () => {
+    it("should use explicit token from options", () => {
+      expect(getAuthToken({ token: "explicit-token" })).toBe("explicit-token");
+    });
+
+    it("should prefer explicit token over environment variable", () => {
+      process.env.SPRITES_TOKEN = "env-token";
+      expect(getAuthToken({ token: "explicit-token" })).toBe("explicit-token");
+    });
+
+    it("should fall back to SPRITES_TOKEN environment variable", () => {
+      process.env.SPRITES_TOKEN = "env-token";
+      expect(getAuthToken()).toBe("env-token");
+    });
+
+    it("should throw a descriptive error when no token is available", () => {
+      expect(() => getAuthToken()).toThrow("Sprites authentication required");
+      expect(() => getAuthToken()).toThrow("SPRITES_TOKEN");
+    });
+
+    it("should ignore empty explicit token", () => {
+      process.env.SPRITES_TOKEN = "env-token";
+      expect(getAuthToken({ token: "" })).toBe("env-token");
+    });
+  });
+
+  describe("getAuthBaseURL", () => {
+    it("should use explicit baseURL from options", () => {
+      expect(getAuthBaseURL({ baseURL: "https://example.com" })).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("should fall back to SPRITES_API_URL environment variable", () => {
+      process.env.SPRITES_API_URL = "https://env.example.com";
+      expect(getAuthBaseURL()).toBe("https://env.example.com");
+    });
+
+    it("should default to the public Sprites API", () => {
+      expect(getAuthBaseURL()).toBe("https://api.sprites.dev");
+    });
+
+    it("should prefer explicit baseURL over environment variable", () => {
+      process.env.SPRITES_API_URL = "https://env.example.com";
+      expect(getAuthBaseURL({ baseURL: "https://explicit.example.com" })).toBe(
+        "https://explicit.example.com",
+      );
+    });
+  });
+
+  describe("getAuthCredentials", () => {
+    it("should return complete credentials", () => {
+      const credentials = getAuthCredentials({
+        token: "my-token",
+        baseURL: "https://example.com",
+      });
+
+      expect(credentials).toEqual({
+        token: "my-token",
+        baseURL: "https://example.com",
+      });
+    });
+
+    it("should resolve from environment variables", () => {
+      process.env.SPRITES_TOKEN = "env-token";
+
+      const credentials = getAuthCredentials();
+
+      expect(credentials).toEqual({
+        token: "env-token",
+        baseURL: "https://api.sprites.dev",
+      });
+    });
+
+    it("should throw when no token is available", () => {
+      expect(() => getAuthCredentials()).toThrow(
+        "Sprites authentication required",
+      );
+    });
+  });
+});

--- a/libs/providers/sprites/src/auth.ts
+++ b/libs/providers/sprites/src/auth.ts
@@ -69,7 +69,7 @@ export function getAuthToken(options?: SpritesSandboxOptions["auth"]): string {
   throw new Error(
     "Sprites authentication required. Provide a token using one of these methods:\n\n" +
       "1. Set the SPRITES_TOKEN environment variable:\n" +
-      "   Create a token with the Sprites CLI (https://sprites.dev/docs):\n" +
+      "   Create a token with the Sprites CLI (https://docs.sprites.dev):\n" +
       "   sprite tokens create\n" +
       "   export SPRITES_TOKEN=your_token_here\n\n" +
       "2. Pass the token directly in options:\n" +

--- a/libs/providers/sprites/src/auth.ts
+++ b/libs/providers/sprites/src/auth.ts
@@ -1,0 +1,126 @@
+/**
+ * Authentication utilities for the Sprites Sandbox.
+ *
+ * This module provides authentication credential resolution for the Sprites
+ * SDK.
+ *
+ * @packageDocumentation
+ */
+
+import type { SpritesSandboxOptions } from "./types.js";
+
+/**
+ * Authentication credentials for the Sprites API.
+ */
+export interface SpritesCredentials {
+  /** Sprites API token */
+  token: string;
+
+  /** Sprites API base URL */
+  baseURL: string;
+}
+
+/** Default Sprites API URL */
+const DEFAULT_BASE_URL = "https://api.sprites.dev";
+
+/**
+ * Get the API token for the Sprites API.
+ *
+ * Authentication is resolved in the following priority order:
+ *
+ * 1. **Explicit token**: If `options.token` is provided, it is used directly.
+ * 2. **SPRITES_TOKEN**: Environment variable for the Sprites API token.
+ *
+ * If no token is found, an error is thrown with setup instructions.
+ *
+ * ## Environment Variable Setup
+ *
+ * ```bash
+ * # Create a token with the Sprites CLI: sprite tokens create
+ * export SPRITES_TOKEN=your_token_here
+ * ```
+ *
+ * @param options - Optional authentication configuration from SpritesSandboxOptions
+ * @returns The API token string
+ * @throws {Error} If no token is available
+ *
+ * @example
+ * ```typescript
+ * // With explicit token
+ * const token = getAuthToken({ token: "my-token" });
+ *
+ * // Using environment variables (auto-detected)
+ * const token = getAuthToken();
+ * ```
+ */
+export function getAuthToken(options?: SpritesSandboxOptions["auth"]): string {
+  // Priority 1: Explicit token in options
+  if (options?.token) {
+    return options.token;
+  }
+
+  // Priority 2: SPRITES_TOKEN environment variable
+  const token = process.env.SPRITES_TOKEN;
+  if (token) {
+    return token;
+  }
+
+  // No token found - throw descriptive error
+  throw new Error(
+    "Sprites authentication required. Provide a token using one of these methods:\n\n" +
+      "1. Set the SPRITES_TOKEN environment variable:\n" +
+      "   Create a token with the Sprites CLI (https://sprites.dev/docs):\n" +
+      "   sprite tokens create\n" +
+      "   export SPRITES_TOKEN=your_token_here\n\n" +
+      "2. Pass the token directly in options:\n" +
+      "   new SpritesSandbox({ auth: { token: '...' } })",
+  );
+}
+
+/**
+ * Get the base URL for the Sprites API.
+ *
+ * URL is resolved in the following priority order:
+ *
+ * 1. **Explicit base URL**: If `options.baseURL` is provided, it is used directly.
+ * 2. **SPRITES_API_URL**: Environment variable for the Sprites API URL.
+ * 3. **Default**: `https://api.sprites.dev`.
+ *
+ * @param options - Optional authentication configuration from SpritesSandboxOptions
+ * @returns The base URL string
+ */
+export function getAuthBaseURL(
+  options?: SpritesSandboxOptions["auth"],
+): string {
+  // Priority 1: Explicit base URL in options
+  if (options?.baseURL) {
+    return options.baseURL;
+  }
+
+  // Priority 2: SPRITES_API_URL environment variable
+  const baseURL = process.env.SPRITES_API_URL;
+  if (baseURL) {
+    return baseURL;
+  }
+
+  // Priority 3: Default URL
+  return DEFAULT_BASE_URL;
+}
+
+/**
+ * Get authentication credentials for the Sprites API.
+ *
+ * This function returns the credentials needed for the Sprites SDK.
+ *
+ * @param options - Optional authentication configuration from SpritesSandboxOptions
+ * @returns Complete authentication credentials
+ * @throws {Error} If no token is available
+ */
+export function getAuthCredentials(
+  options?: SpritesSandboxOptions["auth"],
+): SpritesCredentials {
+  return {
+    token: getAuthToken(options),
+    baseURL: getAuthBaseURL(options),
+  };
+}

--- a/libs/providers/sprites/src/index.ts
+++ b/libs/providers/sprites/src/index.ts
@@ -1,0 +1,63 @@
+/**
+ * @langchain/sprites
+ *
+ * Fly.io Sprites sandbox backend for deepagents.
+ *
+ * This package provides a Sprites implementation of the
+ * SandboxBackendProtocol, enabling agents to execute commands, read/write
+ * files, and manage isolated sandbox environments using Fly.io's Sprites
+ * infrastructure — persistent Linux VMs with instant creation and fast
+ * checkpoint/restore.
+ *
+ * @example
+ * ```typescript
+ * import { SpritesSandbox } from "@langchain/sprites";
+ * import { createDeepAgent } from "deepagents";
+ * import { ChatAnthropic } from "@langchain/anthropic";
+ *
+ * // Create and initialize a sandbox
+ * const sandbox = await SpritesSandbox.create({
+ *   timeout: 300, // 5 minutes
+ * });
+ *
+ * try {
+ *   const agent = createDeepAgent({
+ *     model: new ChatAnthropic({ model: "claude-sonnet-4-5" }),
+ *     systemPrompt: "You are a coding assistant with sandbox access.",
+ *     backend: sandbox,
+ *   });
+ *
+ *   const result = await agent.invoke({
+ *     messages: [new HumanMessage("Create a hello world app")],
+ *   });
+ * } finally {
+ *   await sandbox.close();
+ * }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Export main class
+export { SpritesSandbox } from "./sandbox.js";
+
+// Export factory functions and types
+export {
+  createSpritesSandboxFactory,
+  createSpritesSandboxFactoryFromSandbox,
+  type AsyncSpritesSandboxFactory,
+} from "./sandbox.js";
+
+// Export authentication utilities
+export { getAuthToken, getAuthBaseURL, getAuthCredentials } from "./auth.js";
+export type { SpritesCredentials } from "./auth.js";
+
+// Export types
+export type {
+  SpritesSandboxOptions,
+  SpritesSandboxConfig,
+  SpritesSandboxErrorCode,
+} from "./types.js";
+
+// Export error class (value export)
+export { SpritesSandboxError } from "./types.js";

--- a/libs/providers/sprites/src/sandbox.int.test.ts
+++ b/libs/providers/sprites/src/sandbox.int.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration tests for SpritesSandbox.
+ *
+ * These tests create real Sprites (billable resources) and will be skipped
+ * if SPRITES_TOKEN is not set.
+ *
+ * To run these tests:
+ *   1. Create a Sprites API token (https://sprites.dev/docs)
+ *   2. Set the environment variable:
+ *      export SPRITES_TOKEN=your_token_here
+ *   3. Run: pnpm test:int
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  sandboxStandardTests,
+  withRetry,
+} from "@langchain/sandbox-standard-tests/vitest";
+import { randomBytes } from "node:crypto";
+
+import { SpritesSandbox } from "./index.js";
+
+const hasCredentials = !!process.env.SPRITES_TOKEN;
+
+const TEST_TIMEOUT = 120_000; // 2 minutes
+
+/**
+ * Identify sandboxes created by this test execution. GitHub run ID and attempt
+ * prevent cleanup in one CI run from deleting sandboxes owned by another.
+ */
+const TEST_RUN_ID = process.env.GITHUB_RUN_ID
+  ? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
+  : `local-${randomBytes(3).toString("hex")}`;
+
+/** All Sprites created by this run share this name prefix. */
+const NAME_PREFIX = `ci-deepagents-${TEST_RUN_ID}-`;
+
+function testName(): string {
+  return `${NAME_PREFIX}${randomBytes(3).toString("hex")}`;
+}
+
+/** Remove any sandboxes left behind by this test execution. */
+afterAll(async () => {
+  if (!hasCredentials) return;
+  await SpritesSandbox.deleteAll(NAME_PREFIX);
+}, TEST_TIMEOUT);
+
+sandboxStandardTests({
+  name: "SpritesSandbox",
+  skip: !hasCredentials,
+  timeout: TEST_TIMEOUT,
+  createSandbox: async (options) =>
+    SpritesSandbox.create({
+      name: testName(),
+      labels: ["purpose:integration-test", "package:langchain-sprites"],
+      ...options,
+    }),
+  closeSandbox: (sandbox) => sandbox.close(),
+  resolvePath: (name) => name,
+});
+
+describe.skipIf(!hasCredentials)(
+  "SpritesSandbox Provider-Specific Tests",
+  () => {
+    let sandbox: SpritesSandbox;
+
+    beforeAll(async () => {
+      sandbox = await withRetry(() =>
+        SpritesSandbox.create({
+          name: testName(),
+          labels: ["purpose:integration-test", "package:langchain-sprites"],
+        }),
+      );
+    }, TEST_TIMEOUT);
+
+    afterAll(async () => {
+      try {
+        await sandbox?.close();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }, TEST_TIMEOUT);
+
+    it(
+      "should run shell pipelines",
+      async () => {
+        const result = await sandbox.execute(
+          "printf 'a\\nb\\nc\\n' | wc -l | tr -d ' '",
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.output.trim()).toBe("3");
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      "should get working directory",
+      async () => {
+        const workDir = await sandbox.getWorkDir();
+
+        expect(workDir).toBeTruthy();
+        expect(typeof workDir).toBe("string");
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      "should get user home directory",
+      async () => {
+        const homeDir = await sandbox.getUserHomeDir();
+
+        expect(homeDir).toBeTruthy();
+        expect(homeDir.startsWith("/")).toBe(true);
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      "should reconnect to an existing sandbox by name",
+      async () => {
+        const encoder = new TextEncoder();
+        await sandbox.uploadFiles([
+          ["reconnect-test.txt", encoder.encode("still here")],
+        ]);
+
+        const reconnected = await SpritesSandbox.fromName(sandbox.id);
+        const results = await reconnected.downloadFiles(["reconnect-test.txt"]);
+
+        expect(results[0].error).toBeNull();
+        expect(new TextDecoder().decode(results[0].content!)).toBe(
+          "still here",
+        );
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      "should checkpoint and restore filesystem state",
+      async () => {
+        const encoder = new TextEncoder();
+
+        // Write a file and checkpoint
+        await sandbox.uploadFiles([
+          ["checkpoint-test.txt", encoder.encode("original")],
+        ]);
+        const checkpoint = await sandbox.checkpoint("integration-test");
+        expect(checkpoint.id).toBeTruthy();
+
+        // Modify the file, then roll back
+        await sandbox.uploadFiles([
+          ["checkpoint-test.txt", encoder.encode("modified")],
+        ]);
+        await sandbox.restore(checkpoint.id);
+
+        const results = await sandbox.downloadFiles(["checkpoint-test.txt"]);
+        expect(results[0].error).toBeNull();
+        expect(new TextDecoder().decode(results[0].content!)).toBe("original");
+      },
+      TEST_TIMEOUT,
+    );
+  },
+);
+
+describe.skipIf(!hasCredentials)("SpritesSandbox initialFiles", () => {
+  let sandbox: SpritesSandbox;
+
+  beforeAll(async () => {
+    sandbox = await withRetry(() =>
+      SpritesSandbox.create({
+        name: testName(),
+        labels: ["purpose:integration-test", "package:langchain-sprites"],
+        initialFiles: {
+          "hello.sh": 'echo "Hello from initialFiles!"',
+        },
+      }),
+    );
+  }, TEST_TIMEOUT);
+
+  afterAll(async () => {
+    try {
+      await sandbox?.close();
+    } catch {
+      // Ignore cleanup errors
+    }
+  }, TEST_TIMEOUT);
+
+  it(
+    "should create sandbox with initial files and execute them",
+    async () => {
+      expect(sandbox.isRunning).toBe(true);
+
+      const result = await sandbox.execute("sh hello.sh");
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain("Hello from initialFiles!");
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/libs/providers/sprites/src/sandbox.int.test.ts
+++ b/libs/providers/sprites/src/sandbox.int.test.ts
@@ -5,7 +5,7 @@
  * if SPRITES_TOKEN is not set.
  *
  * To run these tests:
- *   1. Create a Sprites API token (https://sprites.dev/docs)
+ *   1. Create a Sprites API token (https://docs.sprites.dev)
  *   2. Set the environment variable:
  *      export SPRITES_TOKEN=your_token_here
  *   3. Run: pnpm test:int

--- a/libs/providers/sprites/src/sandbox.test.ts
+++ b/libs/providers/sprites/src/sandbox.test.ts
@@ -1,0 +1,600 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  SpritesSandbox,
+  SpritesSandboxError,
+  createSpritesSandboxFactory,
+  createSpritesSandboxFactoryFromSandbox,
+} from "./index.js";
+import { ExecError, FilesystemError } from "@fly/sprites";
+
+const { mockFilesystem, mockSprite, mockClient } = vi.hoisted(() => {
+  const mockFilesystem = {
+    writeFile: vi.fn(),
+    readFile: vi.fn(),
+  };
+
+  const mockSprite = {
+    name: "mock-sprite",
+    execFile: vi.fn(),
+    filesystem: vi.fn(() => mockFilesystem),
+    delete: vi.fn(),
+    createCheckpoint: vi.fn(),
+    restoreCheckpoint: vi.fn(),
+    listCheckpoints: vi.fn(),
+  };
+
+  const mockClient = {
+    createSprite: vi.fn(),
+    getSprite: vi.fn(),
+    listAllSprites: vi.fn(),
+  };
+
+  return { mockFilesystem, mockSprite, mockClient };
+});
+
+vi.mock("@fly/sprites", () => {
+  class MockExecError extends Error {
+    constructor(
+      message: string,
+      public readonly result: {
+        stdout: string;
+        stderr: string;
+        exitCode: number;
+      },
+    ) {
+      super(message);
+      this.name = "ExecError";
+    }
+
+    get exitCode() {
+      return this.result.exitCode;
+    }
+
+    get stdout() {
+      return this.result.stdout;
+    }
+
+    get stderr() {
+      return this.result.stderr;
+    }
+  }
+
+  class MockFilesystemError extends Error {
+    constructor(
+      message: string,
+      public readonly code: string,
+      public readonly path: string,
+    ) {
+      super(message);
+      this.name = "FilesystemError";
+    }
+  }
+
+  return {
+    SpritesClient: class MockSpritesClient {
+      createSprite = mockClient.createSprite;
+      getSprite = mockClient.getSprite;
+      listAllSprites = mockClient.listAllSprites;
+    },
+    Sprite: class MockSprite {},
+    ExecError: MockExecError,
+    FilesystemError: MockFilesystemError,
+  };
+});
+
+/** Build a mock checkpoint/restore stream that emits the given messages. */
+function mockStream(
+  messages: Array<{ type: string; data?: string; error?: string }>,
+) {
+  return {
+    processAll: vi.fn(
+      async (handler: (msg: (typeof messages)[number]) => void) => {
+        for (const msg of messages) {
+          handler(msg);
+        }
+      },
+    ),
+  };
+}
+
+describe("SpritesSandbox", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.SPRITES_TOKEN = "test-token";
+    vi.clearAllMocks();
+    mockClient.createSprite.mockResolvedValue(mockSprite);
+    mockClient.getSprite.mockResolvedValue(mockSprite);
+    mockSprite.execFile.mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+    mockSprite.filesystem.mockReturnValue(mockFilesystem);
+    mockFilesystem.writeFile.mockResolvedValue(undefined);
+    mockFilesystem.readFile.mockResolvedValue(Buffer.from("content"));
+    mockSprite.delete.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("constructor", () => {
+    it("should create instance with default options", () => {
+      const sandbox = new SpritesSandbox();
+      expect(sandbox).toBeInstanceOf(SpritesSandbox);
+      expect(sandbox.id).toMatch(/^deepagents-[0-9a-f]{8}$/);
+    });
+
+    it("should use the provided name as id", () => {
+      const sandbox = new SpritesSandbox({ name: "my-sandbox" });
+      expect(sandbox.id).toBe("my-sandbox");
+    });
+
+    it("should not be running before initialization", () => {
+      const sandbox = new SpritesSandbox();
+      expect(sandbox.isRunning).toBe(false);
+    });
+
+    it("should default the working directory", () => {
+      const sandbox = new SpritesSandbox();
+      expect(sandbox.workdir).toBe("/home/sprite");
+    });
+
+    it("should accept a custom working directory", () => {
+      const sandbox = new SpritesSandbox({ workdir: "/app" });
+      expect(sandbox.workdir).toBe("/app");
+    });
+  });
+
+  describe("instance property", () => {
+    it("should throw when accessed before initialization", () => {
+      const sandbox = new SpritesSandbox();
+      expect(() => sandbox.instance).toThrow(SpritesSandboxError);
+      expect(() => sandbox.instance).toThrow("Sandbox not initialized");
+    });
+  });
+
+  describe("initialize", () => {
+    it("should initialize the sandbox", async () => {
+      const sandbox = new SpritesSandbox({ name: "my-sandbox" });
+      await sandbox.initialize();
+
+      expect(sandbox.isRunning).toBe(true);
+      expect(mockClient.createSprite).toHaveBeenCalledWith("my-sandbox", {});
+    });
+
+    it("should pass creation options through to the SDK", async () => {
+      const sandbox = new SpritesSandbox({
+        name: "my-sandbox",
+        config: { ramMB: 2048, cpus: 2 },
+        environment: { FOO: "bar" },
+        labels: ["ci"],
+        runtime: "dev",
+        waitForCapacity: true,
+      });
+      await sandbox.initialize();
+
+      expect(mockClient.createSprite).toHaveBeenCalledWith("my-sandbox", {
+        config: { ramMB: 2048, cpus: 2 },
+        environment: { FOO: "bar" },
+        labels: ["ci"],
+        runtime: "dev",
+        waitForCapacity: true,
+      });
+    });
+
+    it("should throw when initialized twice", async () => {
+      const sandbox = new SpritesSandbox();
+      await sandbox.initialize();
+
+      await expect(sandbox.initialize()).rejects.toThrow(
+        "Sandbox is already initialized",
+      );
+    });
+
+    it("should throw on authentication failure", async () => {
+      delete process.env.SPRITES_TOKEN;
+      const sandbox = new SpritesSandbox();
+
+      await expect(sandbox.initialize()).rejects.toThrow(
+        "Failed to authenticate with Sprites",
+      );
+    });
+
+    it("should throw SANDBOX_CREATION_FAILED when creation fails", async () => {
+      mockClient.createSprite.mockRejectedValue(new Error("quota exceeded"));
+      const sandbox = new SpritesSandbox();
+
+      await expect(sandbox.initialize()).rejects.toMatchObject({
+        code: "SANDBOX_CREATION_FAILED",
+      });
+    });
+
+    it("should upload initial files", async () => {
+      const sandbox = new SpritesSandbox({
+        initialFiles: { "main.js": "console.log('hi')" },
+      });
+      await sandbox.initialize();
+
+      expect(mockFilesystem.writeFile).toHaveBeenCalledWith(
+        "main.js",
+        Buffer.from("console.log('hi')"),
+      );
+    });
+
+    it("should throw when initial file upload fails", async () => {
+      mockFilesystem.writeFile.mockRejectedValue(
+        new FilesystemError("denied", "EACCES", "main.js"),
+      );
+      const sandbox = new SpritesSandbox({
+        initialFiles: { "main.js": "console.log('hi')" },
+      });
+
+      await expect(sandbox.initialize()).rejects.toMatchObject({
+        code: "FILE_OPERATION_FAILED",
+      });
+    });
+  });
+
+  describe("static create", () => {
+    it("should create and initialize in one step", async () => {
+      const sandbox = await SpritesSandbox.create({ name: "one-step" });
+      expect(sandbox.isRunning).toBe(true);
+    });
+  });
+
+  describe("execute", () => {
+    it("should run commands via bash -lc in the workdir", async () => {
+      mockSprite.execFile.mockResolvedValue({
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const sandbox = await SpritesSandbox.create();
+      const result = await sandbox.execute("echo hello");
+
+      expect(mockSprite.execFile).toHaveBeenCalledWith(
+        "bash",
+        ["-lc", "echo hello"],
+        { cwd: "/home/sprite", timeout: 300_000 },
+      );
+      expect(result).toEqual({
+        output: "hello\n",
+        exitCode: 0,
+        truncated: false,
+      });
+    });
+
+    it("should combine stdout and stderr", async () => {
+      mockSprite.execFile.mockResolvedValue({
+        stdout: "out",
+        stderr: "err",
+        exitCode: 0,
+      });
+
+      const sandbox = await SpritesSandbox.create();
+      const result = await sandbox.execute("some command");
+
+      expect(result.output).toBe("outerr");
+    });
+
+    it("should return non-zero exit codes instead of throwing", async () => {
+      mockSprite.execFile.mockRejectedValue(
+        new ExecError("Command failed with exit code 2", {
+          stdout: "",
+          stderr: "boom\n",
+          exitCode: 2,
+        }),
+      );
+
+      const sandbox = await SpritesSandbox.create();
+      const result = await sandbox.execute("exit 2");
+
+      expect(result.exitCode).toBe(2);
+      expect(result.output).toBe("boom\n");
+    });
+
+    it("should respect a custom timeout", async () => {
+      const sandbox = await SpritesSandbox.create({ timeout: 10 });
+      await sandbox.execute("true");
+
+      expect(mockSprite.execFile).toHaveBeenCalledWith(
+        "bash",
+        ["-lc", "true"],
+        { cwd: "/home/sprite", timeout: 10_000 },
+      );
+    });
+
+    it("should throw COMMAND_TIMEOUT on timeout", async () => {
+      mockSprite.execFile.mockRejectedValue(
+        new Error("Command timed out after 300000 ms"),
+      );
+
+      const sandbox = await SpritesSandbox.create();
+
+      await expect(sandbox.execute("sleep 1000")).rejects.toMatchObject({
+        code: "COMMAND_TIMEOUT",
+      });
+    });
+
+    it("should throw COMMAND_FAILED on other errors", async () => {
+      mockSprite.execFile.mockRejectedValue(new Error("connection lost"));
+
+      const sandbox = await SpritesSandbox.create();
+
+      await expect(sandbox.execute("true")).rejects.toMatchObject({
+        code: "COMMAND_FAILED",
+      });
+    });
+
+    it("should throw when not initialized", async () => {
+      const sandbox = new SpritesSandbox();
+      await expect(sandbox.execute("true")).rejects.toThrow(
+        "Sandbox not initialized",
+      );
+    });
+  });
+
+  describe("uploadFiles", () => {
+    it("should upload files via the filesystem API", async () => {
+      const sandbox = await SpritesSandbox.create();
+      const encoder = new TextEncoder();
+
+      const results = await sandbox.uploadFiles([
+        ["a.txt", encoder.encode("aaa")],
+        ["dir/b.txt", encoder.encode("bbb")],
+      ]);
+
+      expect(mockSprite.filesystem).toHaveBeenCalledWith("/home/sprite");
+      expect(results).toEqual([
+        { path: "a.txt", error: null },
+        { path: "dir/b.txt", error: null },
+      ]);
+    });
+
+    it("should report partial failures", async () => {
+      mockFilesystem.writeFile
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new FilesystemError("denied", "EACCES", "b"));
+
+      const sandbox = await SpritesSandbox.create();
+      const encoder = new TextEncoder();
+
+      const results = await sandbox.uploadFiles([
+        ["a.txt", encoder.encode("aaa")],
+        ["b.txt", encoder.encode("bbb")],
+      ]);
+
+      expect(results[0].error).toBeNull();
+      expect(results[1].error).toBe("permission_denied");
+    });
+  });
+
+  describe("downloadFiles", () => {
+    it("should download file contents", async () => {
+      mockFilesystem.readFile.mockResolvedValue(Buffer.from("hello"));
+
+      const sandbox = await SpritesSandbox.create();
+      const results = await sandbox.downloadFiles(["a.txt"]);
+
+      expect(results[0].error).toBeNull();
+      expect(new TextDecoder().decode(results[0].content!)).toBe("hello");
+    });
+
+    it("should map missing files to file_not_found", async () => {
+      mockFilesystem.readFile
+        .mockResolvedValueOnce(Buffer.from("hello"))
+        .mockRejectedValueOnce(
+          new FilesystemError("no such file", "ENOENT", "missing.txt"),
+        );
+
+      const sandbox = await SpritesSandbox.create();
+      const results = await sandbox.downloadFiles(["a.txt", "missing.txt"]);
+
+      expect(results[0].error).toBeNull();
+      expect(results[1]).toMatchObject({
+        content: null,
+        error: "file_not_found",
+      });
+    });
+
+    it("should map UNKNOWN-code errors by message", async () => {
+      // The server does not always return a structured code; a missing file
+      // can surface as code UNKNOWN with the raw Go error string.
+      mockFilesystem.readFile.mockRejectedValue(
+        new FilesystemError(
+          "open /home/sprite/missing.txt: no such file or directory",
+          "UNKNOWN",
+          "missing.txt",
+        ),
+      );
+
+      const sandbox = await SpritesSandbox.create();
+      const results = await sandbox.downloadFiles(["missing.txt"]);
+
+      expect(results[0].error).toBe("file_not_found");
+    });
+
+    it("should map directory errors to is_directory", async () => {
+      mockFilesystem.readFile.mockRejectedValue(
+        new FilesystemError("is a directory", "EISDIR", "dir"),
+      );
+
+      const sandbox = await SpritesSandbox.create();
+      const results = await sandbox.downloadFiles(["dir"]);
+
+      expect(results[0].error).toBe("is_directory");
+    });
+  });
+
+  describe("close", () => {
+    it("should delete the sprite", async () => {
+      const sandbox = await SpritesSandbox.create();
+      await sandbox.close();
+
+      expect(mockSprite.delete).toHaveBeenCalled();
+      expect(sandbox.isRunning).toBe(false);
+    });
+
+    it("should be a no-op when not initialized", async () => {
+      const sandbox = new SpritesSandbox();
+      await sandbox.close();
+
+      expect(mockSprite.delete).not.toHaveBeenCalled();
+    });
+
+    it("kill should alias close", async () => {
+      const sandbox = await SpritesSandbox.create();
+      await sandbox.kill();
+
+      expect(mockSprite.delete).toHaveBeenCalled();
+      expect(sandbox.isRunning).toBe(false);
+    });
+  });
+
+  describe("checkpoint", () => {
+    it("should create a checkpoint and return the newest one", async () => {
+      const older = {
+        id: "v1",
+        createTime: new Date("2026-01-01T00:00:00Z"),
+      };
+      const newest = {
+        id: "v2",
+        createTime: new Date("2026-02-01T00:00:00Z"),
+        comment: "test",
+      };
+      mockSprite.createCheckpoint.mockResolvedValue(
+        mockStream([{ type: "info", data: "starting" }, { type: "complete" }]),
+      );
+      mockSprite.listCheckpoints.mockResolvedValue([
+        { id: "Current", createTime: new Date("2026-03-01T00:00:00Z") },
+        older,
+        newest,
+      ]);
+
+      const sandbox = await SpritesSandbox.create();
+      const checkpoint = await sandbox.checkpoint("test");
+
+      expect(mockSprite.createCheckpoint).toHaveBeenCalledWith("test");
+      expect(checkpoint).toBe(newest);
+    });
+
+    it("should throw CHECKPOINT_FAILED on stream errors", async () => {
+      mockSprite.createCheckpoint.mockResolvedValue(
+        mockStream([{ type: "error", error: "disk full" }]),
+      );
+
+      const sandbox = await SpritesSandbox.create();
+
+      await expect(sandbox.checkpoint()).rejects.toMatchObject({
+        code: "CHECKPOINT_FAILED",
+      });
+    });
+  });
+
+  describe("restore", () => {
+    it("should restore a checkpoint", async () => {
+      mockSprite.restoreCheckpoint.mockResolvedValue(
+        mockStream([{ type: "complete" }]),
+      );
+
+      const sandbox = await SpritesSandbox.create();
+      await sandbox.restore("v1");
+
+      expect(mockSprite.restoreCheckpoint).toHaveBeenCalledWith("v1");
+    });
+
+    it("should throw CHECKPOINT_FAILED on stream errors", async () => {
+      mockSprite.restoreCheckpoint.mockResolvedValue(
+        mockStream([{ type: "error", error: "no such checkpoint" }]),
+      );
+
+      const sandbox = await SpritesSandbox.create();
+
+      await expect(sandbox.restore("v99")).rejects.toMatchObject({
+        code: "CHECKPOINT_FAILED",
+      });
+    });
+  });
+
+  describe("fromName", () => {
+    it("should connect to an existing sprite", async () => {
+      const sandbox = await SpritesSandbox.fromName("mock-sprite");
+
+      expect(mockClient.getSprite).toHaveBeenCalledWith("mock-sprite");
+      expect(sandbox.isRunning).toBe(true);
+      expect(sandbox.id).toBe("mock-sprite");
+      expect(mockClient.createSprite).not.toHaveBeenCalled();
+    });
+
+    it("should throw SANDBOX_NOT_FOUND for missing sprites", async () => {
+      mockClient.getSprite.mockRejectedValue(new Error("404"));
+
+      await expect(SpritesSandbox.fromName("nope")).rejects.toMatchObject({
+        code: "SANDBOX_NOT_FOUND",
+      });
+    });
+  });
+
+  describe("deleteAll", () => {
+    it("should delete all sprites with the given prefix", async () => {
+      const spriteA = { delete: vi.fn().mockResolvedValue(undefined) };
+      const spriteB = { delete: vi.fn().mockRejectedValue(new Error("gone")) };
+      mockClient.listAllSprites.mockResolvedValue([spriteA, spriteB]);
+
+      const deleted = await SpritesSandbox.deleteAll("ci-");
+
+      expect(mockClient.listAllSprites).toHaveBeenCalledWith("ci-");
+      expect(deleted).toBe(1);
+    });
+
+    it("should reject an empty prefix", async () => {
+      await expect(SpritesSandbox.deleteAll("")).rejects.toThrow(
+        "non-empty name prefix",
+      );
+    });
+  });
+
+  describe("getWorkDir / getUserHomeDir", () => {
+    it("should return the configured workdir", async () => {
+      const sandbox = await SpritesSandbox.create({ workdir: "/app" });
+      expect(await sandbox.getWorkDir()).toBe("/app");
+    });
+
+    it("should resolve the home directory via the shell", async () => {
+      mockSprite.execFile.mockResolvedValue({
+        stdout: "/home/sprite",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const sandbox = await SpritesSandbox.create();
+      expect(await sandbox.getUserHomeDir()).toBe("/home/sprite");
+    });
+  });
+
+  describe("factories", () => {
+    it("createSpritesSandboxFactory should create a new sandbox per call", async () => {
+      const factory = createSpritesSandboxFactory();
+
+      const sandbox1 = await factory();
+      const sandbox2 = await factory();
+
+      expect(sandbox1).not.toBe(sandbox2);
+      expect(mockClient.createSprite).toHaveBeenCalledTimes(2);
+    });
+
+    it("createSpritesSandboxFactoryFromSandbox should reuse the sandbox", async () => {
+      const sandbox = await SpritesSandbox.create();
+      const factory = createSpritesSandboxFactoryFromSandbox(sandbox);
+
+      const runtime = {} as never;
+      expect(factory(runtime)).toBe(sandbox);
+      expect(factory(runtime)).toBe(sandbox);
+    });
+  });
+});

--- a/libs/providers/sprites/src/sandbox.ts
+++ b/libs/providers/sprites/src/sandbox.ts
@@ -1,0 +1,866 @@
+/* oxlint-disable no-instanceof/no-instanceof */
+/**
+ * Sprites Sandbox implementation of the SandboxBackendProtocol.
+ *
+ * This module provides a Fly.io Sprites backend for deepagents, enabling
+ * agents to execute commands, read/write files, and manage isolated sandbox
+ * environments using Sprites' infrastructure.
+ *
+ * @packageDocumentation
+ */
+
+import { randomBytes } from "node:crypto";
+
+import {
+  SpritesClient,
+  Sprite,
+  ExecError,
+  FilesystemError,
+  type Checkpoint,
+} from "@fly/sprites";
+import {
+  BaseSandbox,
+  type ExecuteResponse,
+  type FileDownloadResponse,
+  type FileOperationError,
+  type FileUploadResponse,
+  type BackendFactory,
+} from "deepagents";
+
+import { getAuthCredentials } from "./auth.js";
+import { SpritesSandboxError, type SpritesSandboxOptions } from "./types.js";
+
+/** Default working directory inside a Sprite. */
+const DEFAULT_WORKDIR = "/home/sprite";
+
+/** Default command timeout in seconds. */
+const DEFAULT_TIMEOUT_SECONDS = 300;
+
+/**
+ * Sprites Sandbox backend for deepagents.
+ *
+ * Extends `BaseSandbox` to provide command execution, file operations, and
+ * sandbox lifecycle management using the Fly.io Sprites SDK.
+ *
+ * Sprites are persistent, named Linux VMs that boot in a couple of seconds,
+ * automatically suspend when idle, and support fast checkpoint/restore of
+ * their full filesystem and process state.
+ *
+ * ## Basic Usage
+ *
+ * ```typescript
+ * import { SpritesSandbox } from "@langchain/sprites";
+ *
+ * // Create and initialize a sandbox
+ * const sandbox = await SpritesSandbox.create({
+ *   timeout: 300,
+ * });
+ *
+ * try {
+ *   // Execute commands
+ *   const result = await sandbox.execute("node --version");
+ *   console.log(result.output);
+ * } finally {
+ *   // Always cleanup
+ *   await sandbox.close();
+ * }
+ * ```
+ *
+ * ## Using with DeepAgent
+ *
+ * ```typescript
+ * import { createDeepAgent } from "deepagents";
+ * import { SpritesSandbox } from "@langchain/sprites";
+ *
+ * const sandbox = await SpritesSandbox.create();
+ *
+ * const agent = createDeepAgent({
+ *   model: new ChatAnthropic({ model: "claude-sonnet-4-5" }),
+ *   systemPrompt: "You are a coding assistant with sandbox access.",
+ *   backend: sandbox,
+ * });
+ * ```
+ */
+export class SpritesSandbox extends BaseSandbox {
+  /** Private reference to the Sprites client */
+  #client: SpritesClient | null = null;
+
+  /** Private reference to the underlying Sprite instance */
+  #sprite: Sprite | null = null;
+
+  /** Configuration options for this sandbox */
+  #options: SpritesSandboxOptions;
+
+  /** Sprite name — the unique identifier for this sandbox */
+  #id: string;
+
+  /** Command execution timeout in milliseconds */
+  #timeoutMs: number;
+
+  /** Working directory for commands and relative file paths */
+  #workdir: string;
+
+  /**
+   * Get the unique identifier for this sandbox.
+   *
+   * The identifier is the Sprite name, which is stable across suspends and
+   * restarts and can be used to reconnect with `SpritesSandbox.fromName()`.
+   */
+  get id(): string {
+    return this.#id;
+  }
+
+  /**
+   * Get the underlying Sprite instance.
+   *
+   * @throws {SpritesSandboxError} If the sandbox is not initialized
+   *
+   * @example
+   * ```typescript
+   * const sandbox = await SpritesSandbox.create();
+   * const sprite = sandbox.instance; // Access the raw SDK Sprite
+   * ```
+   */
+  get instance(): Sprite {
+    if (!this.#sprite) {
+      throw new SpritesSandboxError(
+        "Sandbox not initialized. Call initialize() or use SpritesSandbox.create()",
+        "NOT_INITIALIZED",
+      );
+    }
+    return this.#sprite;
+  }
+
+  /**
+   * Get the underlying Sprites client instance.
+   *
+   * @throws {SpritesSandboxError} If the client is not initialized
+   */
+  get client(): SpritesClient {
+    if (!this.#client) {
+      throw new SpritesSandboxError(
+        "Sprites client not initialized. Call initialize() or use SpritesSandbox.create()",
+        "NOT_INITIALIZED",
+      );
+    }
+    return this.#client;
+  }
+
+  /**
+   * Check if the sandbox is initialized.
+   */
+  get isRunning(): boolean {
+    return this.#sprite !== null;
+  }
+
+  /**
+   * Get the working directory used for commands and relative file paths.
+   */
+  get workdir(): string {
+    return this.#workdir;
+  }
+
+  /**
+   * Create a new SpritesSandbox instance.
+   *
+   * Note: This only creates the instance. Call `initialize()` to actually
+   * create the Sprite, or use the static `SpritesSandbox.create()` method.
+   *
+   * @param options - Configuration options for the sandbox
+   *
+   * @example
+   * ```typescript
+   * // Two-step initialization
+   * const sandbox = new SpritesSandbox({ name: "my-sandbox" });
+   * await sandbox.initialize();
+   *
+   * // Or use the factory method
+   * const sandbox = await SpritesSandbox.create({ name: "my-sandbox" });
+   * ```
+   */
+  constructor(options: SpritesSandboxOptions = {}) {
+    super();
+
+    this.#options = {
+      timeout: DEFAULT_TIMEOUT_SECONDS,
+      ...options,
+    };
+
+    this.#timeoutMs = (this.#options.timeout ?? DEFAULT_TIMEOUT_SECONDS) * 1000;
+    this.#workdir = this.#options.workdir ?? DEFAULT_WORKDIR;
+
+    // Sprite names are stable identities; generate one if not provided
+    this.#id =
+      this.#options.name ?? `deepagents-${randomBytes(4).toString("hex")}`;
+  }
+
+  /**
+   * Initialize the sandbox by creating a new Sprite.
+   *
+   * This method authenticates with the Sprites API and provisions a new
+   * Sprite (typically in 1-2 seconds).
+   *
+   * @throws {SpritesSandboxError} If already initialized (`ALREADY_INITIALIZED`)
+   * @throws {SpritesSandboxError} If authentication fails (`AUTHENTICATION_FAILED`)
+   * @throws {SpritesSandboxError} If sandbox creation fails (`SANDBOX_CREATION_FAILED`)
+   *
+   * @example
+   * ```typescript
+   * const sandbox = new SpritesSandbox();
+   * await sandbox.initialize();
+   * console.log(`Sandbox ID: ${sandbox.id}`);
+   * ```
+   */
+  async initialize(): Promise<void> {
+    // Prevent double initialization
+    if (this.#sprite) {
+      throw new SpritesSandboxError(
+        "Sandbox is already initialized. Each SpritesSandbox instance can only be initialized once.",
+        "ALREADY_INITIALIZED",
+      );
+    }
+
+    // Get authentication credentials
+    let credentials: { token: string; baseURL: string };
+    try {
+      credentials = getAuthCredentials(this.#options.auth);
+    } catch (error) {
+      throw new SpritesSandboxError(
+        "Failed to authenticate with Sprites. Check your token configuration.",
+        "AUTHENTICATION_FAILED",
+        error instanceof Error ? error : undefined,
+      );
+    }
+
+    try {
+      this.#client = new SpritesClient(credentials.token, {
+        baseURL: credentials.baseURL,
+      });
+
+      this.#sprite = await this.#client.createSprite(this.#id, {
+        ...(this.#options.config && { config: this.#options.config }),
+        ...(this.#options.environment && {
+          environment: this.#options.environment,
+        }),
+        ...(this.#options.labels && { labels: this.#options.labels }),
+        ...(this.#options.runtime && { runtime: this.#options.runtime }),
+        ...(this.#options.waitForCapacity !== undefined && {
+          waitForCapacity: this.#options.waitForCapacity,
+        }),
+      });
+
+      // Upload initial files if provided
+      if (this.#options.initialFiles) {
+        await this.#uploadInitialFiles(this.#options.initialFiles);
+      }
+    } catch (error) {
+      if (SpritesSandboxError.isInstance(error)) {
+        throw error;
+      }
+      throw new SpritesSandboxError(
+        `Failed to create Sprite: ${error instanceof Error ? error.message : String(error)}`,
+        "SANDBOX_CREATION_FAILED",
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Upload initial files to the sandbox.
+   *
+   * @param files - A map of file paths to their string contents
+   */
+  async #uploadInitialFiles(files: Record<string, string>): Promise<void> {
+    const encoder = new TextEncoder();
+    const fileEntries: Array<[string, Uint8Array]> = Object.entries(files).map(
+      ([path, content]) => [path, encoder.encode(content)],
+    );
+
+    const results = await this.uploadFiles(fileEntries);
+
+    // Check for any errors during upload
+    const errors = results.filter((r) => r.error !== null);
+    if (errors.length > 0) {
+      const errorPaths = errors.map((e) => `${e.path}: ${e.error}`).join(", ");
+      throw new SpritesSandboxError(
+        `Failed to upload initial files: ${errorPaths}`,
+        "FILE_OPERATION_FAILED",
+      );
+    }
+  }
+
+  /**
+   * Execute a command in the sandbox.
+   *
+   * Commands are run with `bash -lc` in the sandbox working directory, so
+   * shell features (pipes, redirection, globbing) work as expected.
+   *
+   * @param command - The shell command to execute
+   * @returns Execution result with combined output, exit code, and truncation flag
+   * @throws {SpritesSandboxError} If the sandbox is not initialized
+   *
+   * @example
+   * ```typescript
+   * const result = await sandbox.execute("echo 'Hello World'");
+   * console.log(result.output); // "Hello World\n"
+   * console.log(result.exitCode); // 0
+   * ```
+   */
+  async execute(command: string): Promise<ExecuteResponse> {
+    const sprite = this.instance; // Throws if not initialized
+
+    try {
+      const result = await sprite.execFile("bash", ["-lc", command], {
+        cwd: this.#workdir,
+        timeout: this.#timeoutMs,
+      });
+
+      return {
+        output: `${result.stdout}${result.stderr}`,
+        exitCode: result.exitCode ?? 0,
+        truncated: false,
+      };
+    } catch (error) {
+      // Non-zero exit codes are reported as results, not errors
+      if (error instanceof ExecError) {
+        return {
+          output: `${error.stdout}${error.stderr}`,
+          exitCode: error.exitCode,
+          truncated: false,
+        };
+      }
+
+      // Check for timeout (the SDK rejects with a plain Error on timeout)
+      if (error instanceof Error && /timed out/i.test(error.message)) {
+        throw new SpritesSandboxError(
+          `Command timed out: ${command}`,
+          "COMMAND_TIMEOUT",
+          error,
+        );
+      }
+
+      throw new SpritesSandboxError(
+        `Command execution failed: ${error instanceof Error ? error.message : String(error)}`,
+        "COMMAND_FAILED",
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Upload files to the sandbox.
+   *
+   * Files are written via the Sprites filesystem API. Parent directories
+   * are created automatically. Relative paths are resolved against the
+   * sandbox working directory.
+   *
+   * @param files - Array of [path, content] tuples to upload
+   * @returns Upload result for each file, with success or error status
+   *
+   * @example
+   * ```typescript
+   * const encoder = new TextEncoder();
+   * const results = await sandbox.uploadFiles([
+   *   ["src/index.js", encoder.encode("console.log('Hello')")],
+   *   ["package.json", encoder.encode('{"name": "test"}')],
+   * ]);
+   * ```
+   */
+  async uploadFiles(
+    files: Array<[string, Uint8Array]>,
+  ): Promise<FileUploadResponse[]> {
+    const sprite = this.instance; // Throws if not initialized
+    const fs = sprite.filesystem(this.#workdir);
+    const results: FileUploadResponse[] = [];
+
+    for (const [path, content] of files) {
+      try {
+        await fs.writeFile(path, Buffer.from(content));
+        results.push({ path, error: null });
+      } catch (error) {
+        results.push({ path, error: this.#mapError(error) });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Download files from the sandbox.
+   *
+   * Each file is read individually, allowing partial success when some
+   * files exist and others don't. Relative paths are resolved against the
+   * sandbox working directory.
+   *
+   * @param paths - Array of file paths to download
+   * @returns Download result for each file, with content or error
+   *
+   * @example
+   * ```typescript
+   * const results = await sandbox.downloadFiles(["src/index.js", "missing.txt"]);
+   * for (const result of results) {
+   *   if (result.content) {
+   *     console.log(new TextDecoder().decode(result.content));
+   *   } else {
+   *     console.error(`Error: ${result.error}`);
+   *   }
+   * }
+   * ```
+   */
+  async downloadFiles(paths: string[]): Promise<FileDownloadResponse[]> {
+    const sprite = this.instance; // Throws if not initialized
+    const fs = sprite.filesystem(this.#workdir);
+    const results: FileDownloadResponse[] = [];
+
+    for (const path of paths) {
+      try {
+        const buffer = await fs.readFile(path, null);
+        results.push({
+          path,
+          content: new Uint8Array(buffer),
+          error: null,
+        });
+      } catch (error) {
+        results.push({
+          path,
+          content: null,
+          error: this.#mapError(error),
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Close the sandbox and release all resources.
+   *
+   * After closing, the sandbox cannot be used again. The Sprite is deleted
+   * along with its filesystem and checkpoints.
+   *
+   * Note: Sprites automatically suspend when idle and cost nothing while
+   * suspended, so if you want to reconnect later with
+   * `SpritesSandbox.fromName()`, simply don't call `close()`.
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   await sandbox.execute("npm run build");
+   * } finally {
+   *   await sandbox.close();
+   * }
+   * ```
+   */
+  async close(): Promise<void> {
+    if (this.#sprite) {
+      try {
+        await this.#sprite.delete();
+      } finally {
+        this.#sprite = null;
+        this.#client = null;
+      }
+    }
+  }
+
+  /**
+   * Forcefully terminate and delete the sandbox.
+   *
+   * @example
+   * ```typescript
+   * await sandbox.kill();
+   * ```
+   */
+  async kill(): Promise<void> {
+    await this.close();
+  }
+
+  /**
+   * Create a checkpoint of the sandbox's full state.
+   *
+   * Checkpoints capture the entire filesystem and memory state of the
+   * Sprite and typically complete in well under a second. Use `restore()`
+   * to roll the sandbox back to a checkpoint.
+   *
+   * @param comment - Optional comment describing the checkpoint
+   * @returns The created checkpoint (including its `id`)
+   * @throws {SpritesSandboxError} If the checkpoint fails (`CHECKPOINT_FAILED`)
+   *
+   * @example
+   * ```typescript
+   * const checkpoint = await sandbox.checkpoint("before running agent");
+   * // ... let the agent make changes ...
+   * await sandbox.restore(checkpoint.id);
+   * ```
+   */
+  async checkpoint(comment?: string): Promise<Checkpoint> {
+    const sprite = this.instance;
+
+    try {
+      const stream = await sprite.createCheckpoint(comment);
+      let streamError: string | undefined;
+      await stream.processAll((msg) => {
+        if (msg.type === "error") {
+          streamError = msg.error ?? msg.data ?? "unknown error";
+        }
+      });
+      if (streamError) {
+        throw new Error(streamError);
+      }
+
+      // The stream doesn't carry the checkpoint id; fetch the newest one.
+      const checkpoints = await sprite.listCheckpoints();
+      const newest = checkpoints
+        .filter((cp) => cp.id !== "Current")
+        .sort((a, b) => b.createTime.getTime() - a.createTime.getTime())[0];
+      if (!newest) {
+        throw new Error("Checkpoint completed but none found");
+      }
+      return newest;
+    } catch (error) {
+      if (SpritesSandboxError.isInstance(error)) throw error;
+      throw new SpritesSandboxError(
+        `Failed to create checkpoint: ${error instanceof Error ? error.message : String(error)}`,
+        "CHECKPOINT_FAILED",
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Restore the sandbox to a previous checkpoint.
+   *
+   * Rolls back the entire filesystem and process state.
+   *
+   * @param checkpointId - The checkpoint id (e.g. `"v3"`) from `checkpoint()`
+   *   or `instance.listCheckpoints()`
+   * @throws {SpritesSandboxError} If the restore fails (`CHECKPOINT_FAILED`)
+   */
+  async restore(checkpointId: string): Promise<void> {
+    const sprite = this.instance;
+
+    try {
+      const stream = await sprite.restoreCheckpoint(checkpointId);
+      let streamError: string | undefined;
+      await stream.processAll((msg) => {
+        if (msg.type === "error") {
+          streamError = msg.error ?? msg.data ?? "unknown error";
+        }
+      });
+      if (streamError) {
+        throw new Error(streamError);
+      }
+    } catch (error) {
+      throw new SpritesSandboxError(
+        `Failed to restore checkpoint '${checkpointId}': ${error instanceof Error ? error.message : String(error)}`,
+        "CHECKPOINT_FAILED",
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Get the working directory path inside the sandbox.
+   *
+   * @returns The absolute path to the sandbox working directory
+   */
+  async getWorkDir(): Promise<string> {
+    return this.#workdir;
+  }
+
+  /**
+   * Get the user's home directory path inside the sandbox.
+   *
+   * @returns The absolute path to the user's home directory
+   */
+  async getUserHomeDir(): Promise<string> {
+    const result = await this.execute('printf "%s" "$HOME"');
+    const home = result.output.trim();
+    return home || DEFAULT_WORKDIR;
+  }
+
+  /**
+   * Set the sandbox from an existing Sprite instance.
+   * Used internally by the static `fromName()` method.
+   */
+  #setFromExisting(client: SpritesClient, sprite: Sprite): void {
+    this.#client = client;
+    this.#sprite = sprite;
+    this.#id = sprite.name;
+  }
+
+  /**
+   * Map Sprites SDK errors to standardized FileOperationError codes.
+   *
+   * @param error - The error from the Sprites SDK
+   * @returns A standardized error code
+   */
+  #mapError(error: unknown): FileOperationError {
+    if (error instanceof FilesystemError) {
+      switch (error.code) {
+        case "ENOENT":
+          return "file_not_found";
+        case "EACCES":
+        case "EPERM":
+          return "permission_denied";
+        case "EISDIR":
+          return "is_directory";
+        // UNKNOWN and other codes carry the raw server error in the
+        // message; fall through to message-based matching below.
+      }
+    }
+
+    if (error instanceof Error) {
+      const msg = error.message.toLowerCase();
+
+      // "no such file" must be checked before the directory heuristics:
+      // the raw error is "no such file or directory".
+      if (
+        msg.includes("not found") ||
+        msg.includes("no such file") ||
+        msg.includes("enoent")
+      ) {
+        return "file_not_found";
+      }
+      if (msg.includes("permission") || msg.includes("eacces")) {
+        return "permission_denied";
+      }
+      if (msg.includes("directory") || msg.includes("eisdir")) {
+        return "is_directory";
+      }
+    }
+
+    return "invalid_path";
+  }
+
+  /**
+   * Create and initialize a new SpritesSandbox in one step.
+   *
+   * This is the recommended way to create a sandbox. It combines
+   * construction and initialization into a single async operation.
+   *
+   * @param options - Configuration options for the sandbox
+   * @returns An initialized and ready-to-use sandbox
+   *
+   * @example
+   * ```typescript
+   * const sandbox = await SpritesSandbox.create({
+   *   config: { ramMB: 2048, cpus: 2 },
+   * });
+   * ```
+   */
+  static async create(
+    options?: SpritesSandboxOptions,
+  ): Promise<SpritesSandbox> {
+    const sandbox = new SpritesSandbox(options);
+    await sandbox.initialize();
+    return sandbox;
+  }
+
+  /**
+   * Connect to an existing Sprite by name.
+   *
+   * This allows you to resume working with a sandbox that was created
+   * earlier. Suspended Sprites resume automatically on first use.
+   *
+   * @param name - The name of the Sprite to connect to
+   * @param options - Optional configuration (auth, timeout, workdir)
+   * @returns A connected sandbox instance
+   * @throws {SpritesSandboxError} If the Sprite does not exist (`SANDBOX_NOT_FOUND`)
+   *
+   * @example
+   * ```typescript
+   * // Resume a sandbox from a stored name
+   * const sandbox = await SpritesSandbox.fromName("my-agent-sandbox");
+   * const result = await sandbox.execute("ls -la");
+   * ```
+   */
+  static async fromName(
+    name: string,
+    options?: Pick<SpritesSandboxOptions, "auth" | "timeout" | "workdir">,
+  ): Promise<SpritesSandbox> {
+    let credentials: { token: string; baseURL: string };
+    try {
+      credentials = getAuthCredentials(options?.auth);
+    } catch (error) {
+      throw new SpritesSandboxError(
+        "Failed to authenticate with Sprites. Check your token configuration.",
+        "AUTHENTICATION_FAILED",
+        error instanceof Error ? error : undefined,
+      );
+    }
+
+    try {
+      const client = new SpritesClient(credentials.token, {
+        baseURL: credentials.baseURL,
+      });
+
+      const existingSprite = await client.getSprite(name);
+
+      const sandbox = new SpritesSandbox({ ...options, name });
+      // Set the existing sprite directly (bypass initialize)
+      sandbox.#setFromExisting(client, existingSprite);
+
+      return sandbox;
+    } catch (error) {
+      throw new SpritesSandboxError(
+        `Sandbox not found: ${name}`,
+        "SANDBOX_NOT_FOUND",
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Delete all Sprites whose names start with the given prefix.
+   *
+   * This is useful for cleaning up stale sandboxes from previous test runs
+   * or CI pipelines that may not have shut down cleanly.
+   *
+   * @param prefix - Name prefix to filter Sprites (e.g. `"ci-deepagents-"`)
+   * @param options - Optional auth configuration
+   * @returns The number of Sprites that were deleted
+   *
+   * @example
+   * ```typescript
+   * const deleted = await SpritesSandbox.deleteAll("ci-deepagents-");
+   * console.log(`Deleted ${deleted} stale sandboxes`);
+   * ```
+   */
+  static async deleteAll(
+    prefix: string,
+    options?: Pick<SpritesSandboxOptions, "auth">,
+  ): Promise<number> {
+    if (!prefix) {
+      throw new SpritesSandboxError(
+        "deleteAll requires a non-empty name prefix",
+        "COMMAND_FAILED",
+      );
+    }
+
+    let credentials: { token: string; baseURL: string };
+    try {
+      credentials = getAuthCredentials(options?.auth);
+    } catch (error) {
+      throw new SpritesSandboxError(
+        "Failed to authenticate with Sprites. Check your token configuration.",
+        "AUTHENTICATION_FAILED",
+        error instanceof Error ? error : undefined,
+      );
+    }
+
+    const client = new SpritesClient(credentials.token, {
+      baseURL: credentials.baseURL,
+    });
+
+    const sprites = await client.listAllSprites(prefix);
+    const results = await Promise.all(
+      sprites.map((sprite) =>
+        sprite
+          .delete()
+          .then(() => true)
+          .catch(() => false),
+      ),
+    );
+
+    return results.filter(Boolean).length;
+  }
+}
+
+/**
+ * Async factory function type for creating Sprites Sandbox instances.
+ *
+ * This is similar to BackendFactory but supports async creation,
+ * which is required for SpritesSandbox since initialization is async.
+ */
+export type AsyncSpritesSandboxFactory = () => Promise<SpritesSandbox>;
+
+/**
+ * Create an async factory function that creates a new Sprites Sandbox per
+ * invocation.
+ *
+ * Each call to the factory will create and initialize a new sandbox.
+ * This is useful when you want fresh, isolated environments for each
+ * agent invocation.
+ *
+ * **Important**: This returns an async factory. For use with middleware that
+ * requires a synchronous BackendFactory, use
+ * `createSpritesSandboxFactoryFromSandbox()` with a pre-created sandbox
+ * instead.
+ *
+ * Note: options.name is ignored here — each sandbox gets a generated name so
+ * repeated invocations don't collide.
+ *
+ * @param options - Optional configuration for sandbox creation
+ * @returns An async factory function that creates new sandboxes
+ *
+ * @example
+ * ```typescript
+ * import { createSpritesSandboxFactory } from "@langchain/sprites";
+ *
+ * const factory = createSpritesSandboxFactory({ timeout: 300 });
+ *
+ * // Each call creates a new sandbox
+ * const sandbox1 = await factory();
+ * const sandbox2 = await factory();
+ *
+ * try {
+ *   // Use sandboxes...
+ * } finally {
+ *   await sandbox1.close();
+ *   await sandbox2.close();
+ * }
+ * ```
+ */
+export function createSpritesSandboxFactory(
+  options?: Omit<SpritesSandboxOptions, "name">,
+): AsyncSpritesSandboxFactory {
+  return async () => {
+    return await SpritesSandbox.create(options);
+  };
+}
+
+/**
+ * Create a backend factory that reuses an existing Sprites Sandbox.
+ *
+ * This allows multiple agent invocations to share the same sandbox,
+ * avoiding the (already small) startup overhead of creating new Sprites.
+ *
+ * Important: You are responsible for managing the sandbox lifecycle
+ * (calling `close()` when done, or leaving the Sprite to suspend if you
+ * want to reconnect later).
+ *
+ * @param sandbox - An existing SpritesSandbox instance (must be initialized)
+ * @returns A BackendFactory that returns the provided sandbox
+ *
+ * @example
+ * ```typescript
+ * import { createDeepAgent, createFilesystemMiddleware } from "deepagents";
+ * import {
+ *   SpritesSandbox,
+ *   createSpritesSandboxFactoryFromSandbox,
+ * } from "@langchain/sprites";
+ *
+ * const sandbox = await SpritesSandbox.create();
+ *
+ * try {
+ *   const agent = createDeepAgent({
+ *     model: new ChatAnthropic({ model: "claude-sonnet-4-5" }),
+ *     systemPrompt: "You are a coding assistant.",
+ *     middlewares: [
+ *       createFilesystemMiddleware({
+ *         backend: createSpritesSandboxFactoryFromSandbox(sandbox),
+ *       }),
+ *     ],
+ *   });
+ *
+ *   await agent.invoke({ messages: [...] });
+ * } finally {
+ *   await sandbox.close();
+ * }
+ * ```
+ */
+export function createSpritesSandboxFactoryFromSandbox(
+  sandbox: SpritesSandbox,
+): BackendFactory {
+  return () => sandbox;
+}

--- a/libs/providers/sprites/src/types.ts
+++ b/libs/providers/sprites/src/types.ts
@@ -1,0 +1,239 @@
+/**
+ * Type definitions for the Sprites Sandbox backend.
+ *
+ * This module contains all type definitions for the @langchain/sprites
+ * package, including options and error types.
+ */
+
+import { type SandboxErrorCode, SandboxError } from "deepagents";
+
+/**
+ * Machine sizing for a Sprite.
+ *
+ * All fields are optional; the Sprites API applies sensible defaults.
+ */
+export interface SpritesSandboxConfig {
+  /** RAM in megabytes */
+  ramMB?: number;
+
+  /** Number of CPUs */
+  cpus?: number;
+
+  /** Region to deploy the Sprite (e.g. "ord", "iad") */
+  region?: string;
+
+  /** Storage in gigabytes */
+  storageGB?: number;
+}
+
+/**
+ * Configuration options for creating a Sprites Sandbox.
+ *
+ * @example
+ * ```typescript
+ * const options: SpritesSandboxOptions = {
+ *   name: "my-agent-sandbox",
+ *   timeout: 300, // 5 minutes
+ *   config: { ramMB: 2048, cpus: 2 },
+ * };
+ * ```
+ */
+export interface SpritesSandboxOptions {
+  /**
+   * Name for the Sprite.
+   *
+   * Sprites are named, persistent VMs: the name is the sandbox's identity
+   * and can be used later to reconnect with `SpritesSandbox.fromName()`.
+   *
+   * @default A generated name like `deepagents-<random>`
+   */
+  name?: string;
+
+  /**
+   * Machine sizing (RAM, CPUs, region, storage).
+   */
+  config?: SpritesSandboxConfig;
+
+  /**
+   * Custom environment variables to set in the Sprite.
+   *
+   * These variables will be available to all commands executed in the
+   * sandbox.
+   *
+   * @example
+   * ```typescript
+   * environment: {
+   *   NODE_ENV: "development",
+   * }
+   * ```
+   */
+  environment?: Record<string, string>;
+
+  /**
+   * Labels to attach to the Sprite, for organizing and filtering.
+   */
+  labels?: string[];
+
+  /**
+   * Runtime image variant.
+   *
+   * @default "default"
+   */
+  runtime?: "default" | "dev";
+
+  /**
+   * Wait for capacity instead of failing immediately when the
+   * organization is at its concurrent-Sprite limit.
+   */
+  waitForCapacity?: boolean;
+
+  /**
+   * Default timeout for command execution in seconds.
+   *
+   * @default 300 (5 minutes)
+   */
+  timeout?: number;
+
+  /**
+   * Working directory for command execution and relative file paths.
+   *
+   * @default "/home/sprite"
+   */
+  workdir?: string;
+
+  /**
+   * Initial files to create in the Sprite after initialization.
+   *
+   * A map of file paths to their contents. Files will be created in the
+   * sandbox filesystem before any commands are executed. Parent
+   * directories are created automatically. Relative paths are resolved
+   * against `workdir`.
+   *
+   * @example
+   * ```typescript
+   * const options: SpritesSandboxOptions = {
+   *   initialFiles: {
+   *     "index.js": "console.log('Hello')",
+   *     "package.json": '{"name": "test"}',
+   *   },
+   * };
+   * ```
+   */
+  initialFiles?: Record<string, string>;
+
+  /**
+   * Authentication configuration for the Sprites API.
+   *
+   * ### Environment Variable Setup
+   *
+   * ```bash
+   * # Create a token with: sprite tokens create
+   * export SPRITES_TOKEN=your_token_here
+   * ```
+   *
+   * Or pass the token directly in this auth configuration.
+   */
+  auth?: {
+    /**
+     * Sprites API token.
+     * If not provided, reads from the `SPRITES_TOKEN` environment variable.
+     */
+    token?: string;
+
+    /**
+     * Sprites API base URL.
+     * If not provided, reads from the `SPRITES_API_URL` environment
+     * variable or uses the default.
+     *
+     * @default "https://api.sprites.dev"
+     */
+    baseURL?: string;
+  };
+}
+
+/**
+ * Error codes for Sprites Sandbox operations.
+ *
+ * Used to identify specific error conditions and handle them appropriately.
+ */
+export type SpritesSandboxErrorCode =
+  | SandboxErrorCode
+  /** Authentication failed - check token configuration */
+  | "AUTHENTICATION_FAILED"
+  /** Failed to create sandbox - check options and quotas */
+  | "SANDBOX_CREATION_FAILED"
+  /** Sandbox not found - may have been deleted */
+  | "SANDBOX_NOT_FOUND"
+  /** File upload/download failed */
+  | "FILE_OPERATION_FAILED"
+  /** Checkpoint or restore operation failed */
+  | "CHECKPOINT_FAILED";
+
+const SPRITES_SANDBOX_ERROR_SYMBOL = Symbol.for("sprites.sandbox.error");
+
+/**
+ * Custom error class for Sprites Sandbox operations.
+ *
+ * Provides structured error information including:
+ * - Human-readable message
+ * - Error code for programmatic handling
+ * - Original cause for debugging
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await sandbox.execute("some command");
+ * } catch (error) {
+ *   if (SpritesSandboxError.isInstance(error)) {
+ *     switch (error.code) {
+ *       case "NOT_INITIALIZED":
+ *         await sandbox.initialize();
+ *         break;
+ *       case "COMMAND_TIMEOUT":
+ *         console.error("Command took too long");
+ *         break;
+ *       default:
+ *         throw error;
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export class SpritesSandboxError extends SandboxError {
+  /** Symbol for identifying sandbox error instances */
+  [SPRITES_SANDBOX_ERROR_SYMBOL] = true as const;
+
+  /** Error name for instanceof checks and logging */
+  override readonly name = "SpritesSandboxError";
+
+  /**
+   * Creates a new SpritesSandboxError.
+   *
+   * @param message - Human-readable error description
+   * @param code - Structured error code for programmatic handling
+   * @param cause - Original error that caused this error (for debugging)
+   */
+  constructor(
+    message: string,
+    public readonly code: SpritesSandboxErrorCode,
+    public override readonly cause?: Error,
+  ) {
+    super(message, code as SandboxErrorCode, cause);
+    // Maintain proper prototype chain for instanceof checks
+    Object.setPrototypeOf(this, SpritesSandboxError.prototype);
+  }
+
+  /**
+   * Checks if the error is an instance of SpritesSandboxError.
+   *
+   * @param error - The error to check
+   * @returns True if the error is an instance of SpritesSandboxError
+   */
+  static isInstance(error: unknown): error is SpritesSandboxError {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      (error as Record<symbol, unknown>)[SPRITES_SANDBOX_ERROR_SYMBOL] === true
+    );
+  }
+}

--- a/libs/providers/sprites/tsconfig.json
+++ b/libs/providers/sprites/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "src/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/providers/sprites/tsdown.config.ts
+++ b/libs/providers/sprites/tsdown.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "tsdown";
+
+// Mark only npm packages as external, excluding relative and absolute (Windows/Unix) paths
+const external = (id: string) =>
+  !id.startsWith(".") && !id.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(id);
+
+export default defineConfig([
+  {
+    entry: ["./src/index.ts"],
+    format: ["esm"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    outDir: "dist",
+    outExtensions: () => ({ js: ".js" }),
+    external,
+  },
+  {
+    entry: ["./src/index.ts"],
+    format: ["cjs"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    outDir: "dist",
+    outExtensions: () => ({ js: ".cjs" }),
+    external,
+  },
+]);

--- a/libs/providers/sprites/vitest.config.ts
+++ b/libs/providers/sprites/vitest.config.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import {
+  configDefaults,
+  defineConfig,
+  type ViteUserConfigExport,
+} from "vitest/config";
+
+const gatewaySetup = path.resolve(
+  __dirname,
+  "../../../scripts/vitest-setup-langsmith-gateway.ts",
+);
+
+export default defineConfig((env) => {
+  const common: ViteUserConfigExport = {
+    test: {
+      environment: "node",
+      hideSkippedTests: true,
+      globals: true,
+      testTimeout: 60_000,
+      hookTimeout: 60_000,
+      teardownTimeout: 60_000,
+      exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
+    },
+  };
+
+  if (env.mode === "int") {
+    return {
+      test: {
+        ...common.test,
+        globals: false,
+        testTimeout: 100_000,
+        hookTimeout: 120_000,
+        teardownTimeout: 120_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.int.test.ts"],
+        name: "int",
+        sequence: { concurrent: false },
+        setupFiles: [gatewaySetup],
+      },
+    } satisfies ViteUserConfigExport;
+  }
+
+  return {
+    test: {
+      ...common.test,
+      include: ["src/**/*.test.ts"],
+    },
+  } satisfies ViteUserConfigExport;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,6 +929,43 @@ importers:
         specifier: ^4.3.6
         version: 4.4.3
 
+  libs/providers/sprites:
+    dependencies:
+      '@fly/sprites':
+        specifier: ^0.2.1
+        version: 0.2.1
+    devDependencies:
+      '@langchain/sandbox-standard-tests':
+        specifier: workspace:*
+        version: link:../../standard-tests
+      '@tsconfig/recommended':
+        specifier: ^1.0.13
+        version: 1.0.13
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.2
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.1.10(vitest@4.1.10)
+      deepagents:
+        specifier: workspace:*
+        version: link:../../deepagents
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.4.2
+      tsdown:
+        specifier: ^0.22.1
+        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.23.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.1.4(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
   libs/standard-tests:
     devDependencies:
       '@tsconfig/recommended':
@@ -1355,6 +1392,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fly/sprites@0.2.1':
+    resolution: {integrity: sha512-uXCRflyR513rUqpaiacdtQDddJeoGW3VWpQ8LbO982s0vbIvXS5NuBL6Zldz0vpHI7ckyisF4H0OuI5ibEr2zg==}
+    engines: {node: '>=24.0.0'}
+    bundledDependencies:
+      - '@fly/client-signals'
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -4650,6 +4693,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@fly/sprites@0.2.1': {}
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -5684,7 +5729,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
+      obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(vite@8.1.4(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
This PR adds `@langchain/sprites`. This package is a sandbox backend for [Fly.io Sprites](https://sprites.dev). It implements the `SandboxBackendProtocol`. It has the same structure as the `daytona` and `modal` provider packages.

Sprites are persistent Linux VMs with names. A Sprite starts in 1 to 2 seconds. A Sprite stops automatically when it is idle. A stopped Sprite has no cost. A Sprite can make a checkpoint of the full machine state in less than one second. A Sprite can restore that checkpoint.

## Contents

- `SpritesSandbox` extends `BaseSandbox`. The `execute()` method runs commands with `bash -lc`. So pipes and glob patterns operate correctly. The `uploadFiles()` and `downloadFiles()` methods use the [Sprites SDK](https://github.com/superfly/sprites-js) filesystem API.
- Persistence functions: `SpritesSandbox.fromName()` connects again to an applicable sandbox. `checkpoint()` and `restore()` roll back the full machine state. `deleteAll(prefix)` removes the test sandboxes in CI.
- Factory functions that are the same as in the other providers (sync and async).
- Tests: 54 unit tests with a mock SDK. The integration suite runs `@langchain/sandbox-standard-tests` and Sprites tests (reconnect, checkpoint, restore).
- A changeset for an initial `0.1.0` release.
- CI: one line supplies `SPRITES_TOKEN` to the `test-int` environment.

## Test results

- `pnpm typecheck`, `pnpm build`, `pnpm format:check`, `pnpm lint`, and `pnpm test:unit` pass.
- The integration suite passes 98 of 98 tests against the live Sprites API.
- The integration tests do not run when `SPRITES_TOKEN` is not set. This is the same pattern as in `modal`. CI stays green until the secret is available.

## Note for maintainers

The integration tests need a `SPRITES_TOKEN` repository secret. Fly.io can supply the token.
