### PR TITLE
fix(deepagents): backport Python's subagent-fork middleware-mirroring rework (#5981)

### DIFF
--- a/.changeset/tame-subagents-inherit-tools.md
+++ b/.changeset/tame-subagents-inherit-tools.md
@@ -1,0 +1,5 @@
+---
+"deepagents": patch
+---
+
+Fix a declarative subagent silently getting no tools when it omitted its own `tools` field (now correctly falls back to the parent's tools, as documented), and make `createDeepAgent` throw at construction if two subagents share a name instead of silently letting the later one win.

--- a/.changeset/tame-subagents-inherit-tools.md
+++ b/.changeset/tame-subagents-inherit-tools.md
@@ -2,4 +2,4 @@
 "deepagents": patch
 ---
 
-Fix a declarative subagent silently getting no tools when it omitted its own `tools` field (now correctly falls back to the parent's tools, as documented), and make `createDeepAgent` throw at construction if two subagents share a name instead of silently letting the later one win.
+Fix a declarative subagent silently getting no tools when it omitted its own `tools` field (now correctly falls back to the parent's tools, as documented), and make `createDeepAgent` throw at construction if two subagents share a name instead of silently letting the later one win. Also drop the separate `ForkedSubAgent` type — `mode: "fork"` is now just a value on `SubAgent` — and allow a fork to declare its own `systemPrompt`, appended to the parent's inherited prompt instead of being rejected.

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -37,7 +37,6 @@ import {
   GENERAL_PURPOSE_SUBAGENT,
   isForkedSubAgent,
   type CompiledSubAgent,
-  type ForkedSubAgent,
 } from "./middleware/subagents.js";
 import type { AsyncSubAgent } from "./middleware/async_subagents.js";
 import type {
@@ -304,7 +303,7 @@ export function createDeepAgent<
    * If a custom subagent needs skills, it must specify its own `skills` array.
    */
   const createSubagentDefaultMiddleware = (
-    input: SubAgent | ForkedSubAgent,
+    input: SubAgent,
     subagentProfile: HarnessProfile,
   ): AgentMiddleware[] => {
     const effectivePermissions = input.permissions ?? permissions;
@@ -332,9 +331,7 @@ export function createDeepAgent<
     ];
   };
 
-  const buildSubagentMiddleware = (
-    input: SubAgent | ForkedSubAgent,
-  ): AgentMiddleware[] => {
+  const buildSubagentMiddleware = (input: SubAgent): AgentMiddleware[] => {
     const subagentProfile = resolveSubagentProfile(input.model);
     const forked = isForkedSubAgent(input);
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(
@@ -395,14 +392,6 @@ export function createDeepAgent<
     middleware: buildSubagentMiddleware(input),
   });
 
-  const normalizeForkedSubagentSpec = (
-    input: ForkedSubAgent,
-  ): ForkedSubAgent => ({
-    ...input,
-    // Omitting tools here lets getSubagents() fall back to the parent's.
-    middleware: buildSubagentMiddleware(input),
-  });
-
   const allSubagents = subagents as readonly AnySubAgent[];
 
   // Split the unified subagents array into sync and async subagents.
@@ -414,19 +403,12 @@ export function createDeepAgent<
   // Process sync subagents:
   // - CompiledSubAgent: use as-is (already has its own middleware baked in)
   // - SubAgent: apply the default deep-agent subagent middleware stack
-  // - ForkedSubAgent: same stack, plus model-matched mirrored middleware
+  //   (a `mode: "fork"` spec gets the same treatment, plus mirrored middleware)
   const inlineSubagents = allSubagents
     .filter(
-      (item): item is SubAgent | CompiledSubAgent | ForkedSubAgent =>
-        !isAsyncSubAgent(item),
+      (item): item is SubAgent | CompiledSubAgent => !isAsyncSubAgent(item),
     )
-    .map((item) =>
-      "runnable" in item
-        ? item
-        : isForkedSubAgent(item)
-          ? normalizeForkedSubagentSpec(item)
-          : normalizeSubagentSpec(item),
-    );
+    .map((item) => ("runnable" in item ? item : normalizeSubagentSpec(item)));
 
   const gpConfig = harnessProfile.generalPurposeSubagent;
   const gpDisabled = gpConfig?.enabled === false;

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -305,6 +305,7 @@ export function createDeepAgent<
   const createSubagentDefaultMiddleware = (
     input: SubAgent,
     subagentProfile: HarnessProfile,
+    forked: boolean,
   ): AgentMiddleware[] => {
     const effectivePermissions = input.permissions ?? permissions;
 
@@ -324,8 +325,11 @@ export function createDeepAgent<
       createSummarizationMiddleware({ backend }),
       // Patches tool calls to ensure compatibility across different model providers.
       createPatchToolCallsMiddleware(),
-      // Loads subagent-specific skills when configured.
-      ...(input.skills != null && input.skills.length > 0
+      // Loads subagent-specific skills when configured. Never for a fork: its
+      // own `skills` is rejected below, and the parent's are mirrored instead
+      // (see buildSubagentMiddleware) — building this here too would produce
+      // a second same-named SkillsMiddleware before that rejection even runs.
+      ...(!forked && input.skills != null && input.skills.length > 0
         ? [createSkillsMiddleware({ backend, sources: input.skills })]
         : []),
     ];
@@ -337,15 +341,13 @@ export function createDeepAgent<
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(
       input,
       subagentProfile,
+      forked,
     );
-    // Forks mirror the parent's skills/memory/middleware to rebuild an
-    // equivalent prompt instead of replaying a captured one.
     if (forked && skills != null && skills.length > 0) {
       subagentDefaultMiddleware.unshift(
         createSkillsMiddleware({ backend, sources: skills }),
       );
     }
-    // Fork's own middleware wins over the mirrored parent one by name.
     const inputMiddleware =
       forked && customMiddleware.length > 0
         ? mergeMiddleware(customMiddleware, input.middleware ?? [])

--- a/libs/deepagents/src/agent.ts
+++ b/libs/deepagents/src/agent.ts
@@ -32,11 +32,10 @@ import type { SystemPromptConfig } from "./compat.js";
 import { InteropZodObject } from "@langchain/core/utils/types";
 import { createCacheBreakpointMiddleware } from "./middleware/cache.js";
 import { createToolExclusionMiddleware } from "./middleware/tool_exclusion.js";
-import { mergeMiddlewareStack } from "./middleware/utils.js";
+import { mergeMiddleware, mergeMiddlewareStack } from "./middleware/utils.js";
 import {
   GENERAL_PURPOSE_SUBAGENT,
   isForkedSubAgent,
-  createParentSystemMessageMiddleware,
   type CompiledSubAgent,
   type ForkedSubAgent,
 } from "./middleware/subagents.js";
@@ -337,18 +336,40 @@ export function createDeepAgent<
     input: SubAgent | ForkedSubAgent,
   ): AgentMiddleware[] => {
     const subagentProfile = resolveSubagentProfile(input.model);
+    const forked = isForkedSubAgent(input);
     const subagentDefaultMiddleware = createSubagentDefaultMiddleware(
       input,
       subagentProfile,
     );
+    // Forks mirror the parent's skills/memory/middleware to rebuild an
+    // equivalent prompt instead of replaying a captured one.
+    if (forked && skills != null && skills.length > 0) {
+      subagentDefaultMiddleware.unshift(
+        createSkillsMiddleware({ backend, sources: skills }),
+      );
+    }
+    // Fork's own middleware wins over the mirrored parent one by name.
+    const inputMiddleware =
+      forked && customMiddleware.length > 0
+        ? mergeMiddleware(customMiddleware, input.middleware ?? [])
+        : (input.middleware ?? []);
 
     let subagentMiddleware = mergeMiddlewareStack(
       subagentDefaultMiddleware,
-      input.middleware ?? [],
+      inputMiddleware,
       [
         // Resolve profile middleware per stack so factories create fresh instances.
         ...resolveMiddleware(subagentProfile.extraMiddleware),
         ...cacheMiddleware,
+        ...(forked && memory != null && memory.length > 0
+          ? [
+              createMemoryMiddleware({
+                backend,
+                sources: memory,
+                addCacheControl: anthropicModel,
+              }),
+            ]
+          : []),
       ],
     );
 
@@ -370,8 +391,7 @@ export function createDeepAgent<
 
   const normalizeSubagentSpec = (input: SubAgent): SubAgent => ({
     ...input,
-    // Leave `tools` untouched when omitted — getSubagents() falls back to
-    // the parent's tools in that case; coercing to `[]` here would defeat that.
+    // Omitting tools here lets getSubagents() fall back to the parent's.
     middleware: buildSubagentMiddleware(input),
   });
 
@@ -379,8 +399,7 @@ export function createDeepAgent<
     input: ForkedSubAgent,
   ): ForkedSubAgent => ({
     ...input,
-    // Leave `tools` untouched when omitted — getSubagents() falls back to
-    // the parent's tools in that case; coercing to `[]` here would defeat that.
+    // Omitting tools here lets getSubagents() fall back to the parent's.
     middleware: buildSubagentMiddleware(input),
   });
 
@@ -513,15 +532,6 @@ export function createDeepAgent<
   if (harnessProfile.excludedMiddleware.size > 0) {
     const excluded = harnessProfile.excludedMiddleware;
     middleware = middleware.filter((entry) => !excluded.has(entry.name));
-  }
-
-  // Capturing the system message costs a state write per model call, so only pay for it when a declarative fork will consume it.
-  const hasDeclarativeFork = inlineSubagents.some(
-    (item) => !("runnable" in item) && isForkedSubAgent(item),
-  );
-  // Must run after everything that can mutate the system message, but before tool exclusion below (which must stay last).
-  if (hasDeclarativeFork) {
-    middleware.push(createParentSystemMessageMiddleware());
   }
 
   // Apply profile tool exclusions via a filtering middleware that runs

--- a/libs/deepagents/src/browser.ts
+++ b/libs/deepagents/src/browser.ts
@@ -96,6 +96,7 @@ export {
   type SubAgentMiddlewareOptions,
   type MemoryMiddlewareOptions,
   type SubAgent,
+  type ForkedSubAgent,
   type CompiledSubAgent,
   type AsyncSubAgentMiddlewareOptions,
   type AsyncSubAgent,

--- a/libs/deepagents/src/browser.ts
+++ b/libs/deepagents/src/browser.ts
@@ -97,7 +97,6 @@ export {
   type MemoryMiddlewareOptions,
   type SubAgent,
   type CompiledSubAgent,
-  type ForkedSubAgent,
   type AsyncSubAgentMiddlewareOptions,
   type AsyncSubAgent,
   type AsyncTask,

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -101,6 +101,7 @@ export {
   type SubAgentMiddlewareOptions,
   type MemoryMiddlewareOptions,
   type SubAgent,
+  type ForkedSubAgent,
   type CompiledSubAgent,
   type AsyncSubAgentMiddlewareOptions,
   type AsyncSubAgent,

--- a/libs/deepagents/src/index.ts
+++ b/libs/deepagents/src/index.ts
@@ -102,7 +102,6 @@ export {
   type MemoryMiddlewareOptions,
   type SubAgent,
   type CompiledSubAgent,
-  type ForkedSubAgent,
   type AsyncSubAgentMiddlewareOptions,
   type AsyncSubAgent,
   type AsyncTask,

--- a/libs/deepagents/src/middleware/index.ts
+++ b/libs/deepagents/src/middleware/index.ts
@@ -13,7 +13,6 @@ export {
   type SubAgentMiddlewareOptions,
   type SubAgent,
   type CompiledSubAgent,
-  type ForkedSubAgent,
   // Constants for building custom subagent configurations
   GENERAL_PURPOSE_SUBAGENT,
   DEFAULT_GENERAL_PURPOSE_DESCRIPTION,

--- a/libs/deepagents/src/middleware/index.ts
+++ b/libs/deepagents/src/middleware/index.ts
@@ -12,6 +12,7 @@ export {
   createSubAgentMiddleware,
   type SubAgentMiddlewareOptions,
   type SubAgent,
+  type ForkedSubAgent,
   type CompiledSubAgent,
   // Constants for building custom subagent configurations
   GENERAL_PURPOSE_SUBAGENT,

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -382,7 +382,7 @@ describe("Subagent summarization state isolation", () => {
   });
 });
 
-describe("ForkedSubAgent", () => {
+describe("SubAgent mode: fork", () => {
   let invokeSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -434,7 +434,7 @@ describe("ForkedSubAgent", () => {
     ).toThrow(/invalid mode 'dynamic'/);
   });
 
-  it("throws at construction when a ForkedSubAgent declares skills", () => {
+  it("throws at construction when a fork declares skills", () => {
     expect(() =>
       createDeepAgent({
         model: new FakeListChatModel({ responses: ["Done"] }),
@@ -447,23 +447,49 @@ describe("ForkedSubAgent", () => {
           } as any,
         ],
       }),
-    ).toThrow(/ForkedSubAgent 'worker' cannot set skills/);
+    ).toThrow(/SubAgent 'worker' cannot set skills under mode: "fork"/);
   });
 
-  it("throws at construction when a ForkedSubAgent declares its own systemPrompt", () => {
-    expect(() =>
-      createDeepAgent({
-        model: new FakeListChatModel({ responses: ["Done"] }),
-        subagents: [
-          {
-            name: "worker",
-            description: "A worker agent",
-            mode: "fork",
-            systemPrompt: "You are a worker.",
-          } as any,
-        ],
-      }),
-    ).toThrow(/ForkedSubAgent 'worker' cannot set systemPrompt/);
+  it("appends a fork's own systemPrompt to the parent's inherited prompt, rather than replacing it", async () => {
+    const model = new FakeListChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: `call_${Date.now()}`,
+              name: "task",
+              args: { description: "continue", subagent_type: "worker" },
+            },
+          ],
+        }) as unknown as string,
+        "Worker done",
+        "Done",
+      ],
+    });
+
+    const agent = createDeepAgent({
+      model,
+      systemPrompt: "PARENT_PROMPT",
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          mode: "fork",
+          systemPrompt: "FORK_EXTRA",
+        },
+      ],
+    });
+
+    await agent.invoke(
+      { messages: [new HumanMessage("start")] },
+      { recursionLimit: 25 },
+    );
+
+    const workerCall = findCallContaining(invokeSpy, "continue");
+    expect(workerCall).toBeDefined();
+    const systemMessage = workerCall!.find(SystemMessage.isInstance);
+    expect(systemMessage?.text).toBe("PARENT_PROMPT\n\nFORK_EXTRA");
   });
 
   it("throws at construction when two subagents share a name", () => {
@@ -532,7 +558,7 @@ describe("ForkedSubAgent", () => {
     expect(text).not.toContain("BANANA42");
   });
 
-  it("should include prior history and the parent's exact system prompt for a ForkedSubAgent", async () => {
+  it("should include prior history and the parent's exact system prompt for a fork", async () => {
     const model = new FakeListChatModel({
       responses: [
         new AIMessage({
@@ -859,7 +885,7 @@ describe("ForkedSubAgent", () => {
     expect(text).not.toContain("get_weather");
   });
 
-  it("should still inherit the parent's system prompt for a ForkedSubAgent even when its model differs", async () => {
+  it("should still inherit the parent's system prompt for a fork even when its model differs", async () => {
     const mainModel = new FakeListChatModel({
       responses: [
         new AIMessage({
@@ -915,8 +941,8 @@ describe("ForkedSubAgent", () => {
       .join("\n");
     expect(text).toContain("BANANA42");
 
-    // ...and the system prompt is still the parent's — a ForkedSubAgent has
-    // no own prompt to fall back to, so model mismatch only means no cache
+    // ...and the system prompt is still the parent's — this fork has no
+    // systemPrompt of its own, so model mismatch only means no cache
     // benefit, not a different prompt.
     const systemMessage = workerCall!.find(SystemMessage.isInstance);
     expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
@@ -2092,7 +2118,7 @@ describe("middleware override by name", () => {
     expect(merged).toEqual([second]);
   });
 
-  it("mirrors the parent's custom middleware into a ForkedSubAgent when the parent has no system prompt", () => {
+  it("mirrors the parent's custom middleware into a fork when the parent has no system prompt", () => {
     const custom = namedMiddleware("MarkerMiddleware");
 
     createDeepAgent({
@@ -2114,7 +2140,7 @@ describe("middleware override by name", () => {
     );
   });
 
-  it("mirrors the parent's custom middleware into a ForkedSubAgent even when its model differs from the parent's", () => {
+  it("mirrors the parent's custom middleware into a fork even when its model differs from the parent's", () => {
     const custom = namedMiddleware("MarkerMiddleware");
     const workerModel = new FakeListChatModel({ responses: ["hello"] });
 
@@ -2139,7 +2165,7 @@ describe("middleware override by name", () => {
     );
   });
 
-  it("a ForkedSubAgent's own middleware entry wins over a same-named mirrored parent one", () => {
+  it("a fork's own middleware entry wins over a same-named mirrored parent one", () => {
     const parentEntry = namedMiddleware("MarkerMiddleware");
     const forkEntry = namedMiddleware("MarkerMiddleware");
 

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -427,12 +427,34 @@ describe("SubAgent mode: fork", () => {
             name: "worker",
             description: "A worker agent",
             systemPrompt: "You are a worker.",
-            mode: "dynamic" as unknown as "handoff",
+            mode: "dynamic" as unknown as "isolated",
           },
         ],
       }),
     ).toThrow(/invalid mode 'dynamic'/);
   });
+
+  it.each(["isolated", "handoff"] as const)(
+    "accepts mode: %s — 'handoff' is a legacy alias for 'isolated', neither forks",
+    (mode) => {
+      const middleware = createSubAgentMiddleware({
+        defaultModel: new FakeListChatModel({ responses: ["ok"] }),
+        generalPurposeAgent: false,
+        subagents: [
+          {
+            name: "worker",
+            description: "A worker agent",
+            mode: mode as unknown as "isolated",
+          },
+        ],
+      });
+
+      const taskTool = middleware.tools![0];
+      expect(taskTool.description).not.toContain(
+        "inherits your full conversation and system prompt",
+      );
+    },
+  );
 
   it("throws at construction when a fork declares skills", () => {
     expect(() =>
@@ -508,7 +530,7 @@ describe("SubAgent mode: fork", () => {
     ).toThrow(/Duplicate subagent name 'worker'/);
   });
 
-  it("should NOT include prior history for the default handoff mode", async () => {
+  it("should NOT include prior history for the default isolated mode", async () => {
     const model = new FakeListChatModel({
       responses: [
         new AIMessage({
@@ -545,7 +567,7 @@ describe("SubAgent mode: fork", () => {
     await agent.invoke(
       { messages: priorHistory },
       {
-        configurable: { thread_id: `test-mode-handoff-${Date.now()}` },
+        configurable: { thread_id: `test-mode-isolated-${Date.now()}` },
         recursionLimit: 50,
       },
     );
@@ -704,10 +726,10 @@ describe("SubAgent mode: fork", () => {
     ).toBe(true);
   });
 
-  it("gives a declarative fork the full parent state, unlike the narrow subagent-safe subset a handoff sees", () => {
+  it("gives a declarative fork the full parent state, unlike the narrow subagent-safe subset an isolated subagent sees", () => {
     const state = {
       messages: ["overwritten unconditionally by runTask either way"],
-      todos: ["excluded from a handoff, survives the fork filter"],
+      todos: ["excluded from an isolated subagent, survives the fork filter"],
       structuredResponse: {
         note: "excluded from both — a stale value must not be mistaken for the fork's own result",
       },
@@ -724,7 +746,7 @@ describe("SubAgent mode: fork", () => {
     const forSubagent = filterStateForSubagent(state);
     const forFork = filterStateForFork(state);
 
-    // Handoff/compiled path: only keys outside the wide EXCLUDED_STATE_KEYS list survive.
+    // Isolated/compiled path: only keys outside the wide EXCLUDED_STATE_KEYS list survive.
     expect(forSubagent).toEqual({
       customUserKey: "carried either way — not a special key",
     });
@@ -1911,7 +1933,7 @@ describe("Subagent tool inheritance", () => {
     createAgentMock.mockClear();
   });
 
-  it("inherits the parent's tools when a declarative subagent omits its own, for both handoff and fork", () => {
+  it("inherits the parent's tools when a declarative subagent omits its own, for both isolated and fork", () => {
     const parentTool = tool(async () => "logs", {
       name: "read_logs",
       description: "Read logs",
@@ -1922,7 +1944,7 @@ describe("Subagent tool inheritance", () => {
       model: new FakeListChatModel({ responses: ["ok"] }),
       tools: [parentTool],
       subagents: [
-        { name: "handoff-worker", description: "a worker" },
+        { name: "isolated-worker", description: "a worker" },
         { name: "fork-worker", description: "a worker", mode: "fork" },
       ],
     });
@@ -1934,7 +1956,7 @@ describe("Subagent tool inheritance", () => {
       ]),
     );
 
-    expect(toolsByAgentName.get("handoff-worker")).toEqual([parentTool]);
+    expect(toolsByAgentName.get("isolated-worker")).toEqual([parentTool]);
     expect(toolsByAgentName.get("fork-worker")).toEqual([parentTool]);
   });
 });

--- a/libs/deepagents/src/middleware/subagent.test.ts
+++ b/libs/deepagents/src/middleware/subagent.test.ts
@@ -46,6 +46,7 @@ import {
   createSubAgent,
   createSubAgentMiddleware,
   filterStateForSubagent,
+  filterStateForFork,
 } from "./subagents.js";
 import { registerHarnessProfile } from "../profiles/index.js";
 
@@ -69,7 +70,8 @@ function getAllSystemPromptsFromSpy(
   return systemPrompts;
 }
 
-// Works around FakeListChatModel always replaying its first response across a subagent's own multiple calls.
+// FakeListChatModel replays its first response across a subagent's own
+// multiple calls; this shares a counter across bound instances instead.
 class SequentialFakeChatModel extends FakeListChatModel {
   private sharedCounter: { i: number };
 
@@ -433,7 +435,6 @@ describe("ForkedSubAgent", () => {
   });
 
   it("throws at construction when a ForkedSubAgent declares skills", () => {
-    // `as any` bypasses the `skills?: undefined` compile-time guard to exercise the runtime check.
     expect(() =>
       createDeepAgent({
         model: new FakeListChatModel({ responses: ["Done"] }),
@@ -449,50 +450,37 @@ describe("ForkedSubAgent", () => {
     ).toThrow(/ForkedSubAgent 'worker' cannot set skills/);
   });
 
-  it.each([
-    { label: "no subagents", subagents: undefined, expected: false },
-    {
-      label: "isolated (handoff) subagent",
-      subagents: [
-        {
-          name: "worker",
-          description: "Starts fresh.",
-          systemPrompt: "You are a worker.",
-        },
-      ],
-      expected: false,
-    },
-    {
-      label: "declarative fork subagent",
-      subagents: [
-        {
-          name: "worker",
-          description: "Continues with context.",
-          mode: "fork" as const,
-        },
-      ],
-      expected: true,
-    },
-  ])(
-    "only installs parentSystemMessageMiddleware for a declarative fork ($label)",
-    ({ subagents, expected }) => {
-      createAgentMock.mockClear();
+  it("throws at construction when a ForkedSubAgent declares its own systemPrompt", () => {
+    expect(() =>
       createDeepAgent({
         model: new FakeListChatModel({ responses: ["Done"] }),
-        systemPrompt: "PARENT_PROMPT",
-        subagents,
-      });
+        subagents: [
+          {
+            name: "worker",
+            description: "A worker agent",
+            mode: "fork",
+            systemPrompt: "You are a worker.",
+          } as any,
+        ],
+      }),
+    ).toThrow(/ForkedSubAgent 'worker' cannot set systemPrompt/);
+  });
 
-      const calls = createAgentMock.mock.calls;
-      const mainAgentCall = calls[calls.length - 1][0] as unknown as {
-        middleware: AgentMiddleware[];
-      };
-      const installed = mainAgentCall.middleware.some(
-        (m) => m.name === "parentSystemMessageMiddleware",
-      );
-      expect(installed).toBe(expected);
-    },
-  );
+  it("throws at construction when two subagents share a name", () => {
+    expect(() =>
+      createDeepAgent({
+        model: new FakeListChatModel({ responses: ["Done"] }),
+        subagents: [
+          { name: "worker", description: "First worker." },
+          {
+            name: "worker",
+            description: "A forked duplicate of the first worker.",
+            mode: "fork",
+          },
+        ],
+      }),
+    ).toThrow(/Duplicate subagent name 'worker'/);
+  });
 
   it("should NOT include prior history for the default handoff mode", async () => {
     const model = new FakeListChatModel({
@@ -599,7 +587,6 @@ describe("ForkedSubAgent", () => {
     const systemMessage = workerCall!.find(SystemMessage.isInstance);
     expect(systemMessage?.text).toContain("PARENT_ROOT_PROMPT_MARKER");
 
-    // The trailing message carries the fork identity preamble ahead of the bare task description.
     const lastMessage = workerCall![workerCall!.length - 1];
     expect(lastMessage.content).toContain(
       "you are that subagent, not the one being asked to delegate further",
@@ -607,7 +594,7 @@ describe("ForkedSubAgent", () => {
     expect(lastMessage.content).toMatch(/UNIQUE_TASK_MARKER$/);
   });
 
-  it("replays the parent's just-computed skills-injected system message into a fork, not a stale static copy", async () => {
+  it("mirrors the parent's SkillsMiddleware into a fork so its own system message includes the same skills content", async () => {
     const taskToolCallId = `call_${Date.now()}`;
     const model = new FakeListChatModel({
       responses: [
@@ -664,6 +651,92 @@ describe("ForkedSubAgent", () => {
       .filter((p) => p.includes("Skills System"));
     expect(forkPrompts.length).toBeGreaterThan(0);
     expect(forkPrompts[0]).toContain("test-skill");
+  });
+
+  it("mirrors the parent's MemoryMiddleware into a fork when the parent has memory sources", () => {
+    createAgentMock.mockClear();
+    createDeepAgent({
+      model: new FakeListChatModel({ responses: ["Done"] }),
+      name: "main",
+      memory: ["/AGENTS.md"],
+      subagents: [
+        {
+          name: "worker",
+          description: "Continues with context.",
+          mode: "fork",
+        },
+      ],
+    });
+
+    const calls = createAgentMock.mock.calls;
+    const workerCall = calls.find(
+      ([params]) => (params as { name?: string }).name === "worker",
+    )?.[0] as unknown as { middleware: AgentMiddleware[] } | undefined;
+    expect(workerCall).toBeDefined();
+    expect(
+      workerCall!.middleware.some((m) => m.name === "MemoryMiddleware"),
+    ).toBe(true);
+  });
+
+  it("gives a declarative fork the full parent state, unlike the narrow subagent-safe subset a handoff sees", () => {
+    const state = {
+      messages: ["overwritten unconditionally by runTask either way"],
+      todos: ["excluded from a handoff, survives the fork filter"],
+      structuredResponse: {
+        note: "excluded from both — a stale value must not be mistaken for the fork's own result",
+      },
+      skillsMetadata: { carried: "for a fork" },
+      memoryContents: "carried for a fork",
+      customUserKey: "carried either way — not a special key",
+      _summarizationEvent: {
+        note: "excluded from both — cutoffIndex is invalid for a fork's own history",
+      },
+      _summarizationSessionId:
+        "excluded from both — runTask assigns a fresh one",
+    };
+
+    const forSubagent = filterStateForSubagent(state);
+    const forFork = filterStateForFork(state);
+
+    // Handoff/compiled path: only keys outside the wide EXCLUDED_STATE_KEYS list survive.
+    expect(forSubagent).toEqual({
+      customUserKey: "carried either way — not a special key",
+    });
+
+    // Declarative fork: everything except structuredResponse and the two
+    // summarization keys survives.
+    expect(forFork).toEqual({
+      messages: state.messages,
+      todos: state.todos,
+      skillsMetadata: state.skillsMetadata,
+      memoryContents: state.memoryContents,
+      customUserKey: state.customUserKey,
+    });
+  });
+
+  it("splices a fork's task tool right after FilesystemMiddleware, matching the parent's tool position", () => {
+    createAgentMock.mockClear();
+    createDeepAgent({
+      model: new FakeListChatModel({ responses: ["Done"] }),
+      name: "main",
+      subagents: [
+        {
+          name: "worker",
+          description: "Continues with context.",
+          mode: "fork",
+        },
+      ],
+    });
+
+    const calls = createAgentMock.mock.calls;
+    const workerCall = calls.find(
+      ([params]) => (params as { name?: string }).name === "worker",
+    )?.[0] as unknown as { middleware: AgentMiddleware[] } | undefined;
+    expect(workerCall).toBeDefined();
+    const names = workerCall!.middleware.map((m) => m.name);
+    const fsIndex = names.indexOf("FilesystemMiddleware");
+    expect(fsIndex).toBeGreaterThanOrEqual(0);
+    expect(names[fsIndex + 1]).toBe("forkTaskToolMiddleware");
   });
 
   it("refuses a fork's own attempt to delegate again, rather than recursing", async () => {
@@ -2019,7 +2092,7 @@ describe("middleware override by name", () => {
     expect(merged).toEqual([second]);
   });
 
-  it("does NOT mirror custom middleware into a ForkedSubAgent when the parent has no system prompt", () => {
+  it("mirrors the parent's custom middleware into a ForkedSubAgent when the parent has no system prompt", () => {
     const custom = namedMiddleware("MarkerMiddleware");
 
     createDeepAgent({
@@ -2037,11 +2110,11 @@ describe("middleware override by name", () => {
 
     const middleware = getMiddlewareStack("worker");
     expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
-      false,
+      true,
     );
   });
 
-  it("does NOT mirror custom middleware into a ForkedSubAgent when its model differs from the parent's", () => {
+  it("mirrors the parent's custom middleware into a ForkedSubAgent even when its model differs from the parent's", () => {
     const custom = namedMiddleware("MarkerMiddleware");
     const workerModel = new FakeListChatModel({ responses: ["hello"] });
 
@@ -2062,8 +2135,33 @@ describe("middleware override by name", () => {
 
     const middleware = getMiddlewareStack("worker");
     expect(middleware.some((entry) => entry.name === "MarkerMiddleware")).toBe(
-      false,
+      true,
     );
+  });
+
+  it("a ForkedSubAgent's own middleware entry wins over a same-named mirrored parent one", () => {
+    const parentEntry = namedMiddleware("MarkerMiddleware");
+    const forkEntry = namedMiddleware("MarkerMiddleware");
+
+    createDeepAgent({
+      model: fakeModel,
+      name: "main",
+      middleware: [parentEntry],
+      subagents: [
+        {
+          name: "worker",
+          description: "A worker agent",
+          mode: "fork",
+          middleware: [forkEntry],
+        },
+      ],
+    });
+
+    const middleware = getMiddlewareStack("worker");
+    const matches = middleware.filter(
+      (entry) => entry.name === "MarkerMiddleware",
+    );
+    expect(matches).toEqual([forkEntry]);
   });
 
   it("replaces default main-agent middleware with same-name custom middleware", () => {

--- a/libs/deepagents/src/middleware/subagents.int.test.ts
+++ b/libs/deepagents/src/middleware/subagents.int.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { createAgent, createMiddleware, ReactAgent, tool } from "langchain";
 import { AIMessage, BaseMessage, HumanMessage } from "@langchain/core/messages";
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import type { LLMResult } from "@langchain/core/outputs";
+import { ChatAnthropic } from "@langchain/anthropic";
 import { MemorySaver } from "@langchain/langgraph";
 import { z } from "zod/v4";
 import {
@@ -903,6 +906,114 @@ Use the write_file tool to save your code.`,
 
       // Verify the tool captured the correct agent name
       expect(capturedAgentName).toBe("weather-agent");
+    },
+  );
+});
+
+describe("Subagent Fork Cache Integration Tests", () => {
+  // Padded well past Anthropic's ~1024-token cache-eligibility minimum.
+  const LONG_SYSTEM_PROMPT = Array.from(
+    { length: 200 },
+    (_, i) =>
+      `Fact ${i}: the project's internal identifier for this scenario is ULTRAVIOLET-${i}-${i * 7}.`,
+  ).join("\n");
+
+  it.concurrent(
+    "reuses the parent's Anthropic prompt-cache prefix on a forked subagent's first model call",
+    { timeout: 90 * 1000 },
+    async () => {
+      // Keyed by runId so a call's cache_read (only available on
+      // handleLLMEnd) can be attributed back to the lc_agent_name metadata
+      // that's only available on handleChatModelStart for that same run.
+      const runAgentNames = new Map<string, string | undefined>();
+      const workerCacheReadTokenCounts: number[] = [];
+
+      class CacheUsageCaptureHandler extends BaseCallbackHandler {
+        name = `capture-cache-usage-${Date.now()}-${Math.random()}`;
+
+        override handleChatModelStart(
+          _llm: unknown,
+          _messages: unknown,
+          runId: string,
+          _parentRunId?: string,
+          _extraParams?: Record<string, unknown>,
+          _tags?: string[],
+          metadata?: Record<string, unknown>,
+        ) {
+          runAgentNames.set(
+            runId,
+            metadata?.lc_agent_name as string | undefined,
+          );
+        }
+
+        async handleLLMEnd(output: LLMResult, runId: string) {
+          // Only the worker's own calls matter here -- the parent's calls
+          // (including its own follow-up after the tool result) reuse the
+          // cache from the parent's own first call regardless of whether the
+          // fork correctly mirrored anything, so aggregating across every
+          // call in the run would let a genuinely cold fork call pass.
+          if (runAgentNames.get(runId) !== "worker") return;
+          for (const generationBatch of output.generations) {
+            for (const generation of generationBatch) {
+              const message = (generation as { message?: AIMessage }).message;
+              const usage = message?.usage_metadata as
+                | { input_token_details?: { cache_read?: number } }
+                | undefined;
+              const cacheRead = usage?.input_token_details?.cache_read;
+              if (typeof cacheRead === "number") {
+                workerCacheReadTokenCounts.push(cacheRead);
+              }
+            }
+          }
+        }
+      }
+
+      const handler = new CacheUsageCaptureHandler();
+
+      // Explicit instance, not a bare model string — isAnthropicModel() can't
+      // see through the ConfigurableModel wrapper a string resolves into,
+      // which would silently no-op the cache middleware (pre-existing gap,
+      // unrelated to forking).
+      const anthropicModel = new ChatAnthropic({
+        model: "claude-sonnet-4-5-20250929",
+      });
+
+      const agent = createDeepAgent({
+        model: anthropicModel,
+        systemPrompt: LONG_SYSTEM_PROMPT,
+        subagents: [
+          {
+            name: "worker",
+            description:
+              "Continues the current investigation with full context",
+            mode: "fork",
+          },
+        ],
+      });
+
+      const response = await agent.invoke(
+        {
+          messages: [
+            new HumanMessage(
+              "Delegate to the worker subagent to state fact 5 back to you.",
+            ),
+          ],
+        },
+        {
+          configurable: { thread_id: `test-fork-cache-${Date.now()}` },
+          recursionLimit: 50,
+          callbacks: [handler],
+        },
+      );
+
+      const toolCalls = extractAllToolCalls(response);
+      const taskCall = toolCalls.find((tc) => tc.name === "task");
+      expect(taskCall).toBeDefined();
+      expect(taskCall!.args.subagent_type).toBe("worker");
+
+      // The fork's first call should read from the parent's cache, not write cold.
+      expect(workerCacheReadTokenCounts.length).toBeGreaterThan(0);
+      expect(workerCacheReadTokenCounts[0]).toBeGreaterThan(0);
     },
   );
 });

--- a/libs/deepagents/src/middleware/subagents.int.test.ts
+++ b/libs/deepagents/src/middleware/subagents.int.test.ts
@@ -922,9 +922,8 @@ describe("Subagent Fork Cache Integration Tests", () => {
     "reuses the parent's Anthropic prompt-cache prefix on a forked subagent's first model call",
     { timeout: 90 * 1000 },
     async () => {
-      // Keyed by runId so a call's cache_read (only available on
-      // handleLLMEnd) can be attributed back to the lc_agent_name metadata
-      // that's only available on handleChatModelStart for that same run.
+      // Bridges lc_agent_name (only on handleChatModelStart) to cache_read
+      // (only on handleLLMEnd) by runId.
       const runAgentNames = new Map<string, string | undefined>();
       const workerCacheReadTokenCounts: number[] = [];
 
@@ -947,11 +946,9 @@ describe("Subagent Fork Cache Integration Tests", () => {
         }
 
         async handleLLMEnd(output: LLMResult, runId: string) {
-          // Only the worker's own calls matter here -- the parent's calls
-          // (including its own follow-up after the tool result) reuse the
-          // cache from the parent's own first call regardless of whether the
-          // fork correctly mirrored anything, so aggregating across every
-          // call in the run would let a genuinely cold fork call pass.
+          // Only the worker's calls count -- the parent's own follow-up call
+          // reuses its own cache regardless of whether the fork mirrored
+          // anything, which would let a cold fork call pass unnoticed.
           if (runAgentNames.get(runId) !== "worker") return;
           for (const generationBatch of output.generations) {
             for (const generation of generationBatch) {

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -41,10 +41,7 @@ export const SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY =
 export const DEFAULT_SUBAGENT_PROMPT =
   "In order to complete the objective that the user asks of you, you have access to a number of standard tools.";
 
-// Carries the parent's post-middleware system message into a fork so it can replay it verbatim.
-const PARENT_SYSTEM_MESSAGE_KEY = "_deepagentsParentSystemMessage";
-
-// Set on a forked subagent's own initial state; lets the task tool refuse recursive delegation.
+// Marks a fork's own state so the task tool can refuse recursive delegation.
 const FORKED_CONTEXT_KEY = "_deepagentsForkedContext";
 
 const FORK_RECURSION_REFUSAL =
@@ -63,8 +60,19 @@ const EXCLUDED_STATE_KEYS = [
   "memoryContents",
   "_summarizationEvent",
   "_summarizationSessionId",
-  PARENT_SYSTEM_MESSAGE_KEY,
   FORKED_CONTEXT_KEY,
+] as const;
+
+/**
+ * State keys excluded when inheriting state into a declarative fork.
+ * Narrower than `EXCLUDED_STATE_KEYS`: a fork's mirrored middleware needs
+ * the parent's private channels (skills metadata, memory contents, etc.)
+ * to rebuild an equivalent prompt.
+ */
+const FORK_EXCLUDED_STATE_KEYS = [
+  "structuredResponse",
+  "_summarizationEvent",
+  "_summarizationSessionId",
 ] as const;
 
 /**
@@ -91,12 +99,10 @@ function getTaskToolDescription(subagentDescriptions: string[]): string {
   `;
 }
 
-// Appended to a declarative forked subagent's line so the model knows it can skip restating context.
 const FORKED_SUBAGENT_TOOL_NOTE =
   " (inherits your full conversation and system prompt — no need to restate context here)";
 
-// A compiled fork's runnable bakes in its own system prompt (see CompiledSubAgent.mode),
-// so it only inherits conversation history — never claim system-prompt inheritance for it.
+// A compiled fork's runnable owns its own system prompt (see CompiledSubAgent.mode).
 const COMPILED_FORKED_SUBAGENT_TOOL_NOTE =
   " (inherits your conversation history — its system prompt is fixed in its own runnable)";
 
@@ -115,7 +121,6 @@ function describeSubagentForTool(
   return `- ${name}: ${description}${suffix}`;
 }
 
-// Marks the replayed delegation as already-happened, so the fork doesn't mistake it as a fresh request.
 const FORK_TASK_PREAMBLE =
   "[The messages above are a prior conversation you are continuing as the " +
   "subagent that was just invoked. Any mention in them of delegating to a " +
@@ -299,13 +304,11 @@ export interface SubAgent extends SubAgentBase {
  * Specification for a subagent that inherits the parent's conversation
  * instead of starting from just the task description.
  *
- * Always forks: it inherits the parent's full message history and its exact
- * system prompt (there's no own prompt to fall back to). Mirrored middleware
- * is only added when its model matches the parent's, since that's the only
- * case with a cache benefit to protect. Deliberately has no `systemPrompt`
- * of its own: since its system slot always carries the parent's prompt,
- * there's nothing of its own to put there. If you need a subagent with a
- * distinguishing system prompt, use {@link SubAgent} without forking instead.
+ * Always forks: inherits the parent's full message history, static system
+ * prompt, and a mirrored copy of the parent's prompt-producing middleware
+ * (skills, memory, custom middleware) — reconstructing the parent's prompt
+ * so an Anthropic prompt cache can hit. Has no `systemPrompt` of its own;
+ * use {@link SubAgent} without forking if you need a distinct one.
  *
  * @example
  * ```typescript
@@ -400,6 +403,22 @@ export function filterStateForSubagent(
 }
 
 /**
+ * Filter state to exclude only summarization keys when inheriting into a
+ * declarative fork — see `FORK_EXCLUDED_STATE_KEYS`.
+ */
+export function filterStateForFork(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(state)) {
+    if (!FORK_EXCLUDED_STATE_KEYS.includes(key as never)) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+}
+
+/**
  * Invalid tool message block types
  */
 const INVALID_TOOL_MESSAGE_BLOCK_TYPES = [
@@ -464,44 +483,12 @@ function stripInFlightAIMessage(messages: BaseMessage[]): BaseMessage[] {
   return hasPendingToolCalls ? messages.slice(0, -1) : messages;
 }
 
-const ParentSystemMessageStateSchema = z.object({
-  [PARENT_SYSTEM_MESSAGE_KEY]: z.instanceof(SystemMessage).optional(),
-});
-
-// Captures the parent's fully-resolved system message into state so a fork can replay it verbatim.
-export function createParentSystemMessageMiddleware(): AgentMiddleware {
-  return createMiddleware({
-    name: "parentSystemMessageMiddleware",
-    stateSchema: ParentSystemMessageStateSchema,
-    wrapModelCall: async (request, handler) => {
-      await handler(request);
-      return new Command({
-        update: { [PARENT_SYSTEM_MESSAGE_KEY]: request.systemMessage },
-      });
-    },
-  });
-}
-
-// Replays the parent's captured system message verbatim, required for Anthropic's cache to hit.
-function createForkSystemMessageMiddleware(): AgentMiddleware {
-  return createMiddleware({
-    name: "forkSystemMessageMiddleware",
-    stateSchema: ParentSystemMessageStateSchema,
-    wrapModelCall: async (request, handler) => {
-      const parentMessage = request.state[PARENT_SYSTEM_MESSAGE_KEY];
-      if (parentMessage != null) {
-        return handler({ ...request, systemMessage: parentMessage });
-      }
-      return handler(request);
-    },
-  });
-}
-
 const ForkedContextStateSchema = z.object({
   [FORKED_CONTEXT_KEY]: z.boolean().optional(),
 });
 
-// Gives a fork a real (but recursion-refusing) `task` tool; must be a separate object from the parent's, and the flag must be set via `beforeAgent` — `getCurrentTaskInput()` won't see it if only seeded on the initial invoke() input.
+// Flag must be set via beforeAgent, not the initial invoke() input —
+// getCurrentTaskInput() won't see it otherwise.
 function createForkTaskToolMiddleware(
   taskTool: StructuredTool,
 ): AgentMiddleware {
@@ -605,6 +592,19 @@ function getSubagents(options: {
   const subagentDescriptions: string[] = [];
   const forkModeNames = new Set<string>();
 
+  // Prevent a duplicate name from silently resolving to the last spec.
+  const seenNames = new Set<string>(
+    generalPurposeAgent ? ["general-purpose"] : [],
+  );
+  for (const agentParams of subagents) {
+    if (seenNames.has(agentParams.name)) {
+      throw new Error(
+        `Duplicate subagent name '${agentParams.name}'; each subagent must have a unique name.`,
+      );
+    }
+    seenNames.add(agentParams.name);
+  }
+
   if (generalPurposeAgent) {
     const generalPurposeMiddleware = [...generalPurposeMiddlewareBase];
     if (defaultInterruptOn) {
@@ -658,26 +658,44 @@ function getSubagents(options: {
       specsByName[agentParams.name] = agentParams;
       if (forked) forkModeNames.add(agentParams.name);
     } else if (forked) {
-      // Cast around the `skills?: undefined` type guard to check it at runtime too.
+      // Re-check at runtime — the type guards don't stop a plain-JS/`as any` caller.
       const rawSkills = (agentParams as { skills?: unknown }).skills;
       if (Array.isArray(rawSkills) && rawSkills.length > 0) {
         throw new Error(
           `ForkedSubAgent '${agentParams.name}' cannot set skills; the parent's system message would discard it.`,
         );
       }
-      // The static systemPrompt is just a construction-time baseline; forkSystemMessageMiddleware overrides it every call.
+      const rawSystemPrompt = (agentParams as { systemPrompt?: unknown })
+        .systemPrompt;
+      if (rawSystemPrompt != null) {
+        throw new Error(
+          `ForkedSubAgent '${agentParams.name}' cannot set systemPrompt; it always inherits the parent's.`,
+        );
+      }
+      // No replay needed: mirrored middleware (see buildSubagentMiddleware)
+      // reconstructs the parent's dynamic prompt additions on top of this
+      // static baseline.
+      const forkMiddleware = [
+        ...defaultSubagentMiddleware,
+        ...(agentParams.middleware ?? []),
+      ];
+      // Splice after Filesystem (always present) to match the parent's tool
+      // order for prompt-cache parity.
+      const fsIndex = forkMiddleware.findIndex(
+        (m) => m.name === "FilesystemMiddleware",
+      );
+      forkMiddleware.splice(
+        fsIndex + 1,
+        0,
+        createForkTaskToolMiddleware(mirroredTaskTool),
+      );
       const resolvedSpec: SubAgent = {
         ...agentParams,
         systemPrompt: parentSystemPrompt ?? "",
         mode: undefined,
         model: agentParams.model ?? defaultModel,
         tools: agentParams.tools ?? defaultTools,
-        middleware: [
-          ...defaultSubagentMiddleware,
-          ...(agentParams.middleware ?? []),
-          createForkSystemMessageMiddleware(),
-          createForkTaskToolMiddleware(mirroredTaskTool),
-        ],
+        middleware: forkMiddleware,
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
       agents[agentParams.name] = createSubAgent(resolvedSpec);
@@ -735,7 +753,6 @@ function createTaskTool(options: {
     parentSystemPrompt = null,
   } = options;
 
-  // Computed from raw specs so the mirrored task tool below shares this exact description string.
   const subagentNames = [
     ...(generalPurposeAgent ? ["general-purpose"] : []),
     ...subagents.map((spec) => spec.name),
@@ -814,7 +831,13 @@ function createTaskTool(options: {
 
     const subagent = selectSubagent(subagent_type, config);
 
-    const subagentState = filterStateForSubagent(currentState);
+    // Compiled runnables are opaque, so only declarative forks get the wider filter.
+    const spec = specsByName[subagent_type];
+    const isDeclarativeFork = shouldFork && !("runnable" in spec);
+
+    const subagentState = isDeclarativeFork
+      ? filterStateForFork(currentState)
+      : filterStateForSubagent(currentState);
 
     if (shouldFork) {
       const trimmed = stripInFlightAIMessage(
@@ -825,11 +848,6 @@ function createTaskTool(options: {
         ...effective,
         new HumanMessage({ content: FORK_TASK_PREAMBLE + description }),
       ];
-      const spec = specsByName[subagent_type];
-      const parentSystemMessage = currentState[PARENT_SYSTEM_MESSAGE_KEY];
-      if (parentSystemMessage != null && !("runnable" in spec)) {
-        subagentState[PARENT_SYSTEM_MESSAGE_KEY] = parentSystemMessage;
-      }
     } else {
       subagentState.messages = [new HumanMessage({ content: description })];
     }
@@ -895,7 +913,7 @@ function createTaskTool(options: {
     schema: taskToolSchema,
   });
 
-  // A separate wrapper around the same name/description/schema/function, not the same object — see createForkTaskToolMiddleware.
+  // Separate object, not the same tool instance — see createForkTaskToolMiddleware.
   const mirroredTaskTool = tool(runTask, {
     name: "task",
     description: finalTaskDescription,

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -292,6 +292,18 @@ export interface SubAgent {
 }
 
 /**
+ * A {@link SubAgent} with `mode: "fork"`.
+ *
+ * Kept as a named type for backward compatibility with code that imported
+ * `ForkedSubAgent` before it merged into `SubAgent` — not a distinct shape
+ * with its own constraints (a fork can now declare its own `systemPrompt`,
+ * same as any `SubAgent`). Prefer `SubAgent` with `mode: "fork"` in new code.
+ */
+export interface ForkedSubAgent extends SubAgent {
+  mode: "fork";
+}
+
+/**
  * Whether a declarative subagent spec has `mode: "fork"` set.
  *
  * A plain boolean, not a type predicate: `SubAgent` covers both `"fork"` and
@@ -347,15 +359,13 @@ export const GENERAL_PURPOSE_SUBAGENT = {
   mode: "handoff",
 } as const;
 
-/**
- * Filter state to exclude certain keys when passing to subagents
- */
-export function filterStateForSubagent(
+function filterState(
   state: Record<string, unknown>,
+  excludedKeys: readonly string[],
 ): Record<string, unknown> {
   const filtered: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(state)) {
-    if (!EXCLUDED_STATE_KEYS.includes(key as never)) {
+    if (!excludedKeys.includes(key)) {
       filtered[key] = value;
     }
   }
@@ -363,19 +373,23 @@ export function filterStateForSubagent(
 }
 
 /**
- * Filter state to exclude only summarization keys when inheriting into a
- * declarative fork — see `FORK_EXCLUDED_STATE_KEYS`.
+ * Filter state to exclude certain keys when passing to subagents
+ */
+export function filterStateForSubagent(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  return filterState(state, EXCLUDED_STATE_KEYS);
+}
+
+/**
+ * Filter state to exclude only the keys a declarative fork must not resume
+ * (structured response, summarization event/session) — see
+ * `FORK_EXCLUDED_STATE_KEYS`.
  */
 export function filterStateForFork(
   state: Record<string, unknown>,
 ): Record<string, unknown> {
-  const filtered: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(state)) {
-    if (!FORK_EXCLUDED_STATE_KEYS.includes(key as never)) {
-      filtered[key] = value;
-    }
-  }
-  return filtered;
+  return filterState(state, FORK_EXCLUDED_STATE_KEYS);
 }
 
 /**
@@ -509,6 +523,26 @@ export function createSubAgent(
 }
 
 /**
+ * Resolve a fork's system prompt: the parent's inherited prompt, with the
+ * fork's own systemPrompt (if any) appended as an addendum rather than
+ * replacing it.
+ */
+function resolveForkSystemPrompt(
+  parentSystemPrompt: string | SystemMessage | null,
+  forkAddendum: string | SystemMessage | undefined,
+): string | SystemMessage {
+  if (!forkAddendum) return parentSystemPrompt ?? "";
+  const addendumText =
+    typeof forkAddendum === "string" ? forkAddendum : forkAddendum.text;
+  if (SystemMessage.isInstance(parentSystemPrompt)) {
+    return appendToSystemMessage(parentSystemPrompt, addendumText);
+  }
+  return parentSystemPrompt
+    ? `${parentSystemPrompt}\n\n${addendumText}`
+    : addendumText;
+}
+
+/**
  * Create subagent instances from specifications.
  *
  * Returns compiled agents, raw specs keyed by name (for on-demand
@@ -617,7 +651,15 @@ function getSubagents(options: {
       agents[agentParams.name] = agentParams.runnable;
       specsByName[agentParams.name] = agentParams;
       if (forked) forkModeNames.add(agentParams.name);
-    } else if (forked) {
+      continue;
+    }
+
+    const subagentMiddleware = [
+      ...defaultSubagentMiddleware,
+      ...(agentParams.middleware ?? []),
+    ];
+
+    if (forked) {
       // Re-check at runtime — the type guard doesn't stop a plain-JS/`as any` caller.
       const rawSkills = (agentParams as { skills?: unknown }).skills;
       if (Array.isArray(rawSkills) && rawSkills.length > 0) {
@@ -628,32 +670,16 @@ function getSubagents(options: {
       // The fork's own systemPrompt (if any) is an addendum appended to the
       // parent's inherited prompt, not a replacement — mirrors createDeepAgent's
       // main-loop merge logic for a declarative fork's own spec.
-      const forkAddendum = agentParams.systemPrompt;
-      const resolvedSystemPrompt = !forkAddendum
-        ? (parentSystemPrompt ?? "")
-        : SystemMessage.isInstance(parentSystemPrompt)
-          ? appendToSystemMessage(
-              parentSystemPrompt,
-              typeof forkAddendum === "string"
-                ? forkAddendum
-                : forkAddendum.text,
-            )
-          : parentSystemPrompt
-            ? `${parentSystemPrompt}\n\n${typeof forkAddendum === "string" ? forkAddendum : forkAddendum.text}`
-            : forkAddendum;
-      // No replay needed: mirrored middleware (see buildSubagentMiddleware)
-      // reconstructs the parent's dynamic prompt additions on top of this
-      // static baseline.
-      const forkMiddleware = [
-        ...defaultSubagentMiddleware,
-        ...(agentParams.middleware ?? []),
-      ];
+      const resolvedSystemPrompt = resolveForkSystemPrompt(
+        parentSystemPrompt,
+        agentParams.systemPrompt,
+      );
       // Splice after Filesystem (always present) to match the parent's tool
       // order for prompt-cache parity.
-      const fsIndex = forkMiddleware.findIndex(
+      const fsIndex = subagentMiddleware.findIndex(
         (m) => m.name === "FilesystemMiddleware",
       );
-      forkMiddleware.splice(
+      subagentMiddleware.splice(
         fsIndex + 1,
         0,
         createForkTaskToolMiddleware(mirroredTaskTool),
@@ -664,7 +690,7 @@ function getSubagents(options: {
         mode: undefined,
         model: agentParams.model ?? defaultModel,
         tools: agentParams.tools ?? defaultTools,
-        middleware: forkMiddleware,
+        middleware: subagentMiddleware,
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
       agents[agentParams.name] = createSubAgent(resolvedSpec);
@@ -677,10 +703,7 @@ function getSubagents(options: {
         mode: "handoff",
         model: agentParams.model ?? defaultModel,
         tools: agentParams.tools ?? defaultTools,
-        middleware: [
-          ...defaultSubagentMiddleware,
-          ...(agentParams.middleware ?? []),
-        ],
+        middleware: subagentMiddleware,
         interruptOn: agentParams.interruptOn ?? defaultInterruptOn ?? undefined,
       };
       agents[agentParams.name] = createSubAgent(resolvedSpec);

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -22,6 +22,7 @@ import type { Runnable } from "@langchain/core/runnables";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { FilesystemPermission } from "../permissions/types.js";
 import { getEffectiveMessages } from "./summarization.js";
+import { appendToSystemMessage } from "./utils.js";
 
 export type { AgentMiddleware };
 
@@ -159,11 +160,30 @@ export interface CompiledSubAgent<
 }
 
 /**
- * Fields shared by both {@link SubAgent} and {@link ForkedSubAgent}.
+ * Specification for a declarative subagent.
  *
- * @internal
+ * When using `createDeepAgent`, subagents automatically receive a default middleware
+ * stack (filesystemMiddleware, summarizationMiddleware, etc.) before any custom
+ * `middleware` specified in this spec. Add `todoListMiddleware` explicitly to opt in.
+ *
+ * By default the subagent is isolated — it only ever sees the delegated task
+ * description, never the parent's conversation. Setting `mode: "fork"` makes
+ * it continue the parent's conversation instead.
+ *
+ * @example
+ * ```typescript
+ * const researcher: SubAgent = {
+ *   name: "researcher",
+ *   description: "Research assistant for complex topics",
+ *   systemPrompt: "You are a research assistant.",
+ *   tools: [webSearchTool],
+ *   skills: ["/skills/research/"],
+ * };
+ * ```
+ *
+ * @experimental `mode: "fork"` is experimental and subject to change.
  */
-interface SubAgentBase {
+export interface SubAgent {
   /** Identifier used to select this subagent in the task tool */
   name: string;
 
@@ -171,15 +191,19 @@ interface SubAgentBase {
   description: string;
 
   /**
-   * The system prompt for the agent. Optional on {@link SubAgent} (falls
-   * back to an empty prompt if omitted); forbidden on {@link ForkedSubAgent},
-   * which always inherits the parent's instead.
+   * The system prompt for the agent. Falls back to an empty prompt if
+   * omitted. Under `mode: "fork"`, this is appended to the parent's
+   * inherited prompt rather than replacing it.
    */
   systemPrompt?: string | SystemMessage;
 
   /**
    * Context mode. `"handoff"` (default) is fully isolated. `"fork"` inherits
-   * the parent's conversation history and system prompt.
+   * the parent's conversation history and mirrors the parent's
+   * prompt-producing middleware (skills, memory, custom middleware) so it
+   * rebuilds an equivalent system prompt — the tradeoff is cache misses if
+   * this subagent's own `model` differs from the parent's. Cannot declare
+   * `skills` under `mode: "fork"`; the parent's skills are inherited instead.
    */
   mode?: "handoff" | "fork";
 
@@ -268,79 +292,15 @@ interface SubAgentBase {
 }
 
 /**
- * Specification for a subagent that can be dynamically created.
+ * Whether a declarative subagent spec has `mode: "fork"` set.
  *
- * When using `createDeepAgent`, subagents automatically receive a default middleware
- * stack (filesystemMiddleware, summarizationMiddleware, etc.) before any custom
- * `middleware` specified in this spec. Add `todoListMiddleware` explicitly to opt in.
- *
- * Always fully isolated — this subagent only ever sees the task description,
- * never the parent's conversation. Use {@link ForkedSubAgent} to inherit the
- * parent's history and system prompt instead.
- *
- * @example
- * ```typescript
- * const researcher: SubAgent = {
- *   name: "researcher",
- *   description: "Research assistant for complex topics",
- *   systemPrompt: "You are a research assistant.",
- *   tools: [webSearchTool],
- *   skills: ["/skills/research/"],
- * };
- * ```
+ * A plain boolean, not a type predicate: `SubAgent` covers both `"fork"` and
+ * `"handoff"`, so there's no distinct type left to narrow to.
  */
-export interface SubAgent extends SubAgentBase {
-  /** The system prompt to use for the agent */
-  systemPrompt?: string | SystemMessage;
-
-  /**
-   * Context mode. `"handoff"` (default) is fully isolated. `"fork"` inherits
-   * the parent's conversation history and system prompt.
-   */
-  mode?: "handoff";
-}
-
-/**
- * Specification for a subagent that inherits the parent's conversation
- * instead of starting from just the task description.
- *
- * Always forks: inherits the parent's full message history, static system
- * prompt, and a mirrored copy of the parent's prompt-producing middleware
- * (skills, memory, custom middleware) — reconstructing the parent's prompt
- * so an Anthropic prompt cache can hit. Has no `systemPrompt` of its own;
- * use {@link SubAgent} without forking if you need a distinct one.
- *
- * @example
- * ```typescript
- * const researcher: ForkedSubAgent = {
- *   name: "researcher",
- *   description: "Continues the current investigation with full context",
- *   mode: "fork",
- *   tools: [webSearchTool],
- * };
- * ```
- *
- * @experimental Forking subagents is experimental and subject to change
- */
-export interface ForkedSubAgent extends SubAgentBase {
-  /** A ForkedSubAgent never has its own system prompt — always the parent's. */
-  systemPrompt?: undefined;
-
-  /** A ForkedSubAgent cannot declare its own skills — the inherited system message would discard them. */
-  skills?: undefined;
-
-  /**
-   * Always `"fork"`. Required (not defaulted) so this can't structurally
-   * collapse into a plain `SubAgent` — see `isForkedSubAgent` below.
-   */
-  mode: "fork";
-}
-
-export function isForkedSubAgent(value: unknown): value is ForkedSubAgent {
+export function isForkedSubAgent(value: unknown): boolean {
   if (typeof value !== "object" || value == null) return false;
   if (!("mode" in value)) return false;
-  if (value.mode !== "fork") return false;
-  return true;
+  return value.mode === "fork";
 }
 
 /**
@@ -561,7 +521,7 @@ function getSubagents(options: {
   defaultMiddleware: AgentMiddleware[] | null;
   generalPurposeMiddleware: AgentMiddleware[] | null;
   defaultInterruptOn: Record<string, boolean | InterruptOnConfig> | null;
-  subagents: (SubAgent | CompiledSubAgent | ForkedSubAgent)[];
+  subagents: (SubAgent | CompiledSubAgent)[];
   generalPurposeAgent: boolean;
   parentSystemPrompt?: string | SystemMessage | null;
   /** The exact tool instance forked subagents mirror — see `createTaskTool`. */
@@ -658,20 +618,29 @@ function getSubagents(options: {
       specsByName[agentParams.name] = agentParams;
       if (forked) forkModeNames.add(agentParams.name);
     } else if (forked) {
-      // Re-check at runtime — the type guards don't stop a plain-JS/`as any` caller.
+      // Re-check at runtime — the type guard doesn't stop a plain-JS/`as any` caller.
       const rawSkills = (agentParams as { skills?: unknown }).skills;
       if (Array.isArray(rawSkills) && rawSkills.length > 0) {
         throw new Error(
-          `ForkedSubAgent '${agentParams.name}' cannot set skills; the parent's system message would discard it.`,
+          `SubAgent '${agentParams.name}' cannot set skills under mode: "fork"; the parent's skills are inherited instead.`,
         );
       }
-      const rawSystemPrompt = (agentParams as { systemPrompt?: unknown })
-        .systemPrompt;
-      if (rawSystemPrompt != null) {
-        throw new Error(
-          `ForkedSubAgent '${agentParams.name}' cannot set systemPrompt; it always inherits the parent's.`,
-        );
-      }
+      // The fork's own systemPrompt (if any) is an addendum appended to the
+      // parent's inherited prompt, not a replacement — mirrors createDeepAgent's
+      // main-loop merge logic for a declarative fork's own spec.
+      const forkAddendum = agentParams.systemPrompt;
+      const resolvedSystemPrompt = !forkAddendum
+        ? (parentSystemPrompt ?? "")
+        : SystemMessage.isInstance(parentSystemPrompt)
+          ? appendToSystemMessage(
+              parentSystemPrompt,
+              typeof forkAddendum === "string"
+                ? forkAddendum
+                : forkAddendum.text,
+            )
+          : parentSystemPrompt
+            ? `${parentSystemPrompt}\n\n${typeof forkAddendum === "string" ? forkAddendum : forkAddendum.text}`
+            : forkAddendum;
       // No replay needed: mirrored middleware (see buildSubagentMiddleware)
       // reconstructs the parent's dynamic prompt additions on top of this
       // static baseline.
@@ -691,7 +660,7 @@ function getSubagents(options: {
       );
       const resolvedSpec: SubAgent = {
         ...agentParams,
-        systemPrompt: parentSystemPrompt ?? "",
+        systemPrompt: resolvedSystemPrompt,
         mode: undefined,
         model: agentParams.model ?? defaultModel,
         tools: agentParams.tools ?? defaultTools,
@@ -736,7 +705,7 @@ function createTaskTool(options: {
   defaultMiddleware: AgentMiddleware[] | null;
   generalPurposeMiddleware: AgentMiddleware[] | null;
   defaultInterruptOn: Record<string, boolean | InterruptOnConfig> | null;
-  subagents: (SubAgent | CompiledSubAgent | ForkedSubAgent)[];
+  subagents: (SubAgent | CompiledSubAgent)[];
   generalPurposeAgent: boolean;
   taskDescription: string | null;
   parentSystemPrompt?: string | SystemMessage | null;
@@ -961,14 +930,14 @@ export interface SubAgentMiddlewareOptions {
   /** The tool configs for the default general-purpose subagent */
   defaultInterruptOn?: Record<string, boolean | InterruptOnConfig> | null;
   /** A list of additional subagents to provide to the agent */
-  subagents?: (SubAgent | CompiledSubAgent | ForkedSubAgent)[];
+  subagents?: (SubAgent | CompiledSubAgent)[];
   /** Full system prompt override */
   systemPrompt?: string | null;
   /** Whether to include the general-purpose agent */
   generalPurposeAgent?: boolean;
   /** Custom description for the task tool */
   taskDescription?: string | null;
-  /** Inherited by `ForkedSubAgent`s and `mode: "fork"` compiled subagents */
+  /** Inherited by a `mode: "fork"` declarative or compiled subagent */
   parentSystemPrompt?: string | SystemMessage | null;
 }
 

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -295,7 +295,7 @@ export interface SubAgent {
 /**
  * A {@link SubAgent} with `mode: "fork"`.
  *
- * Kept as a named type for backward compatibility with code that imported
+ * @deprecated Kept as a named type for backward compatibility with code that imported
  * `ForkedSubAgent` before it merged into `SubAgent` — not a distinct shape
  * with its own constraints (a fork can now declare its own `systemPrompt`,
  * same as any `SubAgent`). Prefer `SubAgent` with `mode: "fork"` in new code.

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -154,9 +154,9 @@ export interface CompiledSubAgent<
   /**
    * Context mode. `"fork"` inherits the parent's conversation history
    * (but not its system prompt — that's baked into the runnable).
-   * `"handoff"` (default) is fully isolated.
+   * `"isolated"` (default) only sees the delegated task.
    */
-  mode?: "handoff" | "fork";
+  mode?: "isolated" | "fork";
 }
 
 /**
@@ -198,14 +198,15 @@ export interface SubAgent {
   systemPrompt?: string | SystemMessage;
 
   /**
-   * Context mode. `"handoff"` (default) is fully isolated. `"fork"` inherits
-   * the parent's conversation history and mirrors the parent's
-   * prompt-producing middleware (skills, memory, custom middleware) so it
-   * rebuilds an equivalent system prompt — the tradeoff is cache misses if
-   * this subagent's own `model` differs from the parent's. Cannot declare
-   * `skills` under `mode: "fork"`; the parent's skills are inherited instead.
+   * Context mode. `"isolated"` (default) only sees the delegated task.
+   * `"fork"` inherits the parent's conversation history and mirrors the
+   * parent's prompt-producing middleware (skills, memory, custom middleware)
+   * so it rebuilds an equivalent system prompt — the tradeoff is cache
+   * misses if this subagent's own `model` differs from the parent's. Cannot
+   * declare `skills` under `mode: "fork"`; the parent's skills are inherited
+   * instead.
    */
-  mode?: "handoff" | "fork";
+  mode?: "isolated" | "fork";
 
   /** The tools to use for the agent (tool instances, not names). Defaults to defaultTools */
   tools?: StructuredTool[];
@@ -307,7 +308,7 @@ export interface ForkedSubAgent extends SubAgent {
  * Whether a declarative subagent spec has `mode: "fork"` set.
  *
  * A plain boolean, not a type predicate: `SubAgent` covers both `"fork"` and
- * `"handoff"`, so there's no distinct type left to narrow to.
+ * `"isolated"`, so there's no distinct type left to narrow to.
  */
 export function isForkedSubAgent(value: unknown): boolean {
   if (typeof value !== "object" || value == null) return false;
@@ -356,7 +357,7 @@ export const GENERAL_PURPOSE_SUBAGENT = {
   name: "general-purpose",
   description: DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
   systemPrompt: DEFAULT_SUBAGENT_PROMPT,
-  mode: "handoff",
+  mode: "isolated",
 } as const;
 
 function filterState(
@@ -628,10 +629,17 @@ function getSubagents(options: {
   }
 
   for (const agentParams of subagents) {
-    const rawMode = agentParams.mode;
-    if (rawMode != null && rawMode !== "handoff" && rawMode !== "fork") {
+    // Widened to string: a plain-JS/`as any` caller can still pass the
+    // legacy "handoff" value, which no longer appears in the type itself.
+    const rawMode = agentParams.mode as string | undefined;
+    if (
+      rawMode != null &&
+      rawMode !== "isolated" &&
+      rawMode !== "fork" &&
+      rawMode !== "handoff" // legacy alias for "isolated"
+    ) {
       throw new Error(
-        `SubAgent '${agentParams.name}' has invalid mode '${rawMode}' — must be "handoff" or "fork".`,
+        `SubAgent '${agentParams.name}' has invalid mode '${rawMode}' — must be "isolated" or "fork".`,
       );
     }
 
@@ -700,7 +708,7 @@ function getSubagents(options: {
       // Plain SubAgent — never forks, keeps its own prompt untouched.
       const resolvedSpec: SubAgent = {
         ...agentParams,
-        mode: "handoff",
+        mode: "isolated",
         model: agentParams.model ?? defaultModel,
         tools: agentParams.tools ?? defaultTools,
         middleware: subagentMiddleware,

--- a/libs/deepagents/src/stream.test.ts
+++ b/libs/deepagents/src/stream.test.ts
@@ -517,6 +517,73 @@ describe("streamEvents", () => {
     expect(subagentNames).toEqual(["researcher"]);
   });
 
+  it("run.subagents streams a forked subagent's messages separately from the parent's projection", async () => {
+    const rootModel = fakeModel()
+      .respondWithTools([
+        {
+          name: "task",
+          id: "task-worker",
+          args: {
+            description: "Continue with ticket T-123",
+            subagent_type: "worker",
+          },
+        },
+      ])
+      .respond(new AIMessage("parent done"));
+
+    const workerModel = fakeModel().respond(
+      new AIMessage("FORK_PRIVATE_RESULT"),
+    );
+
+    const agent = createDeepAgent({
+      model: rootModel,
+      checkpointer: new MemorySaver(),
+      subagents: [
+        {
+          name: "worker",
+          description: "Continues the current conversation",
+          model: workerModel,
+          mode: "fork",
+        },
+      ],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("ticket is T-123")] },
+      {
+        version: "v3",
+        configurable: { thread_id: `test-fork-subagent-${Date.now()}` },
+        recursionLimit: 100,
+      },
+    );
+
+    // Iterating run.subagents below drives the stream, so collect concurrently.
+    const rootMessagesPromise = collectWithTimeout(run.messages);
+
+    const subagentNames: string[] = [];
+    const forkTexts: string[] = [];
+    for await (const sub of run.subagents) {
+      subagentNames.push(sub.name);
+      expect(sub.cause).toEqual({
+        type: "toolCall",
+        tool_call_id: "task-worker",
+      });
+
+      const msgs = await collectWithTimeout(sub.messages);
+      const texts = await Promise.all(msgs.map((m) => m.text));
+      forkTexts.push(...texts);
+    }
+
+    const rootMessages = await rootMessagesPromise;
+    const rootTexts = await Promise.all(rootMessages.map((m) => m.text));
+
+    expect(subagentNames).toEqual(["worker"]);
+    expect(forkTexts).toContain("FORK_PRIVATE_RESULT");
+    expect(rootTexts.some((t) => t.includes("FORK_PRIVATE_RESULT"))).toBe(
+      false,
+    );
+  });
+
   it("can iterate raw protocol events", async () => {
     const model = fakeModel().respond(new AIMessage("Hello world."));
     const agent = createDeepAgent({

--- a/libs/deepagents/src/types.ts
+++ b/libs/deepagents/src/types.ts
@@ -32,10 +32,7 @@ import type {
   StateDefinitionInit,
   StreamTransformer,
 } from "@langchain/langgraph";
-import type {
-  CompiledSubAgent,
-  ForkedSubAgent,
-} from "./middleware/subagents.js";
+import type { CompiledSubAgent } from "./middleware/subagents.js";
 import type {
   ASYNC_TASK_TOOL_NAMES,
   FILESYSTEM_TOOL_NAMES,
@@ -85,12 +82,8 @@ type InferDeepAgentStreamExtensions<
     ? P & InferDeepAgentStreamExtensions<Rest>
     : Record<string, unknown>;
 
-/** Any subagent specification — sync, compiled, forked, or async. */
-export type AnySubAgent =
-  | SubAgent
-  | CompiledSubAgent
-  | ForkedSubAgent
-  | AsyncSubAgent;
+/** Any subagent specification — sync, compiled, or async. */
+export type AnySubAgent = SubAgent | CompiledSubAgent | AsyncSubAgent;
 
 // TODO: import TypedToolStrategy from "langchain" once exported from the top-level entry point
 // (currently only available via "langchain/dist/agents/responses.js")
@@ -480,10 +473,10 @@ export type InferSubagentByName<T, TName extends string> =
  * ```
  */
 export type InferSubagentReactAgentType<
-  TSubagent extends SubAgent | CompiledSubAgent | ForkedSubAgent,
+  TSubagent extends SubAgent | CompiledSubAgent,
 > = TSubagent extends CompiledSubAgent
   ? TSubagent["runnable"]
-  : TSubagent extends SubAgent | ForkedSubAgent
+  : TSubagent extends SubAgent
     ? ReactAgent<
         AgentTypeConfig<
           ResponseFormatUndefined,


### PR DESCRIPTION
Backports two `langchain-ai/deepagents` changes onto JS's existing subagent-fork support:

**#5981 — middleware-mirroring rework.** Instead of capturing the parent's composed system message at runtime and replaying it, a fork now mirrors the parent's own prompt-producing middleware (skills, memory, custom middleware) so it reconstructs an equivalent prompt itself — same cache parity, one less middleware pair.

**#6016 — drop `ForkedSubAgent`, allow `systemPrompt` on a fork.** `mode: "fork"` is now just a value on `SubAgent` instead of a separate type. A fork's own `systemPrompt` is no longer rejected — it's appended to the parent's inherited prompt instead of replacing it.