### PR TITLE
fix(infra): migrate Changesets action v2 inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,10 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version: pnpm run changeset:version
-          publish: pnpm release
-          title: "chore: version packages"
-          commit: "chore: version packages"
+          version-script: pnpm run changeset:version
+          publish-script: pnpm release
+          pr-title: "chore: version packages"
+          commit-message: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
The Release workflow fails immediately after upgrading to `changesets/action` v2.1.1 because it rejects the v1 input names. Rename `version`, `publish`, `title`, and `commit` to `version-script`, `publish-script`, `pr-title`, and `commit-message`, preserving the existing commands and messages.

Validation: parsed the workflow YAML, checked every configured input against `action.yml` at the pinned action commit, and ran `git diff --check`. The release workflow was not executed locally.

Fixes the input-validation failure in https://github.com/langchain-ai/deepagentsjs/actions/runs/34384630550.
