### PR TITLE
fix(daytona): publish the patched SDK range

### DIFF
--- a/.changeset/secure-daytona-runtime.md
+++ b/.changeset/secure-daytona-runtime.md
@@ -1,0 +1,5 @@
+---
+"@langchain/daytona": patch
+---
+
+Publish the already-updated Daytona runtime range so consumers resolve the patched OpenTelemetry Jaeger propagator.


### PR DESCRIPTION
## Summary

- queue a patch release of `@langchain/daytona` with the already-merged `@daytona/sdk@^0.202.0` runtime range
- remove the published dependency path through `sdk-node@0.219.0` and vulnerable `propagator-jaeger@2.8.0`

## Why

#721 updated the provider manifest to `@daytona/sdk@^0.202.0`, but did not include a changeset. As a result, npm still serves `@langchain/daytona@0.2.2` with `@daytona/sdk@^0.200.1`.

## Testing

- `pnpm install --frozen-lockfile`
- Daytona provider build
- root format and lint checks
- packed package installed in a clean consumer
- dependency tree resolved `@daytona/sdk@0.202.0` → `@opentelemetry/sdk-node@0.220.0` → `@opentelemetry/propagator-jaeger@2.9.0`
- `npm audit --omit=dev` reported 0 vulnerabilities

Closes #801
