### PR TITLE
fix(infra): pin npm 11 for Changesets publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
           cache: "pnpm"
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        # npm 12 returns an array from `pnpm info --json`, which Changesets v3 cannot parse.
+        run: npm install -g npm@11.19.0
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The Release workflow installs `npm@latest`, which now selects npm 12.0.2. With pnpm 10.29.2, `pnpm info <package> --json` delegates to npm and returns a one-element array. Changesets CLI 3.0.1 assumes an object, reads an undefined `versions` field, and crashes in `getUnpublishedPackages` before publishing.

Pin the release runner to npm 11.19.0, which retains the expected metadata shape and supports trusted publishing. Add a comment explaining the compatibility constraint. The same parsing code is present in Changesets 3.0.2.

This pin is a temporary compatibility workaround. The long-term fix belongs in Changesets’ pnpm metadata parser: normalize both object and single-element array responses, validate the metadata shape, and add regression tests for both formats. Once a Changesets release includes that fix and is verified with npm 12, we can remove or update the npm 11 pin.

Validation:
- Reproduced the exact `Cannot read properties of undefined (reading 'includes')` error with npm 12.0.2, pnpm 10.29.2, and the locked Changesets CLI 3.0.1 using the read-only `changeset publish-plan` command.
- The same command succeeds with npm 11.19.0 and produces an empty publish plan: all current package versions are already published.
- Parsed the workflow YAML and ran `git diff --check`. No publishing or tagging commands were run.

Failure: https://github.com/langchain-ai/deepagentsjs/actions/runs/34392087420

