### PR TITLE
fix(deepagents): align skills middleware with Python's per-thread state loading

### DIFF
--- a/.changeset/skills-per-thread-state-loading.md
+++ b/.changeset/skills-per-thread-state-loading.md
@@ -1,0 +1,7 @@
+---
+"deepagents": patch
+---
+
+fix(deepagents): align skills middleware with Python's per-thread state loading
+
+`createSkillsMiddleware` stored loaded skills in a `loadedSkills` closure, created once per middleware instance and reused for every invocation that instance serves. A single agent commonly serves many threads, so the first thread to load won for all of them: later threads were given the first thread's skills metadata and never saw their own. Skills are now loaded per invocation from graph state, as in the Python SDK.

--- a/libs/deepagents/src/middleware/skills.test.ts
+++ b/libs/deepagents/src/middleware/skills.test.ts
@@ -5,7 +5,7 @@ import {
   SystemMessage,
   type BaseMessage,
 } from "@langchain/core/messages";
-import { MemorySaver } from "@langchain/langgraph";
+import { MemorySaver, InMemoryStore } from "@langchain/langgraph";
 
 import {
   createSkillsMiddleware,
@@ -23,7 +23,12 @@ import {
 import { createFileData } from "../backends/utils.js";
 import { createDeepAgent } from "../agent.js";
 import { createMockBackend } from "./test.js";
-import type { BackendProtocol } from "../backends/protocol.js";
+import { StoreBackend } from "../backends/store.js";
+import type {
+  BackendProtocol,
+  BackendProtocolV2,
+  BackendRuntime,
+} from "../backends/protocol.js";
 
 const VALID_SKILL_CONTENT = `---
 name: web-research
@@ -47,6 +52,19 @@ description: Systematic code review process with best practices
 1. Check for bugs
 2. Check for style
 `;
+
+/** Minimal valid SKILL.md whose frontmatter name matches its directory. */
+function skillMd(name: string): string {
+  return `---\nname: ${name}\ndescription: The ${name} skill\n---\n`;
+}
+
+/** Skill names from a state update or agent result, in load order. */
+function skillNames(value: unknown): string[] {
+  const entries =
+    (value as { skillsMetadata?: SkillMetadataEntry[] } | undefined)
+      ?.skillsMetadata ?? [];
+  return entries.map((entry) => entry.name);
+}
 
 describe("createSkillsMiddleware", () => {
   describe("beforeAgent", () => {
@@ -410,26 +428,58 @@ description: A skill with very large content
         },
       });
 
+      let listings = 0;
+      const countingBackend: BackendProtocolV2 = {
+        ...mockBackend,
+        ls: (path: string) => {
+          listings += 1;
+          return mockBackend.ls(path);
+        },
+      };
+
       const middleware = createSkillsMiddleware({
-        backend: mockBackend,
+        backend: countingBackend,
         sources: ["/skills/user/"],
       });
 
       // First call - should load skills
       // @ts-expect-error - typing issue in LangChain
       const result1 = await middleware.beforeAgent?.({});
-      expect(result1?.skillsMetadata).toHaveLength(1);
+      expect(skillNames(result1)).toEqual(["web-research"]);
+      expect(listings).toBe(1);
 
-      // Second call with empty state - should re-emit skills to state
-      // (new thread scenario: closure has skills but state doesn't)
+      // Second call with those skills in state - should skip the reload
+      // without going back to the backend.
       // @ts-expect-error - typing issue in LangChain
-      const result2 = await middleware.beforeAgent?.({});
-      expect(result2?.skillsMetadata).toHaveLength(1);
+      const result2 = await middleware.beforeAgent?.(result1);
+      expect(result2).toBeUndefined();
+      expect(listings).toBe(1);
+    });
 
-      // Third call with skills in state - should skip (both closure and state have skills)
+    it("should load skills per invocation rather than once per middleware instance", async () => {
+      // A backend resolved from the runtime models StateBackend, whose files
+      // live in per-thread graph state. One middleware instance serves every
+      // thread, so each invocation must load the skills its own state holds.
+      const backendForState = (runtime: BackendRuntime) => {
+        const name = (runtime.state as { skill?: string }).skill ?? "";
+        return createMockBackend({
+          files: { [`/skills/user/${name}/SKILL.md`]: skillMd(name) },
+          directories: { "/skills/user/": [{ name, type: "directory" }] },
+        });
+      };
+
+      const middleware = createSkillsMiddleware({
+        backend: backendForState,
+        sources: ["/skills/user/"],
+      });
+
       // @ts-expect-error - typing issue in LangChain
-      const result3 = await middleware.beforeAgent?.(result2);
-      expect(result3).toBeUndefined();
+      const threadA = await middleware.beforeAgent?.({ skill: "alpha" });
+      // @ts-expect-error - typing issue in LangChain
+      const threadB = await middleware.beforeAgent?.({ skill: "beta" });
+
+      expect(skillNames(threadA)).toEqual(["alpha"]);
+      expect(skillNames(threadB)).toEqual(["beta"]);
     });
 
     it("should skip reload when skillsMetadata exists in checkpoint state", async () => {
@@ -2454,5 +2504,51 @@ description: Project-level skill for team collaboration
     // Should still have a system prompt with the "no skills" message
     expect(systemPrompt).toContain("No skills available yet");
     invokeSpy.mockRestore();
+  });
+});
+
+/**
+ * Integration tests for StoreBackend with createDeepAgent.
+ *
+ * StoreBackend derives its namespace from the runnable config, so one agent
+ * instance can serve callers whose files live in different namespaces.
+ */
+describe("StoreBackend integration with createDeepAgent", () => {
+  it("should load skills from the namespace resolved for each invocation", async () => {
+    const store = new InMemoryStore();
+    const now = new Date().toISOString();
+    const seed = (namespace: string, name: string) =>
+      store.put([namespace, "skills"], `/skills/${name}/SKILL.md`, {
+        content: skillMd(name),
+        mimeType: "text/plain",
+        created_at: now,
+        modified_at: now,
+      });
+    await seed("ns-a", "alpha");
+    await seed("ns-b", "beta");
+
+    const agent = createDeepAgent({
+      model: new FakeListChatModel({ responses: ["ok", "ok"] }),
+      backend: new StoreBackend({
+        store,
+        namespace: ({ config }) => [
+          (config?.configurable?.namespace as string) ?? "unknown",
+          "skills",
+        ],
+      }),
+      skills: ["/skills/"],
+      store,
+    });
+
+    const hello = { messages: [new HumanMessage("hi")] };
+    const resultA = await agent.invoke(hello, {
+      configurable: { namespace: "ns-a" },
+    });
+    const resultB = await agent.invoke(hello, {
+      configurable: { namespace: "ns-b" },
+    });
+
+    expect(skillNames(resultA)).toEqual(["alpha"]);
+    expect(skillNames(resultB)).toEqual(["beta"]);
   });
 });

--- a/libs/deepagents/src/middleware/skills.ts
+++ b/libs/deepagents/src/middleware/skills.ts
@@ -814,10 +814,6 @@ export function validateModulePath(raw: unknown): string | undefined {
 export function createSkillsMiddleware(options: SkillsMiddlewareOptions) {
   const { backend, sources } = options;
 
-  // Closure variable to store loaded skills - wrapModelCall can access this
-  // directly since beforeAgent state updates aren't immediately available
-  let loadedSkills: SkillMetadata[] = [];
-
   return createMiddleware({
     name: "SkillsMiddleware",
     stateSchema: SkillsStateSchema,
@@ -828,16 +824,9 @@ export function createSkillsMiddleware(options: SkillsMiddlewareOptions) {
         Array.isArray(state.skillsMetadata) &&
         state.skillsMetadata.length > 0;
 
-      if (loadedSkills.length > 0) {
-        // Closure has skills from a prior thread — push to state if missing
-        // so getCurrentTaskInput() sees them in the tool node.
-        return stateHasSkills ? undefined : { skillsMetadata: loadedSkills };
-      }
-
-      // Check if skills were restored from checkpoint (non-empty array in state)
+      // Already loaded for this thread (same run, a later turn, or a
+      // restored checkpoint) - keep what state holds.
       if (stateHasSkills) {
-        // Restore from state (e.g., after checkpoint restore)
-        loadedSkills = state.skillsMetadata as SkillMetadata[];
         return undefined;
       }
 
@@ -865,19 +854,14 @@ export function createSkillsMiddleware(options: SkillsMiddlewareOptions) {
         }
       }
 
-      // Store in closure for immediate access by wrapModelCall
-      loadedSkills = Array.from(allSkills.values());
-
-      return { skillsMetadata: loadedSkills };
+      return { skillsMetadata: Array.from(allSkills.values()) };
     },
 
     wrapModelCall(request, handler) {
-      // Use closure variable which is populated by beforeAgent
-      // Fall back to state for checkpoint restore scenarios
+      // Populated by beforeAgent, which runs as its own graph node - its
+      // state update is committed before the model node reads it.
       const skillsMetadata: SkillMetadata[] =
-        loadedSkills.length > 0
-          ? loadedSkills
-          : (request.state?.skillsMetadata as SkillMetadata[]) || [];
+        (request.state?.skillsMetadata as SkillMetadata[]) || [];
 
       // Format skills section
       const skillsLocations = formatSkillsLocations(sources);


### PR DESCRIPTION
## Summary

`createSkillsMiddleware` stored loaded skills in a `loadedSkills` closure, created once per middleware instance and reused for every invocation that instance serves. A single agent commonly serves many threads, so the first thread to load won for all of them: later threads were given the first thread's skills metadata and never saw their own. The list is also written to state, so it is checkpointed into those threads and persists after upgrading.

Python does not have this — `skills_metadata` lives in graph state only and `wrap_model_call` reads `request.state`. This change does the same in JS: `beforeAgent` returns the loaded list as a state update, and `wrapModelCall` reads it back from `request.state`.

The closure's comment said `beforeAgent` state updates aren't available to `wrapModelCall`. That isn't the case: `beforeAgent` runs as its own graph node, so its update is committed before the model node reads state.

Caching is now scoped to per-thread graph state, as in Python, and is deliberately less effective than the closure was: each thread loads from the backend once rather than one load serving every thread, and subagents, which do not inherit `skillsMetadata`, load per spawn. Python pays the same cost — its `skills_metadata` is a `PrivateStateAttr`, which `subagents.py` strips from inherited state.

Not addressed here: a thread that has already loaded skills won't re-scan for new ones. That is existing behaviour in both SDKs (langchain-ai/deepagents#5416) and needs a separate invalidation design.

## Testing

Two regression tests, both failing without the source change:

- `should load skills per invocation rather than once per middleware instance` — a backend resolved from the runtime, as `StateBackend` is, with two invocations carrying different state.
- `should load skills from the namespace resolved for each invocation` — one `createDeepAgent` over a `StoreBackend` whose namespace factory reads the runnable config, invoked twice under different namespaces.

The existing `should not reload when skills are already loaded` now counts backend listings, so the `stateHasSkills` short-circuit is asserted rather than inferred from an `undefined` return.
