### PR TITLE
chore: exit rc prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@examples/async-subagents-parallel-research": null,
@@ -13,5 +13,7 @@
     "@langchain/quickjs": "0.6.2",
     "@langchain/sandbox-standard-tests": "2.0.0"
   },
-  "changesets": ["omit-middleware-trace-inputs"]
+  "changesets": [
+    "omit-middleware-trace-inputs"
+  ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,7 +13,5 @@
     "@langchain/quickjs": "0.6.2",
     "@langchain/sandbox-standard-tests": "2.0.0"
   },
-  "changesets": [
-    "omit-middleware-trace-inputs"
-  ]
+  "changesets": ["omit-middleware-trace-inputs"]
 }


### PR DESCRIPTION
## Summary

Runs `changeset pre exit` so the next release publishes stable versions rather than `-rc` ones. `.changeset/pre.json` moves to `"mode": "exit"`; the release workflow deletes the file when it next versions, and the open release PR (#843) will regenerate as a stable `chore: version packages`.

Pairs with #844, which reverts #837. #837 is what pulled rc dependency ranges into the tree, so both are needed before a stable release can go out.

## Testing

No code change — `.changeset/pre.json` only.
