### PR TITLE
feat(evals): add orcarouter eval runner

### DIFF
--- a/.changeset/orcarouter-eval-runner.md
+++ b/.changeset/orcarouter-eval-runner.md
@@ -1,0 +1,5 @@
+---
+"@deepagents/evals": patch
+---
+
+Add an `orcarouter` eval runner backed by the OrcaRouter OpenAI-compatible gateway.

--- a/evals/README.md
+++ b/evals/README.md
@@ -35,7 +35,10 @@ Available runners are registered in
 [`internal/eval-harness/src/setup.ts`](../internal/eval-harness/src/setup.ts):
 
 You also need `LANGSMITH_API_KEY` set for result tracking (and the appropriate
-`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` for the model you choose).
+`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` for the model you choose). The
+`orcarouter` runner instead reads `ORCAROUTER_API_KEY` and routes every eval
+through the [OrcaRouter](https://www.orcarouter.ai) OpenAI-compatible gateway
+using its adaptive `orcarouter/fusion` model.
 
 ```bash
 # Run all eval suites with Sonnet 4.5
@@ -49,6 +52,9 @@ EVAL_RUNNER=sonnet-4-5 pnpm --filter @deepagents/eval-all test:eval
 
 # Run with a different model
 EVAL_RUNNER=gpt-4.1 pnpm --filter @deepagents/eval-files test:eval
+
+# Run through the OrcaRouter gateway
+EVAL_RUNNER=orcarouter pnpm --filter @deepagents/eval-files test:eval
 ```
 
 ## Writing a new eval

--- a/internal/eval-harness/src/runners.ts
+++ b/internal/eval-harness/src/runners.ts
@@ -48,3 +48,14 @@ registerDeepAgentRunner("gpt-4.1-mini", (config) =>
 registerDeepAgentRunner("o3-mini", (config) =>
   createDeepAgent({ ...config, model: new ChatOpenAI({ model: "o3-mini" }) }),
 );
+
+registerDeepAgentRunner("orcarouter", (config) =>
+  createDeepAgent({
+    ...config,
+    model: new ChatOpenAI({
+      model: "orcarouter/fusion",
+      apiKey: process.env.ORCAROUTER_API_KEY,
+      configuration: { baseURL: "https://www.orcarouter.ai/v1" },
+    }),
+  }),
+);


### PR DESCRIPTION
The eval harness can now run Deep Agents through OrcaRouter as a first-class provider. `EVAL_RUNNER=orcarouter` routes every eval through the [OrcaRouter](https://www.orcarouter.ai) OpenAI-compatible gateway on the adaptive `orcarouter/fusion` model, so you get the same trajectory assertions and LangSmith tracking as the existing `gpt-4.1`/`sonnet-4-5` runners.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means Deep Agents users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The runner mirrors the existing `ChatOpenAI`-backed runners in `internal/eval-harness/src/runners.ts` (same as `gpt-4.1`), pointing at `https://www.orcarouter.ai/v1` and reading `ORCAROUTER_API_KEY`. I verified it live: `EVAL_RUNNER=orcarouter` successfully invoked a Deep Agent through the gateway and returned a response, and `pnpm format:check`, `pnpm lint`, the `deepagents` build, and the `@deepagents/evals` build all pass. A changeset and an evals README note are included.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.