### PR TITLE
fix(deepagents): omit middleware trace inputs

### DIFF
--- a/.changeset/omit-middleware-trace-inputs.md
+++ b/.changeset/omit-middleware-trace-inputs.md
@@ -1,0 +1,10 @@
+---
+"deepagents": patch
+"@langchain/quickjs": patch
+---
+
+fix(middleware): omit repeated conversation and state inputs from owned middleware lifecycle traces
+
+Keep middleware spans and outputs, and preserve model/tool tracing and user-supplied middleware policies. Apply the defaults to standalone middleware, subagents, and QuickJS cleanup. Lifecycle chain events also receive the omitted inputs.
+
+Require LangChain 1.5.11-rc.0 and LangGraph 1.4.15-rc.0 or newer for middleware trace-policy support. QuickJS now declares its LangChain peer requirement explicitly.

--- a/.changeset/omit-middleware-trace-inputs.md
+++ b/.changeset/omit-middleware-trace-inputs.md
@@ -6,5 +6,3 @@
 fix(middleware): omit repeated conversation and state inputs from owned middleware lifecycle traces
 
 Keep middleware spans and outputs, and preserve model/tool tracing and user-supplied middleware policies. Apply the defaults to standalone middleware, subagents, and QuickJS cleanup. Lifecycle chain events also receive the omitted inputs.
-
-Require LangChain 1.5.11-rc.0 and LangGraph 1.4.15-rc.0 or newer for middleware trace-policy support. QuickJS now declares its LangChain peer requirement explicitly.

--- a/libs/deepagents/package.json
+++ b/libs/deepagents/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@langchain/anthropic": "^1.5.0",
     "@langchain/core": "^1.2.9",
-    "@langchain/langgraph": "^1.4.10",
+    "@langchain/langgraph": "^1.4.15-rc.0",
     "@langchain/langgraph-checkpoint": "^1.1.5",
     "@langchain/langgraph-sdk": "^1.9.23",
     "@langchain/openai": "^1.5.1",
@@ -58,7 +58,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
     "dotenv": "^17.2.4",
-    "langchain": "^1.5.10",
+    "langchain": "^1.5.11-rc.0",
     "tsdown": "^0.22.1",
     "tsx": "^4.21.0",
     "typescript": "^7.0.2",
@@ -100,10 +100,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.2.9",
-    "@langchain/langgraph": "^1.4.10",
+    "@langchain/langgraph": "^1.4.15-rc.0",
     "@langchain/langgraph-checkpoint": "^1.1.5",
     "@langchain/langgraph-sdk": "^1.9.23",
-    "langchain": "^1.5.10",
+    "langchain": "^1.5.11-rc.0",
     "langsmith": ">=0.7.1 <0.10.0"
   },
   "files": [

--- a/libs/deepagents/src/middleware/agent-memory.ts
+++ b/libs/deepagents/src/middleware/agent-memory.ts
@@ -35,6 +35,7 @@ import fs from "node:fs";
 import { z } from "zod";
 import {
   createMiddleware,
+  omitPayload,
   /**
    * required for type inference
    */
@@ -236,6 +237,7 @@ export function createAgentMemoryMiddleware(
 
   return createMiddleware({
     name: "AgentMemoryMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: AgentMemoryStateSchema as any,
 
     beforeAgent(state: any) {

--- a/libs/deepagents/src/middleware/async_subagents.ts
+++ b/libs/deepagents/src/middleware/async_subagents.ts
@@ -2,6 +2,7 @@ import { Command, ReducedValue, StateSchema } from "@langchain/langgraph";
 import { Client, type DefaultValues, type Run } from "@langchain/langgraph-sdk";
 import {
   createMiddleware,
+  omitPayload,
   tool,
   ToolMessage,
   SystemMessage,
@@ -875,6 +876,7 @@ export function createAsyncSubAgentMiddleware(
 
   return createMiddleware({
     name: "asyncSubAgentMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: AsyncTaskStateSchema,
     tools,
     wrapModelCall: async (request, handler) => {

--- a/libs/deepagents/src/middleware/cache.ts
+++ b/libs/deepagents/src/middleware/cache.ts
@@ -1,4 +1,4 @@
-import { createMiddleware, SystemMessage } from "langchain";
+import { createMiddleware, omitPayload, SystemMessage } from "langchain";
 
 /**
  * Import langchain for type inference
@@ -36,6 +36,7 @@ import { isAnthropicModel } from "../utils.js";
 export function createCacheBreakpointMiddleware() {
   return createMiddleware({
     name: "CacheBreakpointMiddleware",
+    tracePolicy: { processInputs: omitPayload },
 
     wrapModelCall(request, handler) {
       // Per-call provider gate: the boot-time install gate in createDeepAgent

--- a/libs/deepagents/src/middleware/completion_callback.ts
+++ b/libs/deepagents/src/middleware/completion_callback.ts
@@ -78,6 +78,7 @@
 import * as z from "zod";
 import {
   createMiddleware,
+  omitPayload,
   /**
    * required for type inference
    */
@@ -303,6 +304,7 @@ export function createCompletionCallbackMiddleware(
 
   return createMiddleware({
     name: "CompletionCallbackMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: CompletionCallbackStateSchema,
 
     /**

--- a/libs/deepagents/src/middleware/fs.ts
+++ b/libs/deepagents/src/middleware/fs.ts
@@ -9,6 +9,7 @@
 import {
   context,
   createMiddleware,
+  omitPayload,
   tool,
   HumanMessage,
   ToolMessage,
@@ -2019,6 +2020,7 @@ export function createFilesystemMiddleware(
 
   return createMiddleware({
     name: "FilesystemMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: FilesystemStateSchema,
     tools: allTools,
     async beforeAgent(state) {

--- a/libs/deepagents/src/middleware/memory.ts
+++ b/libs/deepagents/src/middleware/memory.ts
@@ -52,6 +52,7 @@ import { z } from "zod";
 import {
   context,
   createMiddleware,
+  omitPayload,
   SystemMessage,
   /**
    * required for type inference
@@ -287,6 +288,7 @@ export function createMemoryMiddleware(options: MemoryMiddlewareOptions) {
 
   return createMiddleware({
     name: "MemoryMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: MemoryStateSchema,
 
     async beforeAgent(state) {

--- a/libs/deepagents/src/middleware/patch_tool_calls.ts
+++ b/libs/deepagents/src/middleware/patch_tool_calls.ts
@@ -1,5 +1,6 @@
 import {
   createMiddleware,
+  omitPayload,
   ToolMessage,
   AIMessage,
   /**
@@ -134,6 +135,7 @@ export function patchDanglingToolCalls(messages: BaseMessage[]): {
 export function createPatchToolCallsMiddleware() {
   return createMiddleware({
     name: "patchToolCallsMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     beforeAgent: async (state) => {
       const messages = state.messages;
 

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -45,6 +45,7 @@ import yaml from "yaml";
 import {
   context,
   createMiddleware,
+  omitPayload,
   /**
    * required for type inference
    */
@@ -820,6 +821,7 @@ export function createSkillsMiddleware(options: SkillsMiddlewareOptions) {
 
   return createMiddleware({
     name: "SkillsMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: SkillsStateSchema,
 
     async beforeAgent(state) {

--- a/libs/deepagents/src/middleware/subagents.ts
+++ b/libs/deepagents/src/middleware/subagents.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 
 import {
   createMiddleware,
+  omitPayload,
   createAgent,
   AgentMiddleware,
   tool,
@@ -469,6 +470,7 @@ function createForkTaskToolMiddleware(
 ): AgentMiddleware {
   return createMiddleware({
     name: "forkTaskToolMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: ForkedContextStateSchema,
     tools: [taskTool],
     beforeAgent: () => ({ [FORKED_CONTEXT_KEY]: true }),
@@ -1003,6 +1005,7 @@ export function createSubAgentMiddleware(options: SubAgentMiddlewareOptions) {
 
   return createMiddleware({
     name: "subAgentMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     tools: [taskTool],
     wrapModelCall: async (request, handler) => {
       if (systemPrompt !== null) {

--- a/libs/deepagents/src/middleware/summarization.ts
+++ b/libs/deepagents/src/middleware/summarization.ts
@@ -43,6 +43,7 @@
 import { z } from "zod";
 import {
   createMiddleware,
+  omitPayload,
   countTokensApproximately,
   HumanMessage,
   AIMessage,
@@ -1182,6 +1183,7 @@ export function createSummarizationMiddleware(
 
   return createMiddleware({
     name: "SummarizationMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     stateSchema: SummarizationStateSchema,
 
     async wrapModelCall(request, handler) {

--- a/libs/deepagents/src/middleware/tool_exclusion.ts
+++ b/libs/deepagents/src/middleware/tool_exclusion.ts
@@ -1,5 +1,5 @@
 import { ToolMessage } from "@langchain/core/messages";
-import { createMiddleware, type AgentMiddleware } from "langchain";
+import { createMiddleware, omitPayload, type AgentMiddleware } from "langchain";
 
 function hasToolName(tool: unknown): tool is { name: string } {
   return (
@@ -22,6 +22,7 @@ export function createToolExclusionMiddleware(
 ): AgentMiddleware {
   return createMiddleware({
     name: "_ToolExclusionMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     wrapModelCall(request, handler) {
       return handler({
         ...request,

--- a/libs/deepagents/src/middleware/trace_policy.test.ts
+++ b/libs/deepagents/src/middleware/trace_policy.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import { fakeModel } from "@langchain/core/testing";
+import { FakeStreamingChatModel } from "@langchain/core/utils/testing";
+import { BaseTracer, type Run } from "@langchain/core/tracers/base";
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
+import { createAgent, createMiddleware, tool } from "langchain";
+import { z } from "zod/v4";
+
+import { createDeepAgent } from "../agent.js";
+import { createFileData } from "../backends/utils.js";
+import { createFilesystemMiddleware } from "./fs.js";
+import { createPatchToolCallsMiddleware } from "./patch_tool_calls.js";
+
+class RecordingTracer extends BaseTracer {
+  name = "recording_tracer";
+  roots: Run[] = [];
+
+  protected async persistRun(run: Run): Promise<void> {
+    this.roots.push(run);
+  }
+
+  get runs(): Run[] {
+    const flatten = (run: Run): Run[] => [
+      run,
+      ...run.child_runs.flatMap(flatten),
+    ];
+    return this.roots.flatMap(flatten);
+  }
+}
+
+const LARGE_MESSAGE = "Conversation context. ".repeat(2048);
+const LIFECYCLE_NAMES = [
+  "FilesystemMiddleware.before_agent",
+  "patchToolCallsMiddleware.before_agent",
+  "MemoryMiddleware.before_agent",
+  "SkillsMiddleware.before_agent",
+];
+
+describe("middleware trace inputs", () => {
+  it("omits built-in state payloads while retaining user middleware and model/tool traces", async () => {
+    const tracer = new RecordingTracer();
+    const userMiddleware = createMiddleware({
+      name: "UserMiddleware",
+      beforeModel: () => undefined,
+    });
+    const echo = tool(({ text }) => text, {
+      name: "echo",
+      description: "Echo text",
+      schema: z.object({ text: z.string() }),
+    });
+    const model = fakeModel()
+      .respondWithTools([
+        { id: "echo-call", name: "echo", args: { text: "tool result" } },
+      ])
+      .respond(new AIMessage("Done"));
+    const agent = createDeepAgent({
+      model,
+      tools: [echo],
+      memory: ["/AGENTS.md"],
+      skills: ["/skills/"],
+      middleware: [userMiddleware],
+    });
+    const result = await agent.invoke(
+      {
+        messages: [new HumanMessage(LARGE_MESSAGE)],
+        files: {
+          "/AGENTS.md": createFileData("Remember the project conventions."),
+          "/large.txt": createFileData(LARGE_MESSAGE),
+          "/skills/example/SKILL.md": createFileData(
+            "---\nname: example\ndescription: Example skill\n---\nFollow these instructions.",
+          ),
+        },
+      },
+      { callbacks: [tracer] },
+    );
+
+    expect(result.messages[0].content).toBe(LARGE_MESSAGE);
+    expect(result.messages.at(-1)?.content).toBe("Done");
+    expect(result.messages.find(ToolMessage.isInstance)?.content).toBe(
+      "tool result",
+    );
+    for (const name of LIFECYCLE_NAMES) {
+      const runs = tracer.runs.filter((run) => run.name === name);
+      expect(runs.length, name).toBeGreaterThan(0);
+      for (const run of runs) {
+        expect(Object.keys(run.inputs), name).toEqual([]);
+        expect(run.end_time).toBeDefined();
+        expect(run.parent_run_id).toBeDefined();
+      }
+    }
+    const userRun = tracer.runs.find(
+      (run) => run.name === "UserMiddleware.before_model",
+    );
+    expect(JSON.stringify(userRun?.inputs)).toContain(LARGE_MESSAGE);
+    const modelRuns = tracer.runs.filter((run) => run.run_type === "llm");
+    expect(modelRuns.length).toBeGreaterThan(0);
+    expect(JSON.stringify(modelRuns[0].inputs)).toContain(LARGE_MESSAGE);
+    expect(modelRuns[0].parent_run_id).toBeDefined();
+    const toolRun = tracer.runs.find(
+      (run) => run.name === "echo" && run.run_type === "tool",
+    );
+    expect(JSON.stringify(toolRun?.inputs)).toContain("tool result");
+    expect(JSON.stringify(toolRun?.outputs)).toContain("tool result");
+    expect(toolRun?.parent_run_id).toBeDefined();
+  });
+
+  it("preserves explicit policies on replacement middleware", async () => {
+    const replacement = {
+      ...createFilesystemMiddleware(),
+      tracePolicy: { processInputs: () => ({ recorded: "custom" }) },
+    };
+    const tracer = new RecordingTracer();
+    await createDeepAgent({
+      model: fakeModel().respond(new AIMessage("Done")),
+      middleware: [replacement],
+    }).invoke(
+      { messages: [new HumanMessage("Hello")] },
+      { callbacks: [tracer] },
+    );
+
+    expect(
+      tracer.runs.find(
+        (run) => run.name === "FilesystemMiddleware.before_agent",
+      )?.inputs,
+    ).toEqual({ recorded: "custom" });
+    expect(
+      tracer.runs.find(
+        (run) => run.name === "patchToolCallsMiddleware.before_agent",
+      )?.inputs,
+    ).toEqual({});
+  });
+
+  it("keeps repaired messages in lifecycle outputs and streaming events", async () => {
+    const agent = createAgent({
+      model: new FakeStreamingChatModel({ responses: [new AIMessage("Done")] }),
+      middleware: [createPatchToolCallsMiddleware()],
+    });
+    const events = [];
+    for await (const event of agent.streamEvents(
+      {
+        messages: [
+          new HumanMessage("Hello"),
+          new AIMessage({
+            content: "",
+            tool_calls: [{ id: "unanswered", name: "echo", args: {} }],
+          }),
+        ],
+      },
+      { version: "v2" },
+    )) {
+      events.push(event);
+    }
+
+    const start = events.find(
+      (event) =>
+        event.name === "patchToolCallsMiddleware.before_agent" &&
+        event.event === "on_chain_start",
+    );
+    const end = events.find(
+      (event) =>
+        event.name === "patchToolCallsMiddleware.before_agent" &&
+        event.event === "on_chain_end",
+    );
+    expect(start?.data.input).toEqual({});
+    expect(JSON.stringify(end?.data.output)).toContain("unanswered");
+    expect(events.some((event) => event.event === "on_chat_model_stream")).toBe(
+      true,
+    );
+  });
+
+  it.each(["fresh", "fork"] as const)(
+    "applies defaults inside %s subagents",
+    async (mode) => {
+      const tracer = new RecordingTracer();
+      const model = fakeModel()
+        .respondWithTools([
+          {
+            id: "delegate",
+            name: "task",
+            args: { description: "Complete the task", subagent_type: "worker" },
+          },
+        ])
+        .respond(new AIMessage("Parent done"));
+      const agent = createDeepAgent({
+        model,
+        subagents: [
+          {
+            name: "worker",
+            description: "Worker",
+            model: fakeModel().respond(new AIMessage("Worker done")),
+            ...(mode === "fork" ? { mode: "fork" as const } : {}),
+          },
+        ],
+      });
+      const result = await agent.invoke(
+        { messages: [new HumanMessage("Delegate this task")] },
+        { callbacks: [tracer] },
+      );
+
+      expect(result.messages.at(-1)?.content).toBe("Parent done");
+      expect(result.messages.find(ToolMessage.isInstance)?.content).toContain(
+        "Worker done",
+      );
+      for (const name of LIFECYCLE_NAMES.slice(0, 2)) {
+        const runs = tracer.runs.filter((run) => run.name === name);
+        expect(runs.length, name).toBeGreaterThanOrEqual(2);
+        expect(
+          runs.every((run) => Object.keys(run.inputs).length === 0),
+          name,
+        ).toBe(true);
+      }
+      if (mode === "fork") {
+        expect(
+          tracer.runs.find(
+            (run) => run.name === "forkTaskToolMiddleware.before_agent",
+          )?.inputs,
+        ).toEqual({});
+      }
+    },
+  );
+});

--- a/libs/providers/quickjs/package.json
+++ b/libs/providers/quickjs/package.json
@@ -50,11 +50,12 @@
     "quickjs-emscripten-core": "^0.32.0"
   },
   "peerDependencies": {
-    "deepagents": ">=1.12.0-rc.0"
+    "deepagents": ">=1.12.0-rc.0",
+    "langchain": "^1.5.11-rc.0"
   },
   "devDependencies": {
     "@langchain/core": "^1.2.9",
-    "@langchain/langgraph": "^1.4.10",
+    "@langchain/langgraph": "^1.4.15-rc.0",
     "@tsconfig/recommended": "^1.0.13",
     "@types/dedent": "^0.7.2",
     "@types/estree": "^1.0.8",
@@ -62,7 +63,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "deepagents": "workspace:*",
     "dotenv": "^17.2.3",
-    "langchain": "^1.5.10",
+    "langchain": "^1.5.11-rc.0",
     "tsdown": "^0.22.1",
     "tsx": "^4.21.0",
     "typescript": "^7.0.2",

--- a/libs/providers/quickjs/src/middleware.test.ts
+++ b/libs/providers/quickjs/src/middleware.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { tool } from "langchain";
+import { createAgent, tool } from "langchain";
+import { fakeModel } from "@langchain/core/testing";
 import * as z from "zod";
-import { SystemMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import { Command } from "@langchain/langgraph";
 import {
   createCodeInterpreterMiddleware,
@@ -13,6 +19,33 @@ import { ReplSession } from "./session.js";
 describe("createCodeInterpreterMiddleware", () => {
   beforeEach(() => {
     ReplSession.clearCache();
+  });
+
+  it("omits conversation inputs from the cleanup span while preserving model output", async () => {
+    const agent = createAgent({
+      model: fakeModel().respond(new AIMessage("Done")),
+      middleware: [createCodeInterpreterMiddleware()],
+    });
+    const events = [];
+    for await (const event of agent.streamEvents(
+      {
+        messages: [
+          new HumanMessage("Long conversation context. ".repeat(1024)),
+        ],
+      },
+      { version: "v2" },
+    )) {
+      events.push(event);
+    }
+
+    const cleanup = events.find(
+      (event) =>
+        event.name === "CodeInterpreterMiddleware.after_agent" &&
+        event.event === "on_chain_start",
+    );
+    expect(cleanup?.data.input).toEqual({});
+    const model = events.find((event) => event.event === "on_chat_model_end");
+    expect(JSON.stringify(model?.data.output)).toContain("Done");
   });
 
   describe("tool registration", () => {

--- a/libs/providers/quickjs/src/middleware.ts
+++ b/libs/providers/quickjs/src/middleware.ts
@@ -9,6 +9,7 @@
 
 import {
   createMiddleware,
+  omitPayload,
   tool,
   type AgentMiddleware as _AgentMiddleware,
 } from "langchain";
@@ -523,6 +524,7 @@ export function createCodeInterpreterMiddleware(
 
   return createMiddleware({
     name: "CodeInterpreterMiddleware",
+    tracePolicy: { processInputs: omitPayload },
     tools: [evalTool],
     wrapModelCall: async (request, handler) => {
       const agentTools = (request.tools || []) as StructuredToolInterface[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,8 +651,8 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@langchain/langgraph':
-        specifier: ^1.4.10
-        version: 1.4.12(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        specifier: ^1.4.15-rc.0
+        version: 1.4.15-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       '@langchain/langgraph-checkpoint':
         specifier: ^1.1.5
         version: 1.1.5(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))
@@ -687,8 +687,8 @@ importers:
         specifier: ^17.2.4
         version: 17.4.2
       langchain:
-        specifier: ^1.5.10
-        version: 1.5.10(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.1)
+        specifier: ^1.5.11-rc.0
+        version: 1.5.11-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.1)
       tsdown:
         specifier: ^0.22.1
         version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
@@ -887,8 +887,8 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@langchain/langgraph':
-        specifier: ^1.4.10
-        version: 1.4.12(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        specifier: ^1.4.15-rc.0
+        version: 1.4.15-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       '@tsconfig/recommended':
         specifier: ^1.0.13
         version: 1.0.13
@@ -911,8 +911,8 @@ importers:
         specifier: ^17.2.3
         version: 17.4.2
       langchain:
-        specifier: ^1.5.10
-        version: 1.5.10(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.1)
+        specifier: ^1.5.11-rc.0
+        version: 1.5.11-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.1)
       tsdown:
         specifier: ^0.22.1
         version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
@@ -1447,6 +1447,18 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.1.48
 
+  '@langchain/langgraph-sdk@1.10.3-rc.0':
+    resolution: {integrity: sha512-rC88vymdJYb8oAf4M96bxOPtB52GU6o40UuNzA62A+92wzgS4Z728WGPITNeIBUtjxyNUXmyJcRbgNsFll/R/g==}
+    peerDependencies:
+      '@langchain/core': ^1.1.48
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@langchain/langgraph-sdk@1.9.28':
     resolution: {integrity: sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==}
     peerDependencies:
@@ -1490,6 +1502,13 @@ packages:
       '@langchain/core': ^1.1.48
       zod: ^3.25.32 || ^4.2.0
 
+  '@langchain/langgraph@1.4.15-rc.0':
+    resolution: {integrity: sha512-S6kcrItAlhDtovmxO4fU48tdABk74OBjwvbyLl9tzTw0hM1x0BnY6W21AFJJwUEpCwcPUOsm0cYZJclIGPkgtA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.48
+      zod: ^3.25.32 || ^4.2.0
+
   '@langchain/openai@1.5.5':
     resolution: {integrity: sha512-wX7dwb9z4nf5FHXlIl/X2mk08pzonvRHCt1D4+s1zXLP0duYDC95j7dulPIQJ6fmhbyYQc9Ki8mEhY/D1lB8kw==}
     engines: {node: '>=20'}
@@ -1498,6 +1517,9 @@ packages:
 
   '@langchain/protocol@0.0.18':
     resolution: {integrity: sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==}
+
+  '@langchain/protocol@0.0.19':
+    resolution: {integrity: sha512-9hKcRrH7cBX6gfutdfXPoft1OCchHe4FEpALoDJMl5Qu+n/YG5ynZmyu8+8cxORlPwHBoKTxggvXz+76M1yX1Q==}
 
   '@langchain/tavily@1.2.0':
     resolution: {integrity: sha512-aPLPgtw8+b/Rnr3H+X8H8z98T/Y7JuCE4B5eqRDHoEWgZvMDUFF7divqwQqCTMq2deQttlVrm5bN5JbKaAR7/w==}
@@ -3182,6 +3204,12 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.2.9
 
+  langchain@1.5.11-rc.0:
+    resolution: {integrity: sha512-rnLhKTwo03bMahyHg7TXRX5Y9Mwz+HlC1HFC7ixzq+koDiIQxhOF0j9cJS5jetf05Bm2bwJXjN97cx9LilZCag==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.2.9
+
   langsmith@0.8.9:
     resolution: {integrity: sha512-6ikTB5SO+3SlBQ/+oH8K/JzhglxB8AM4RAe5bHzgWSEIHTgTe+b71bSjf1fDvlYuEXoiPn6uP10BbczrbznUnA==}
     peerDependencies:
@@ -4776,6 +4804,17 @@ snapshots:
     dependencies:
       '@langchain/core': 1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
 
+  '@langchain/langgraph-sdk@1.10.3-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@langchain/core': 1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
+      '@langchain/protocol': 0.0.19
+      '@types/json-schema': 7.0.15
+      p-queue: 9.3.3
+      p-retry: 7.1.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   '@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@langchain/core': 1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
@@ -4859,6 +4898,18 @@ snapshots:
       - svelte
       - vue
 
+  '@langchain/langgraph@1.4.15-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
+      '@langchain/langgraph-checkpoint': 1.1.5(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))
+      '@langchain/langgraph-sdk': 1.10.3-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@langchain/protocol': 0.0.19
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@langchain/openai@1.5.5(@aws-sdk/credential-provider-node@3.972.76)(@langchain/core@1.2.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(@smithy/signature-v4@5.6.12)(ws@8.21.1)':
     dependencies:
       '@langchain/core': 1.2.4(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
@@ -4884,6 +4935,8 @@ snapshots:
       - ws
 
   '@langchain/protocol@0.0.18': {}
+
+  '@langchain/protocol@0.0.19': {}
 
   '@langchain/tavily@1.2.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))':
     dependencies:
@@ -6286,6 +6339,22 @@ snapshots:
       - react-dom
       - svelte
       - vue
+      - ws
+
+  langchain@1.5.11-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.1):
+    dependencies:
+      '@langchain/core': 1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
+      '@langchain/langgraph': 1.4.15-rc.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.1.5(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))
+      langsmith: 0.8.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
       - ws
 
   langsmith@0.8.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1):


### PR DESCRIPTION
(in an rc release, using this to test in a real deployment)

* adopts a policy of dropping inputs for built in middleware -- we seldom get value out of these input values and for large traces this can cause issues

see https://github.com/langchain-ai/langchainjs/pull/11568 and https://github.com/langchain-ai/langgraphjs/pull/2794